### PR TITLE
[Doppins] Upgrade dependency django-extensions to ==1.7.6

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -25,7 +25,7 @@ daphne==1.0.1
 djangorestframework==3.5.3
 djangorestframework-jwt==1.9.0
 djangorestframework-camel-case==0.2.0
-django-extensions==1.7.5
+django-extensions==1.7.6
 django-autoslug==1.9.3
 django-oauth-toolkit==0.11.0
 django-filter==1.0.1


### PR DESCRIPTION
Hi!

A new version was just released of `django-extensions`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django-extensions from `==1.7.5` to `==1.7.6`

