### PR TITLE
[Doppins] Upgrade dependency markdown to ==2.6.6

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 django==1.9.4
 
 psycopg2==2.6.1
-markdown==2.6.5
+markdown==2.6.6
 unicode-slugify==0.1.3
 pyyaml==3.11
 raven==5.11.1


### PR DESCRIPTION
Hi!

A new version was just released of `markdown`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded markdown from `==2.6.5` to `==2.6.6`
