### PR TITLE
Fix randomly failing registration test.

### DIFF
--- a/lego/app/events/tests/test_models.py
+++ b/lego/app/events/tests/test_models.py
@@ -466,7 +466,7 @@ class RegistrationTestCase(TestCase):
         pool_one_size_before = pool_one.number_of_registrations
         pool_two_size_before = pool_two.number_of_registrations
 
-        user_to_unregister = pool_two.registrations.first().user
+        user_to_unregister = event.registrations.first().user
 
         event.unregister(user_to_unregister)
 


### PR DESCRIPTION
Test failing due to using the first pool available in the register function when event is merged. This pool may vary - therefore we cant know for sure that the user is registered into 'pool_two' in the test.
