### PR TITLE
[Doppins] Upgrade dependency django-mptt to ==0.8.7

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,7 +26,7 @@ django-autoslug==1.9.3
 django-oauth-toolkit==0.11.0
 django-filter==1.0.1
 django-cors-headers==1.3.1
-django-mptt==0.8.6
+django-mptt==0.8.7
 django-environ==0.4.1
 django-redis==4.6.0
 django-ipware==1.1.6


### PR DESCRIPTION
Hi!

A new version was just released of `django-mptt`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django-mptt from `==0.8.6` to `==0.8.7`

