### PR TITLE
Remove tree API endpoint for groups

### DIFF
--- a/lego/users/tests/test_abakusgroup_api.py
+++ b/lego/users/tests/test_abakusgroup_api.py
@@ -255,23 +255,3 @@ class DeleteAbakusGroupAPITestCase(APITestCase):
         response = self.client.delete(_get_detail_url(self.test_group.pk))
 
         self.assertEqual(response.status_code, 403)
-
-
-class HierarchyAbakusGroupTestCase(APITestCase):
-    fixtures = ['initial_abakus_groups.yaml', 'test_users.yaml']
-
-    def test_hierarchy_authenticated(self):
-        self.client.force_authenticate(user=User.objects.get(pk=1))
-        response = self.client.get(reverse('abakusgroup-hierarchy'))
-        self.assertEqual(200, response.status_code)
-        root_nodes = response.data
-        root = root_nodes[0]
-        abakom = root['children'][0]
-        self.assertEqual(1, len(root_nodes))
-        self.assertEqual(1, len(root['children']))
-        self.assertEqual(AbakusGroup.objects.all().count() - 2,  # minus Abakus and Abakom
-                         len(abakom['children']))
-
-    def test_hierarchy_unauthenticated(self):
-        response = self.client.get(reverse('abakusgroup-hierarchy'))
-        self.assertEqual(401, response.status_code)

--- a/lego/users/views/abakus_groups.py
+++ b/lego/users/views/abakus_groups.py
@@ -1,34 +1,12 @@
-from mptt.templatetags.mptt_tags import cache_tree_children
 from rest_framework import viewsets
-from rest_framework.decorators import list_route
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.response import Response
 
 from lego.users.models import AbakusGroup
 from lego.users.permissions import AbakusGroupPermissions
-from lego.users.serializers import AbakusGroupSerializer, PublicAbakusGroupSerializer
-
-
-def build_tree(nodes):
-    tree = []
-    for node in nodes:
-        serializer = PublicAbakusGroupSerializer(node)
-        tree.append({
-            'children': build_tree(node.get_children()),
-            'group': serializer.data
-        })
-
-    return tree
+from lego.users.serializers import AbakusGroupSerializer
 
 
 class AbakusGroupViewSet(viewsets.ModelViewSet):
     queryset = AbakusGroup.objects.all()
     serializer_class = AbakusGroupSerializer
     permission_classes = (IsAuthenticated, AbakusGroupPermissions)
-
-    @list_route(methods=['GET'])
-    def hierarchy(self, request):
-        # mptt 0.8 requires the QuerySet to be ordered by tree_id and lft:
-        top_nodes = cache_tree_children(self.queryset.order_by('tree_id', 'lft'))
-        tree = build_tree(top_nodes)
-        return Response(data=tree)


### PR DESCRIPTION
We decided to create the tree structure in the frontend instead.
