### PR TITLE
[Doppins] Upgrade dependency raven to ==5.15.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@ psycopg2==2.6.1
 markdown==2.6.6
 unicode-slugify==0.1.3
 pyyaml==3.11
-raven==5.14.0
+raven==5.15.0
 redis==2.10.5
 
 djangorestframework==3.3.3


### PR DESCRIPTION
Hi!

A new version was just released of `raven`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded raven from `==5.14.0` to `==5.15.0`
