### PR TITLE
[Doppins] Upgrade dependency certifi to ==2016.9.26

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ redis==2.10.5
 hiredis==0.2.0
 stream-framework==1.3.6
 git+https://github.com/django-statsd/django-statsd.git#67c8077
-certifi==2016.2.28
+certifi==2016.9.26
 elasticsearch==2.3.0
 celery==3.1.23
 


### PR DESCRIPTION
Hi!

A new version was just released of `certifi`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded certifi from `==2016.2.28` to `==2016.9.26`
