### PR TITLE
[Doppins] Upgrade dependency django-mptt to ==0.8.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,6 +20,6 @@ django-filter==0.12.0
 django-oauth-toolkit==0.10.0
 django-cors-headers==1.1.0
 django-celery==3.1.17
-django-mptt==0.8.1
+django-mptt==0.8.2
 django-environ==0.4.0
 django-secure==1.0.1


### PR DESCRIPTION
Hi!

A new version was just released of `django-mptt`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django-mptt from `==0.8.0` to `==0.8.1`
#### Changelog:
#### Version 0.8.1
- Fix issues with `raw_id_fields` in admin.
- New `DraggableMPTTAdmin` admin class that provides drag & drop node moving functionality
