### PR TITLE
Fix fixture loading

### DIFF
--- a/lego/apps/users/fixtures/development_users.yaml
+++ b/lego/apps/users/fixtures/development_users.yaml
@@ -1,11 +1,4 @@
 - fields:
-    email: adiykgoaet@gmail.com
-    first_name: Anonymous
-    last_name: user
-    username: anonymous
-  model: users.User
-  pk: 1
-- fields:
     email: tnmxpclxrn@gmail.com
     first_name: Per Kristian J
     last_name: Fjellby

--- a/lego/utils/management/commands/load_fixtures.py
+++ b/lego/utils/management/commands/load_fixtures.py
@@ -7,6 +7,9 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         self.stdout.write('Loading regular fixtures:')
+        call_command('loaddata', 'lego/apps/users/fixtures/initial_abakus_groups.yaml')
+        call_command('loaddata', 'lego/apps/users/fixtures/initial_users.yaml')
+        call_command('loaddata', 'lego/apps/users/fixtures/initial_memberships.yaml')
         if settings.DEVELOPMENT:
             self.stdout.write('Loading development fixtures:')
             call_command('loaddata', 'lego/apps/users/fixtures/development_users.yaml')
@@ -15,7 +18,4 @@ class Command(BaseCommand):
             call_command('loaddata', 'lego/apps/events/fixtures/development_registrations.yaml')
             call_command('loaddata', 'lego/apps/articles/fixtures/development_articles.yaml')
             call_command('loaddata', 'lego/apps/quotes/fixtures/development_quotes.yaml')
-        call_command('loaddata', 'lego/apps/users/fixtures/initial_abakus_groups.yaml')
-        call_command('loaddata', 'lego/apps/users/fixtures/initial_users.yaml')
-        call_command('loaddata', 'lego/apps/users/fixtures/initial_memberships.yaml')
         self.stdout.write('Done!')


### PR DESCRIPTION
Runs loaddata on initial fixtures before dev so that dependencies works for development fixtures. Removes duplicate pk so that the initial user does not get overwritten.
