### PR TITLE
[Depsy] Upgrade dependency ipython to ==4.0.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 django==1.8.7
-ipython==4.0.0
+ipython==4.0.1
 
 psycopg2==2.6.1
 markdown==2.6.5


### PR DESCRIPTION
Hi!

A new version was just released of `ipython`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded ipython to ==4.0.1
