### PR TITLE
[Depsy] Upgrade dependency django-mptt to ==0.8.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,4 +19,4 @@ django-filter==0.11.0
 django-oauth-toolkit==0.10.0
 django-cors-headers==1.1.0
 django-celery==3.1.17
-django-mptt==0.7.4
+django-mptt==0.8.0


### PR DESCRIPTION
Hi!

A new version was just released of `django-mptt`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django-mptt to ==0.8.0
#### Changelog:
#### Version 0.8.0

New features:
- Add support for python 3.5 (dropped 2.6)
- Add support for django 1.9 (dropped 1.4, 1.6, 1.7)
- Add a node_moved signal
- Spanish (Argentina) translation
- `TreeQuerySet.get_cached_trees()`

Fixes etc:
- Much faster `get_queryset_ancestors/descendants`
- Fixed `#176` (infinite recursion when using `.only()` / `.defer()`)
- Much improved test coverage
