### PR TITLE
[Doppins] Upgrade dependency django-filter to ==1.0.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,7 +21,7 @@ djangorestframework-jwt==1.8.0
 djangorestframework-camel-case==0.2.0
 django-extensions==1.7.4
 django-autoslug==1.9.3
-django-filter==0.15.3
+django-filter==1.0.0
 django-oauth-toolkit==0.10.0
 django-cors-headers==1.3.1
 django-mptt==0.8.6


### PR DESCRIPTION
Hi!

A new version was just released of `django-filter`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django-filter from `==0.15.3` to `==1.0.0`

