### PR TITLE
[Doppins] Upgrade dependency django-cachalot to ==1.2.1

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,4 +1,4 @@
 -r base.txt
 
 python3-memcached==1.51
-django-cachalot==1.2.0
+django-cachalot==1.2.1


### PR DESCRIPTION
Hi, and thank you for trying out [Doppins](https://doppins.com).

This initial pull request upgrades all your dependency ranges to the latest
available version. From now on any new dependency releases will result in a pull
request to your repository, submitted in real-time.

Make sure that it doesn't break anything, and happy merging! :shipit:

**The upgraded dependencies are:**

---
### Upgraded django-cachalot from `==1.2.0` to `==1.2.1`
