### PR TITLE
[Doppins] Upgrade dependency djangorestframework to ==3.5.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,7 +14,7 @@ certifi==2016.9.26
 elasticsearch==2.4.0
 celery==3.1.24
 
-djangorestframework==3.5.0
+djangorestframework==3.5.1
 djangorestframework-jwt==1.8.0
 djangorestframework-camel-case==0.2.0
 django-extensions==1.7.4


### PR DESCRIPTION
Hi!

A new version was just released of `djangorestframework`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded djangorestframework from `==3.4.7` to `==3.5.0`
