### PR TITLE
[Doppins] Upgrade dependency djangorestframework-jwt to ==1.8.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ redis==2.10.5
 ipython==4.1.2
 
 djangorestframework==3.3.3
-djangorestframework-jwt==1.7.2
+djangorestframework-jwt==1.8.0
 djangorestframework-camel-case==0.2.0
 
 django-basis==0.4.0


### PR DESCRIPTION
Hi!

A new version was just released of `djangorestframework-jwt`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded djangorestframework-jwt from `==1.7.2` to `==1.8.0`
