### PR TITLE
[Doppins] Upgrade dependency stream-framework to ==1.4.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ pyyaml==3.12
 raven==5.28.0
 redis==2.10.5
 hiredis==0.2.0
-stream-framework==1.3.6
+stream-framework==1.4.0
 git+https://github.com/django-statsd/django-statsd.git#67c8077
 certifi==2016.9.26
 elasticsearch==2.4.0


### PR DESCRIPTION
Hi!

A new version was just released of `stream-framework`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded stream-framework from `==1.3.6` to `==1.4.0`
