### PR TITLE
[Doppins] Upgrade dependency raven to ==5.12.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@ psycopg2==2.6.1
 markdown==2.6.5
 unicode-slugify==0.1.3
 pyyaml==3.11
-raven==5.11.2
+raven==5.12.0
 redis==2.10.5
 ipython==4.1.2
 


### PR DESCRIPTION
Hi!

A new version was just released of `raven`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded raven from `==5.11.1` to `==5.11.2`
