### PR TITLE
[Depsy] Upgrade dependency django-extensions to ==1.5.9

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,7 @@ redis==2.10.5
 djangorestframework>=3,<4
 djangorestframework-jwt==1.7.2
 django-basis==0.4.0
-django-extensions==1.5.8
+django-extensions==1.5.9
 django-haystack==2.4.1
 django-secure==1.0.1
 django-autoslug==1.9.3


### PR DESCRIPTION
Hi!

A new version was just released of `django-extensions`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django-extensions to ==1.5.8
