### PR TITLE
[Doppins] Upgrade dependency whitenoise to ==3.2.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,7 +14,7 @@ elasticsearch==5.0.1
 asgi_redis==1.0.0
 channels==0.17.3
 celery==4.0.2
-whitenoise==3.2.2
+whitenoise==3.2.3
 stripe==1.44.0
 structlog==16.1.0
 boto3==1.4.3


### PR DESCRIPTION
Hi!

A new version was just released of `whitenoise`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded whitenoise from `==3.2.2` to `==3.2.3`

