### PR TITLE
[Doppins] Upgrade dependency django-redis to ==4.7.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,6 +29,6 @@ django-filter==1.0.1
 django-cors-headers==1.3.1
 django-mptt==0.8.7
 django-environ==0.4.1
-django-redis==4.6.0
+django-redis==4.7.0
 django-ipware==1.1.6
 django-thumbor==0.5.6


### PR DESCRIPTION
Hi!

A new version was just released of `django-redis`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django-redis from `==4.6.0` to `==4.7.0`

