### PR TITLE
[Doppins] Upgrade dependency ipython to ==4.2.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 django==1.9.5
-ipython==4.1.2
+ipython==4.2.0
 
 psycopg2==2.6.1
 markdown==2.6.6


### PR DESCRIPTION
Hi!

A new version was just released of `ipython`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded ipython from `==4.1.2` to `==4.2.0`
