### PR TITLE
[Doppins] Upgrade dependency whitenoise to ==3.3.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ stream-framework==1.4.0
 certifi==2017.1.23
 elasticsearch==5.1.0
 celery==4.0.2
-whitenoise==3.2.3
+whitenoise==3.3.0
 stripe==1.46.0
 structlog==16.1.0
 boto3==1.4.4


### PR DESCRIPTION
Hi!

A new version was just released of `whitenoise`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded whitenoise from `==3.2.3` to `==3.3.0`

