### PR TITLE
[Depsy] Upgrade dependency redis to ==2.10.5

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@ markdown==2.6.3
 unicode-slugify==0.1.3
 pyyaml==3.11
 raven==5.8.1
-redis==2.10.4
+redis==2.10.5
 
 djangorestframework>=3,<4
 djangorestframework-jwt==1.7.2


### PR DESCRIPTION
Hi!

A new version was just released of `redis`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded redis to ==2.10.4
