### PR TITLE
[Doppins] Upgrade dependency coverage to ==4.1

### DIFF
--- a/requirements/coverage.txt
+++ b/requirements/coverage.txt
@@ -1,1 +1,1 @@
-coverage==4.0.3
+coverage==4.1


### PR DESCRIPTION
Hi!

A new version was just released of `coverage`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded coverage from `==4.0.3` to `==4.1`
