### PR TITLE
[Doppins] Upgrade dependency raven to ==5.29.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@ psycopg2==2.6.2
 markdown==2.6.7
 unicode-slugify==0.1.3
 pyyaml==3.12
-raven==5.28.0
+raven==5.29.0
 redis==2.10.5
 hiredis==0.2.0
 stream-framework==1.3.6


### PR DESCRIPTION
Hi!

A new version was just released of `raven`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded raven from `==5.28.0` to `==5.29.0`
#### Changelog:
#### Version 5.4.0
- Binding transports via a scheme prefix on DSNs is now deprecated.
- `raven.conf.load` has been removed.
- Upstream-related configuration (such as url, project_id, and keys) is now contained in `RemoteConfig`
  attached to `Client.remote`
- The `aiohttp` transport has been moved to `raven-aiohttp` package.
#### Version 5.3.0
- The UDP transport has been removed.
- The integrated Sentry+Django client has been removed. This is now part of Sentry core.
- Server configuration _must_ now be specified with a DSN.
- Upstream errors now have increased verbosity in logs.
- Unsent events now log to 'sentry.errors.uncaught'.
- Django management commands should now effectively autopatch (when run from the CLI).
- Flask wrapper now includes user_context, tags_context, and extra_context helpers.
- Python version is now reported with modules.
