### PR TITLE
[Doppins] Upgrade dependency channels to ==1.0.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,7 +18,7 @@ structlog==16.1.0
 boto3==1.4.4
 
 # channels:
-channels==1.0.2
+channels==1.0.3
 asgi_redis==1.0.0
 daphne==1.0.1
 


### PR DESCRIPTION
Hi!

A new version was just released of `channels`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded channels from `==1.0.2` to `==1.0.3`

