### PR TITLE
[Doppins] Upgrade dependency elasticsearch to ==5.0.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,7 @@ hiredis==0.2.0
 stream-framework==1.4.0
 git+https://github.com/django-statsd/django-statsd.git#67c8077
 certifi==2016.9.26
-elasticsearch==5.0.0
+elasticsearch==5.0.1
 celery==3.1.24
 
 djangorestframework==3.4.7


### PR DESCRIPTION
Hi!

A new version was just released of `elasticsearch`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded elasticsearch from `==2.4.0` to `==5.0.0`
