### PR TITLE
Set fields explicitly due to deprecation in drf 3.3.0

### DIFF
--- a/lego/apps/permissions/tests/serializer.py
+++ b/lego/apps/permissions/tests/serializer.py
@@ -6,3 +6,4 @@ from lego.apps.permissions.tests.models import TestModel
 class TestSerializer(serializers.ModelSerializer):
     class Meta:
         model = TestModel
+        fields = '__all__'


### PR DESCRIPTION
Why does the build in master pass? 😅 
