### PR TITLE
Number of users in group calculation

### DIFF
--- a/lego/users/models.py
+++ b/lego/users/models.py
@@ -37,7 +37,7 @@ class AbakusGroup(MPTTModel, PersistentModel):
             return self.parent.name == 'Abakom'
         return False
 
-    @property
+    @cached_property
     def number_of_users(self):
         return Membership.objects.filter(user__abakus_groups__in=self.get_descendants(True))\
             .distinct().count()

--- a/lego/users/tests/test_models.py
+++ b/lego/users/tests/test_models.py
@@ -102,7 +102,6 @@ class UserTestCase(TestCase):
         abakus = AbakusGroup.objects.get(name='Abakus')
         abakom = AbakusGroup.objects.get(name='Abakom')
         webkom = AbakusGroup.objects.get(name='Webkom')
-        self.assertEqual(abakus.number_of_users, 0)
 
         abakus.add_user(self.user)
         abakom.add_user(User.objects.get(pk=2))
@@ -112,11 +111,15 @@ class UserTestCase(TestCase):
         self.assertEqual(abakom.number_of_users, 2)
         self.assertEqual(webkom.number_of_users, 1)
 
-        webkom.remove_user(User.objects.get(pk=3))
+    def test_add_remove_user(self):
+        abakus = AbakusGroup.objects.get(name='Abakus')
 
-        self.assertEqual(abakus.number_of_users, 2)
-        self.assertEqual(abakom.number_of_users, 1)
-        self.assertEqual(webkom.number_of_users, 0)
+        abakus.add_user(self.user)
+        self.assertEqual(abakus.number_of_users, 1)
+
+        abakus = AbakusGroup.objects.get(name='Abakus')
+        abakus.remove_user(self.user)
+        self.assertEqual(abakus.number_of_users, 0)
 
     def test_natural_key(self):
         found_user = User.objects.get_by_natural_key(self.user.username)


### PR DESCRIPTION
Adds a method to calculate number of users in a group and its descendants, so that e.g. Webkom members are considered Abakus members.

Do we want to cache this manually? I guess this will be handled in some manner by cachalot, but may be better to use memcached ourselves?
