### PR TITLE
[Doppins] Upgrade dependency pyyaml to ==3.12

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@ django==1.10
 psycopg2==2.6.2
 markdown==2.6.6
 unicode-slugify==0.1.3
-pyyaml==3.11
+pyyaml==3.12
 raven==5.25.0
 redis==2.10.5
 hiredis==0.2.0


### PR DESCRIPTION
Hi!

A new version was just released of `pyyaml`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded pyyaml from `==3.11` to `==3.12`
