### PR TITLE
[Doppins] Upgrade dependency stripe to ==1.46.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ asgi_redis==1.0.0
 channels==0.17.3
 celery==4.0.2
 whitenoise==3.2.3
-stripe==1.45.0
+stripe==1.46.0
 structlog==16.1.0
 boto3==1.4.3
 


### PR DESCRIPTION
Hi!

A new version was just released of `stripe`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded stripe from `==1.44.0` to `==1.45.0`

