### PR TITLE
[Doppins] Upgrade dependency djangorestframework to ==3.3.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ raven==5.11.1
 redis==2.10.5
 ipython==4.1.2
 
-djangorestframework==3.3.2
+djangorestframework==3.3.3
 djangorestframework-jwt==1.7.2
 djangorestframework-camel-case==0.2.0
 


### PR DESCRIPTION
Hi!

A new version was just released of `djangorestframework`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded djangorestframework from `==3.3.2` to `==3.3.3`
