### PR TITLE
[Doppins] Upgrade dependency markdown to ==2.6.7

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@ ipython==5.1.0
 django==1.10
 
 psycopg2==2.6.2
-markdown==2.6.6
+markdown==2.6.7
 unicode-slugify==0.1.3
 pyyaml==3.12
 raven==5.27.1


### PR DESCRIPTION
Hi!

A new version was just released of `markdown`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded markdown from `==2.6.6` to `==2.6.7`
