### PR TITLE
[Doppins] Upgrade dependency djangorestframework-jwt to ==1.9.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,7 +17,7 @@ celery==4.0.0
 whitenoise==3.2.2
 
 djangorestframework==3.5.3
-djangorestframework-jwt==1.8.0
+djangorestframework-jwt==1.9.0
 djangorestframework-camel-case==0.2.0
 django-extensions==1.7.4
 django-autoslug==1.9.3


### PR DESCRIPTION
Hi!

A new version was just released of `djangorestframework-jwt`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded djangorestframework-jwt from `==1.8.0` to `==1.9.0`

