### PR TITLE
[Depsy] Upgrade dependency django to ==1.8.7

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-django==1.8.6
+django==1.8.7
 ipython==4.0.0
 
 psycopg2==2.6.1


### PR DESCRIPTION
Hi!

A new version was just released of `django`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django to ==1.8.7
