### PR TITLE
[Doppins] Upgrade dependency django-extensions to ==1.7.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ djangorestframework==3.4.4
 djangorestframework-jwt==1.8.0
 djangorestframework-camel-case==0.2.0
 django-basis==0.4.0
-django-extensions==1.7.1
+django-extensions==1.7.2
 django-autoslug==1.9.3
 django-filter==0.14.0
 django-oauth-toolkit==0.10.0


### PR DESCRIPTION
Hi!

A new version was just released of `django-extensions`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django-extensions from `==1.7.1` to `==1.7.2`
