### PR TITLE
[Doppins] Upgrade dependency celery to ==3.1.24

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ stream-framework==1.3.6
 git+https://github.com/django-statsd/django-statsd.git#67c8077
 certifi==2016.9.26
 elasticsearch==2.4.0
-celery==3.1.23
+celery==3.1.24
 
 djangorestframework==3.4.7
 djangorestframework-jwt==1.8.0


### PR DESCRIPTION
Hi!

A new version was just released of `celery`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded celery from `==3.1.23` to `==3.1.24`
