### PR TITLE
[Doppins] Upgrade dependency daphne to ==1.0.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ boto3==1.4.4
 # channels:
 channels==1.0.2
 asgi_redis==1.0.0
-daphne==1.0.1
+daphne==1.0.2
 
 djangorestframework==3.5.3
 djangorestframework-jwt==1.9.0


### PR DESCRIPTION
Hi!

A new version was just released of `daphne`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded daphne from `==1.0.1` to `==1.0.2`

