### PR TITLE
[Depsy] Upgrade dependency raven to ==5.9.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@ psycopg2==2.6.1
 markdown==2.6.5
 unicode-slugify==0.1.3
 pyyaml==3.11
-raven==5.9.1
+raven==5.9.2
 redis==2.10.5
 
 djangorestframework==3.3.1


### PR DESCRIPTION
Hi!

A new version was just released of `raven`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded raven to ==5.9.0
