### PR TITLE
[Doppins] Upgrade dependency raven to ==5.24.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@ psycopg2==2.6.2
 markdown==2.6.6
 unicode-slugify==0.1.3
 pyyaml==3.11
-raven==5.24.1
+raven==5.24.2
 redis==2.10.5
 hiredis==0.2.0
 stream-framework==1.3.6


### PR DESCRIPTION
Hi!

A new version was just released of `raven`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded raven from `==5.24.1` to `==5.24.2`
