### PR TITLE
[Doppins] Upgrade dependency channels to ==0.17.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ stream-framework==1.4.0
 certifi==2016.9.26
 elasticsearch==2.4.0
 asgi_redis==1.0.0
-channels==0.17.2
+channels==0.17.3
 celery==4.0.0
 
 djangorestframework==3.5.3


### PR DESCRIPTION
Hi!

A new version was just released of `channels`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded channels from `==0.17.2` to `==0.17.3`

