### PR TITLE
[Doppins] Upgrade dependency django-cors-headers to ==1.2.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,6 +21,6 @@ django-extensions==1.7.4
 django-autoslug==1.9.3
 django-filter==0.15.2
 django-oauth-toolkit==0.10.0
-django-cors-headers==1.2.1
+django-cors-headers==1.2.2
 django-mptt==0.8.6
 django-environ==0.4.0


### PR DESCRIPTION
Hi!

A new version was just released of `django-cors-headers`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django-cors-headers from `==1.2.1` to `==1.2.2`
