### PR TITLE
[Doppins] Upgrade dependency celery to ==4.0.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,7 @@ certifi==2016.9.26
 elasticsearch==5.0.1
 asgi_redis==1.0.0
 channels==0.17.3
-celery==4.0.0
+celery==4.0.1
 whitenoise==3.2.2
 stripe==1.41.0
 


### PR DESCRIPTION
Hi!

A new version was just released of `celery`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded celery from `==4.0.0` to `==4.0.1`

