### PR TITLE
Clean up the Membership-model

### DIFF
--- a/lego/users/migrations/0003_auto_20141103_1725.py
+++ b/lego/users/migrations/0003_auto_20141103_1725.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0002_auto_20141031_1236'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='membership',
+            name='permission_status',
+        ),
+        migrations.AddField(
+            model_name='membership',
+            name='is_active',
+            field=models.BooleanField(verbose_name='is active', default=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='membership',
+            name='role',
+            field=models.CharField(verbose_name='role', max_length=2, default='M', choices=[('M', 'Member'), ('L', 'Leader'), ('CL', 'Co-Leader'), ('T', 'Treasurer')]),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='user',
+            name='groups',
+            field=models.ManyToManyField(verbose_name='groups', blank=True, to='users.AbakusGroup', related_query_name='user', help_text='The groups this user belongs to. A user will get all permissions granted to each of their groups.', through='users.Membership', related_name='users'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='user',
+            name='user_permissions',
+            field=models.ManyToManyField(verbose_name='user permissions', blank=True, to='auth.Permission', related_query_name='user', help_text='Specific permissions for this user.', related_name='users'),
+            preserve_default=True,
+        ),
+    ]

--- a/lego/users/models.py
+++ b/lego/users/models.py
@@ -182,33 +182,28 @@ class User(AbstractBaseUser, PermissionsMixin):
 
 
 class Membership(BasisModel):
-    DEPRECATED = 0
-    ACTIVE_RETIREE = 1
-    MEMBER = 2
-    LEADER = 3
+    MEMBER = 'M'
+    LEADER = 'L'
+    CO_LEADER = 'CL'
+    TREASURER = 'T'
 
-    PERMISSION_TYPES = (
-        (DEPRECATED, _('Previous member')),
-        (ACTIVE_RETIREE, _('Previous member who\'s still active')),
-        (MEMBER, _('Active member')),
-        (LEADER, _('Leader'))
+    ROLES = (
+        (MEMBER, _('Member')),
+        (LEADER, _('Leader')),
+        (CO_LEADER, _('Co-Leader')),
+        (TREASURER, _('Treasurer'))
     )
 
     user = models.ForeignKey(User, verbose_name=_('user'))
     group = models.ForeignKey(AbakusGroup, verbose_name=_('group'))
-    role = models.CharField(_('role'), max_length=30, blank=True, default=_('Member'))
+    role = models.CharField(_('role'), max_length=2, choices=ROLES, default=MEMBER)
+    is_active = models.BooleanField(_('is active'), default=True)
 
     start_date = models.DateField(_('start date'), auto_now=True, blank=True)
     end_date = models.DateField(_('end date'), null=True, blank=True)
-
-    permission_status = models.PositiveSmallIntegerField(
-        _('permission status'),
-        choices=PERMISSION_TYPES,
-        default=MEMBER
-    )
 
     class Meta:
         unique_together = ('user', 'group')
 
     def __str__(self):
-        return self.role
+        return '{0} is {1} in {2}'.format(self.user, self.get_role_display(), self.group)

--- a/lego/users/tests/test_models.py
+++ b/lego/users/tests/test_models.py
@@ -19,10 +19,15 @@ class GroupTestCase(TestCase):
 class UserTestCase(TestCase):
     fixtures = ['test_users.yaml']
 
+    def setUp(self):
+        self.user = User.objects.get(pk=1)
+
     def test_full_name(self):
-        user = User.objects.get(pk=1)
-        full_name = '{0} {1}'.format(user.first_name, user.last_name)
-        self.assertEqual(full_name, user.get_full_name())
+        full_name = '{0} {1}'.format(self.user.first_name, self.user.last_name)
+        self.assertEqual(full_name, self.user.get_full_name())
+
+    def test_short_name(self):
+        self.assertEqual(self.user.get_short_name(), self.user.first_name)
 
 
 class MembershipTestCase(TestCase):
@@ -34,9 +39,16 @@ class MembershipTestCase(TestCase):
         self.test_membership = Membership(
             user=self.test_user,
             group=self.test_committee,
-            role='The Best Test User',
+            role=Membership.TREASURER
         )
         self.test_membership.save()
 
-    def test_permission_status(self):
-        self.assertEqual(self.test_membership.permission_status, Membership.MEMBER)
+    def test_to_string(self):
+        self.assertEqual(
+            str(self.test_membership),
+            '{0} is {1} in {2}'.format(
+                self.test_membership.user,
+                self.test_membership.get_role_display(),
+                self.test_membership.group
+            )
+        )


### PR DESCRIPTION
This removes the permission types from the Membership-model, since we decided we didn't need it. Also changes the role field to only allow a few options and updates the tests.
