### PR TITLE
[Doppins] Upgrade dependency django-mptt to ==0.8.5

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,5 +21,5 @@ django-filter==0.13.0
 django-oauth-toolkit==0.10.0
 django-cors-headers==1.1.0
 django-celery==3.1.17
-django-mptt==0.8.4
+django-mptt==0.8.5
 django-environ==0.4.0


### PR DESCRIPTION
Hi!

A new version was just released of `django-mptt`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django-mptt from `==0.8.4` to `==0.8.5`
