### PR TITLE
[Doppins] Upgrade dependency psycopg2 to ==2.6.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 django==1.9.7
 ipython==4.2.1
 
-psycopg2==2.6.1
+psycopg2==2.6.2
 markdown==2.6.6
 unicode-slugify==0.1.3
 pyyaml==3.11


### PR DESCRIPTION
Hi!

A new version was just released of `psycopg2`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded psycopg2 from `==2.6.1` to `==2.6.2`
