### PR TITLE
[Doppins] Upgrade dependency stripe to ==1.44.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ asgi_redis==1.0.0
 channels==0.17.3
 celery==4.0.1
 whitenoise==3.2.2
-stripe==1.43.0
+stripe==1.44.0
 
 djangorestframework==3.5.3
 djangorestframework-jwt==1.9.0


### PR DESCRIPTION
Hi!

A new version was just released of `stripe`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded stripe from `==1.43.0` to `==1.44.0`

