### PR TITLE
[Doppins] Upgrade dependency django-filter to ==0.15.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ djangorestframework-camel-case==0.2.0
 django-basis==0.4.0
 django-extensions==1.7.4
 django-autoslug==1.9.3
-django-filter==0.14.0
+django-filter==0.15.0
 django-oauth-toolkit==0.10.0
 django-cors-headers==1.1.0
 django-mptt==0.8.6


### PR DESCRIPTION
Hi!

A new version was just released of `django-filter`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django-filter from `==0.14.0` to `==0.15.0`
