### PR TITLE
Add a --development flag to the load_fixtures command

### DIFF
--- a/lego/utils/management/commands/load_fixtures.py
+++ b/lego/utils/management/commands/load_fixtures.py
@@ -5,6 +5,14 @@ from django.core.management import BaseCommand, call_command
 class Command(BaseCommand):
     help = 'Loads initial data from fixtures.'
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--development',
+            action='store_true',
+            default=False,
+            help='Load development fixtures.',
+        )
+
     def handle(self, *args, **options):
         self.stdout.write('Loading regular fixtures:')
 
@@ -12,7 +20,7 @@ class Command(BaseCommand):
         call_command('loaddata', 'lego/apps/users/fixtures/initial_users.yaml')
         call_command('loaddata', 'lego/apps/users/fixtures/initial_memberships.yaml')
 
-        if getattr(settings, 'DEVELOPMENT', None):
+        if getattr(settings, 'DEVELOPMENT', None) or options['development']:
             self.stdout.write('Loading development fixtures:')
             call_command('loaddata', 'lego/apps/users/fixtures/development_users.yaml')
             call_command('loaddata', 'lego/apps/events/fixtures/development_events.yaml')


### PR DESCRIPTION
This makes it easier to load development settings into a site running with production/environment config. Could be useful in our test environment.