### PR TITLE
[Doppins] Upgrade dependency django-environ to ==0.4.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,4 +23,4 @@ django-filter==0.15.3
 django-oauth-toolkit==0.10.0
 django-cors-headers==1.3.0
 django-mptt==0.8.6
-django-environ==0.4.0
+django-environ==0.4.1


### PR DESCRIPTION
Hi!

A new version was just released of `django-environ`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django-environ from `==0.4.0` to `==0.4.1`

#### Changelog:

#### Version 0.4.1
- Fix for unsafe characters into URLs
- Clarifying warning on missing or unreadable file. Thanks to `@nickcatal`
- Add support for Django 1.10.
- Fix support for Oracle urls
- Fix support for django-redis

