### PR TITLE
Replace nested routers with regex

### DIFF
--- a/lego/api/urls.py
+++ b/lego/api/urls.py
@@ -5,8 +5,6 @@ from django.http import Http404, HttpResponseRedirect
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import RedirectView
 
-from .v1 import events_router as v1_events
-from .v1 import pools_router as v1_pools
 from .v1 import router as v1
 
 
@@ -25,7 +23,5 @@ urlpatterns = [
     url(r'^v1/', include(v1.urls, namespace='v1')),
 
     url(r'^$', RedirectView.as_view(url='/api/{0}/'.format(settings.API_VERSION)), name='default'),
-    url(r'^v1/', include(v1_events.urls)),
-    url(r'^v1/', include(v1_pools.urls)),
     url(r'^(.*)/$', version_redirect),
 ]

--- a/lego/api/v1.py
+++ b/lego/api/v1.py
@@ -1,4 +1,4 @@
-from rest_framework_nested import routers
+from rest_framework import routers
 
 from lego.app.articles.views.articles import ArticlesViewSet
 from lego.app.events.views.events import EventViewSet, PoolViewSet, RegistrationViewSet
@@ -12,9 +12,8 @@ router.register(r'groups', AbakusGroupViewSet)
 router.register(r'pages', PageViewSet)
 router.register(r'articles', ArticlesViewSet)
 router.register(r'events', EventViewSet)
-
-events_router = routers.NestedSimpleRouter(router, r'events', lookup='event')
-events_router.register(r'register', RegistrationViewSet, base_name='register')
-events_router.register(r'pools', PoolViewSet)
-pools_router = routers.NestedSimpleRouter(events_router, r'pools', lookup='pool')
-pools_router.register(r'registrations', RegistrationViewSet)
+router.register(r'events/(?P<event_pk>[^/]+)/pools', PoolViewSet)
+router.register(r'events/(?P<event_pk>[^/]+)/pools/(?P<pool_pk>[^/]+)/registrations',
+                RegistrationViewSet)
+router.register(r'events/(?P<event_pk>[^/]+)/register',
+                RegistrationViewSet, base_name='register')

--- a/lego/app/events/models.py
+++ b/lego/app/events/models.py
@@ -177,7 +177,8 @@ class Event(Content):
         """
         Calculates total registrations with or without multiple pools.
         """
-        return self.registrations.filter(waiting_list=None, waiting_pool=None, unregistration_date=None).count()
+        return self.registrations.filter(waiting_list=None, waiting_pool=None,
+                                         unregistration_date=None).count()
 
     @property
     def number_of_waiting_registrations(self):

--- a/lego/app/events/tests/test_events_api.py
+++ b/lego/app/events/tests/test_events_api.py
@@ -65,27 +65,27 @@ def _get_detail_url(pk):
 
 
 def _get_pools_list_url(event_pk):
-    return reverse('pool-list', kwargs={'event_pk': event_pk})
+    return reverse('api:v1:pool-list', kwargs={'event_pk': event_pk})
 
 
 def _get_pools_detail_url(event_pk, pool_pk):
-    return reverse('pool-detail', kwargs={'event_pk': event_pk,
-                                          'pk': pool_pk})
+    return reverse('api:v1:pool-detail', kwargs={'event_pk': event_pk,
+                                                 'pk': pool_pk})
 
 
 def _get_register_list_url(event_pk):
-    return reverse('register-list', kwargs={'event_pk': event_pk})
+    return reverse('api:v1:register-list', kwargs={'event_pk': event_pk})
 
 
 def _get_registration_list_url(event_pk, pool_pk):
-    return reverse('registration-list', kwargs={'event_pk': event_pk,
-                                                'pool_pk': pool_pk})
+    return reverse('api:v1:registration-list', kwargs={'event_pk': event_pk,
+                                                       'pool_pk': pool_pk})
 
 
 def _get_registration_detail_url(event_pk, pool_pk, registration_pk):
-    return reverse('registration-detail', kwargs={'event_pk': event_pk,
-                                                  'pool_pk': pool_pk,
-                                                  'pk': registration_pk})
+    return reverse('api:v1:registration-detail', kwargs={'event_pk': event_pk,
+                                                         'pool_pk': pool_pk,
+                                                         'pk': registration_pk})
 
 
 class ListEventsTestCase(APITestCase):
@@ -178,9 +178,10 @@ class CreateEventsTestCase(APITestCase):
 
         pool_update_response = self.client.put(_get_pools_detail_url(event_id, pool_id),
                                                _test_pools_data[1])
-        self.assertIsNotNone(pool_update_response.data.pop('id'))
         self.assertEqual(pool_update_response.status_code, 200)
-        self.assertEqual(_test_pools_data[1], pool_update_response.data)
+        pool_update_get_response = self.client.get(_get_pools_detail_url(event_id, pool_id))
+        self.assertIsNotNone(pool_update_get_response.data.pop('id'))
+        self.assertEqual(_test_pools_data[1], pool_update_get_response.data)
 
 
 class RetrievePoolsTestCase(APITestCase):

--- a/lego/app/events/views/events.py
+++ b/lego/app/events/views/events.py
@@ -30,7 +30,8 @@ class PoolViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         event_id = self.kwargs.get('event_pk', None)
         if event_id:
-            return Pool.objects.filter(event=event_id).prefetch_related('permission_groups', 'registrations')
+            return Pool.objects.filter(event=event_id).prefetch_related('permission_groups',
+                                                                        'registrations')
 
 
 class RegistrationViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
Removes nested routers and uses plain regex instead. Alternative to drf-extensions proposed by @eirsyl. Tests are running, except pool_update due to timezones difference in db and test data.
