### PR TITLE
[Doppins] Upgrade dependency ipython to ==5.2.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-ipython==5.2.1
+ipython==5.2.2
 django==1.10.5
 
 psycopg2==2.6.2


### PR DESCRIPTION
Hi!

A new version was just released of `ipython`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded ipython from `==5.2.1` to `==5.2.2`

