### PR TITLE
[Doppins] Upgrade dependency djangorestframework to ==3.4.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,7 @@ hiredis==0.2.0
 stream-framework==1.3.6
 git+https://github.com/django-statsd/django-statsd.git#67c8077
 
-djangorestframework==3.3.3
+djangorestframework==3.4.0
 djangorestframework-jwt==1.8.0
 djangorestframework-camel-case==0.2.0
 django-basis==0.4.0


### PR DESCRIPTION
Hi!

A new version was just released of `djangorestframework`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded djangorestframework from `==3.3.3` to `==3.4.0`
