### PR TITLE
Add CONN_MAX_AGE to database settings in prod

### DIFF
--- a/lego/settings/production.py
+++ b/lego/settings/production.py
@@ -24,6 +24,7 @@ DATABASES = {
         'PASSWORD': os.environ['DB_PASSWORD'],
         'HOST': '129.241.208.149',
         'PORT': '',
+        'CONN_MAX_AGE': 300,
         'OPTIONS': {
             'autocommit': True,
         },


### PR DESCRIPTION
From django docs:

> ### Persistent connections
> 
> Persistent connections avoid the overhead of re-establishing a connection to the database in each request. They’re controlled by the CONN_MAX_AGE parameter which defines the maximum lifetime of a connection. It can be set independently for each database.
> 
> The default value is 0, preserving the historical behavior of closing the database connection at the end of each request. To enable persistent connections, set CONN_MAX_AGE to a positive number of seconds. For unlimited persistent connections, set it to None.
