### PR TITLE
Fixed issue with exception when grabbing request as AnonymousUser

### DIFF
--- a/lego/apps/users/permissions.py
+++ b/lego/apps/users/permissions.py
@@ -1,3 +1,5 @@
+from django.contrib.auth.models import AnonymousUser
+
 from lego.apps.permissions.permissions import AbakusPermission
 from lego.apps.users.models import Membership
 
@@ -48,7 +50,7 @@ class AbakusGroupPermissions(AbakusPermission):
         return True if view.action in self.allowed_leader else super().has_permission(request, view)
 
     def has_object_permission(self, request, view, obj):
-        if view.action in self.allowed_leader:
+        if view.action in self.allowed_leader and not isinstance(request.user, AnonymousUser):
             user = request.user
             is_owner = bool(Membership.objects.filter(abakus_group=obj, user=user,
                                                       role=Membership.LEADER))


### PR DESCRIPTION
Grabbing a detailed route without being authenticated returns an error:
```
Traceback (most recent call last):
  File "lego/venv/lib/python3.5/site-packages/django/utils/six.py", line 686, in reraise
    raise value
  File "lego/venv/lib/python3.5/site-packages/django/core/handlers/exception.py", line 39, in inner
    response = get_response(request)
  File "lego/venv/lib/python3.5/site-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
    response = self._get_response(request)
  File "lego/venv/lib/python3.5/site-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "lego/venv/lib/python3.5/site-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "lego/venv/lib/python3.5/site-packages/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "lego/venv/lib/python3.5/site-packages/rest_framework/viewsets.py", line 83, in view
    return self.dispatch(request, *args, **kwargs)
  File "lego/venv/lib/python3.5/site-packages/rest_framework/views.py", line 477, in dispatch
    response = self.handle_exception(exc)
  File "lego/venv/lib/python3.5/site-packages/rest_framework/views.py", line 437, in handle_exception
    self.raise_uncaught_exception(exc)
  File "lego/venv/lib/python3.5/site-packages/rest_framework/views.py", line 474, in dispatch
    response = handler(request, *args, **kwargs)
  File "lego/venv/lib/python3.5/site-packages/rest_framework/mixins.py", line 67, in update
    instance = self.get_object()
  File "lego/venv/lib/python3.5/site-packages/rest_framework/generics.py", line 100, in get_object
    self.check_object_permissions(self.request, obj)
  File "lego/venv/lib/python3.5/site-packages/rest_framework/views.py", line 332, in check_object_permissions
    if not permission.has_object_permission(request, self, obj):
  File "lego/lego/apps/users/permissions.py", line 61, in has_object_permission
    role=Membership.LEADER))
  File "lego/venv/lib/python3.5/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "lego/venv/lib/python3.5/site-packages/django/db/models/query.py", line 794, in filter
    return self._filter_or_exclude(False, *args, **kwargs)
  File "lego/venv/lib/python3.5/site-packages/django/db/models/query.py", line 812, in _filter_or_exclude
    clone.query.add_q(Q(*args, **kwargs))
  File "lego/venv/lib/python3.5/site-packages/django/db/models/sql/query.py", line 1227, in add_q
    clause, _ = self._add_q(q_object, self.used_aliases)
  File "lego/venv/lib/python3.5/site-packages/django/db/models/sql/query.py", line 1253, in _add_q
    allow_joins=allow_joins, split_subq=split_subq,
  File "lego/venv/lib/python3.5/site-packages/django/db/models/sql/query.py", line 1183, in build_filter
    condition = lookup_class(lhs, value)
  File "lego/venv/lib/python3.5/site-packages/django/db/models/lookups.py", line 19, in __init__
    self.rhs = self.get_prep_lookup()
  File "lego/venv/lib/python3.5/site-packages/django/db/models/fields/related_lookups.py", line 100, in get_prep_lookup
    self.rhs = target_field.get_prep_value(self.rhs)
  File "lego/venv/lib/python3.5/site-packages/django/db/models/fields/__init__.py", line 946, in get_prep_value
    return int(value)
TypeError: int() argument must be a string, a bytes-like object or a number, not 'AnonymousUser'
```

This PR fixes it by checking if the user is a "AnonymousUser" before checking their membership.