### PR TITLE
[Depsy] Upgrade dependency django-filter to ==0.12.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ django-extensions==1.6.1
 django-haystack==2.4.1
 django-secure==1.0.1
 django-autoslug==1.9.3
-django-filter==0.11.0
+django-filter==0.12.0
 django-oauth-toolkit==0.10.0
 django-cors-headers==1.1.0
 django-celery==3.1.17


### PR DESCRIPTION
Hi!

A new version was just released of `django-filter`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django-filter to ==0.12.0
