### PR TITLE
Fixed event serializer for comments to work

### DIFF
--- a/lego/app/events/serializers.py
+++ b/lego/app/events/serializers.py
@@ -1,8 +1,15 @@
 from basis.serializers import BasisSerializer
+from rest_framework.fields import CharField
 
+from lego.app.comments.serializers import CommentSerializer
 from lego.app.events.models import Event
 
 
 class EventSerializer(BasisSerializer):
+    comments = CommentSerializer(read_only=True, many=True)
+    comment_target = CharField(read_only=True)
+
     class Meta:
         model = Event
+        fields = ('id', 'title', 'ingress', 'text', 'comments', 'comment_target', 'end_time',
+                  'event_type', 'location', 'author', 'start_time')


### PR DESCRIPTION
Fix for front-end comments to display. Serializer currently does not return comments or comment_target values.
