### PR TITLE
[Doppins] Upgrade dependency boto3 to ==1.4.4

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ celery==4.0.2
 whitenoise==3.2.3
 stripe==1.46.0
 structlog==16.1.0
-boto3==1.4.3
+boto3==1.4.4
 
 # channels:
 channels==1.0.2


### PR DESCRIPTION
Hi!

A new version was just released of `boto3`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded boto3 from `==1.4.3` to `==1.4.4`

