### PR TITLE
Add verify-jwt endpoint and change the jwt user serializer

### DIFF
--- a/lego/urls.py
+++ b/lego/urls.py
@@ -1,11 +1,12 @@
 from django.conf.urls import include, url
 from django.contrib.auth.views import login, logout
 from django.views.generic import TemplateView
-from rest_framework_jwt.views import obtain_jwt_token, refresh_jwt_token
+from rest_framework_jwt.views import obtain_jwt_token, refresh_jwt_token, verify_jwt_token
 
 jwt_urlpatterns = [
     url(r'^token-auth/$', obtain_jwt_token, name='obtain_jwt_token'),
     url(r'^token-auth/refresh/$', refresh_jwt_token, name='refresh_jwt_token'),
+    url(r'^token-auth/verify/$', verify_jwt_token, name='verify_jwt_token'),
 ]
 
 authorization_urlpatterns = [

--- a/lego/utils/json_web_tokens.py
+++ b/lego/utils/json_web_tokens.py
@@ -1,8 +1,8 @@
-from lego.apps.users.serializers import DetailedUserSerializer
+from lego.apps.users.serializers import MeSerializer
 
 
 def response_handler(token, user=None, request=None):
     return {
         'token': token,
-        'user': DetailedUserSerializer(user).data
+        'user': MeSerializer(user).data
     }


### PR DESCRIPTION
The jwt backend now uses the same serializer used by the /me endpoint wich is used when retrieving the profile when authenticating with oAuth2.

This may break the webapp? @Hanse @ekmartin 

HEADS UP: The "committees" field should be changed to a "groups" with a list of all groups. Related issue: #237
