### PR TITLE
[Doppins] Upgrade dependency django to ==1.10.5

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 ipython==5.1.0
-django==1.10.4
+django==1.10.5
 
 psycopg2==2.6.2
 markdown==2.6.7


### PR DESCRIPTION
Hi!

A new version was just released of `django`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django from `==1.10.4` to `==1.10.5`

