### PR TITLE
[Doppins] Upgrade dependency django to ==1.9.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-django==1.9.1
+django==1.9.3
 ipython==4.0.1
 
 psycopg2==2.6.1


### PR DESCRIPTION
Hi!

A new version was just released of `django`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django from `==1.9.1` to `==1.9.3`
