### PR TITLE
[Doppins] Upgrade dependency asgi_redis to ==1.0.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,7 @@ hiredis==0.2.0
 stream-framework==1.4.0
 certifi==2016.9.26
 elasticsearch==2.4.0
-asgi_redis==0.14.1
+asgi_redis==1.0.0
 channels==0.17.2
 celery==4.0.0
 


### PR DESCRIPTION
Hi!

A new version was just released of `asgi_redis`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded asgi_redis from `==0.14.1` to `==1.0.0`

