### PR TITLE
[Depsy] Upgrade dependency django-haystack to ==2.4.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ djangorestframework>=3,<4
 djangorestframework-jwt==1.7.2
 django-basis==0.4.0
 django-extensions==1.5.7
-django-haystack==2.4.0
+django-haystack==2.4.1
 django-secure==1.0.1
 django-autoslug==1.9.3
 django-filter==0.11.0


### PR DESCRIPTION
Hi!

A new version was just released of `django-haystack`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django-haystack to ==2.4.1
