### PR TITLE
[Doppins] Upgrade dependency django-cors-headers to ==2.0.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -30,7 +30,7 @@ django-extensions==1.7.6
 django-autoslug==1.9.3
 django-oauth-toolkit==0.11.0
 django-filter==1.0.1
-django-cors-headers==2.0.1
+django-cors-headers==2.0.2
 django-mptt==0.8.7
 django-environ==0.4.1
 django-redis==4.7.0


### PR DESCRIPTION
Hi!

A new version was just released of `django-cors-headers`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django-cors-headers from `==2.0.1` to `==2.0.2`

