### PR TITLE
[Depsy] Upgrade dependency djangorestframework to ==3.3.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ pyyaml==3.11
 raven==5.8.1
 redis==2.10.5
 
-djangorestframework==3.3.1
+djangorestframework==3.3.2
 djangorestframework-jwt==1.7.2
 django-basis==0.4.0
 django-extensions==1.5.9


### PR DESCRIPTION
Hi!

A new version was just released of `djangorestframework`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded djangorestframework to ==3.3.2
