### PR TITLE
[Doppins] Upgrade dependency django-mptt to ==0.8.4

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,6 +19,6 @@ django-filter==0.13.0
 django-oauth-toolkit==0.10.0
 django-cors-headers==1.1.0
 django-celery==3.1.17
-django-mptt==0.8.3
+django-mptt==0.8.4
 django-environ==0.4.0
 django-secure==1.0.1


### PR DESCRIPTION
Hi!

A new version was just released of `django-mptt`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django-mptt from `==0.8.3` to `==0.8.4`
#### Changelog:
#### Version 0.8.4
- build tweaks (`#450`, `#456`)
- Update russian translation
