### PR TITLE
[Depsy] Upgrade dependency markdown to ==2.6.5

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@ django==1.8.7
 ipython==4.0.0
 
 psycopg2==2.6.1
-markdown==2.6.4
+markdown==2.6.5
 unicode-slugify==0.1.3
 pyyaml==3.11
 raven==5.8.1


### PR DESCRIPTION
Hi!

A new version was just released of `markdown`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded markdown to ==2.6.5
