### PR TITLE
[Doppins] Upgrade dependency djangorestframework to ==3.4.6

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,7 +14,7 @@ certifi==2016.2.28
 elasticsearch==2.3.0
 celery==3.1.23
 
-djangorestframework==3.4.5
+djangorestframework==3.4.6
 djangorestframework-jwt==1.8.0
 djangorestframework-camel-case==0.2.0
 django-basis==0.4.0


### PR DESCRIPTION
Hi!

A new version was just released of `djangorestframework`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded djangorestframework from `==3.4.5` to `==3.4.6`
