### PR TITLE
Change feed key for user related feeds

### DIFF
--- a/lego/apps/feed/feed_handlers/comment_handler.py
+++ b/lego/apps/feed/feed_handlers/comment_handler.py
@@ -29,14 +29,12 @@ class CommentHandler(BaseHandler):
     def get_feeds_and_recipients(self, comment):
         result = []
         if hasattr(comment.content_object, 'followers'):
-            result.append(
-                (
-                    [PersonalFeed],
-                    list(comment.content_object.followers.values_list('follower_id', flat=True))
-                )
-            )
+            result.append((
+                [PersonalFeed],
+                list(comment.content_object.followers.values_list('follower__username', flat=True))
+            ))
         if comment.created_by:
-            result.append(([UserFeed], [comment.created_by.id]))
+            result.append(([UserFeed], [comment.created_by.username]))
         return result
 
     def get_activity(self, comment):

--- a/lego/apps/feed/tests/test_comment_handler.py
+++ b/lego/apps/feed/tests/test_comment_handler.py
@@ -24,7 +24,7 @@ class TestCommentHandler(FeedTestBase):
 
         self.comment1 = self.comments[0]
         self.comment2 = self.comments[1]
-        self.feed = UserFeed(self.comment1.created_by.id)
+        self.feed = UserFeed(self.comment1.created_by.username)
 
     def test_duplicate_create(self):
         self.handler.handle_create(self.comment1)
@@ -62,8 +62,8 @@ class TestCommentHandler(FeedTestBase):
             object_id=follow.target.id
         ).first()
 
-        follower_feed = PersonalFeed(follow.follower.id)
-        creator_feed = PersonalFeed(comment.created_by.id)
+        follower_feed = PersonalFeed(follow.follower.username)
+        creator_feed = PersonalFeed(comment.created_by.username)
 
         self.assertIsNotNone(comment)
 

--- a/lego/apps/feed/tests/test_manager.py
+++ b/lego/apps/feed/tests/test_manager.py
@@ -28,23 +28,23 @@ class ManagerTestCase(FeedTestBase):
         )
 
     def test_adding_actitivites_to_notification_feeds(self):
-        feed_manager.add_activity(self.activity, [1, 2], [NotificationFeed])
+        feed_manager.add_activity(self.activity, ['test1', 'test2'], [NotificationFeed])
 
-        self.assertIn(self.activity, self.all_activities(NotificationFeed(1)))
-        self.assertIn(self.activity, self.all_activities(NotificationFeed(2)))
-        self.assertNotIn(self.activity, self.all_activities(NotificationFeed(3)))
+        self.assertIn(self.activity, self.all_activities(NotificationFeed('test1')))
+        self.assertIn(self.activity, self.all_activities(NotificationFeed('test2')))
+        self.assertNotIn(self.activity, self.all_activities(NotificationFeed('useradmin_test')))
 
     def test_adding_actitivites_to_aggregated_feeds(self):
-        feed_manager.add_activity(self.activity, [1, 2], [UserFeed])
-        feed_manager.add_activity(self.activity, [3, 2], [PersonalFeed])
+        feed_manager.add_activity(self.activity, ['test1', 'test2'], [UserFeed])
+        feed_manager.add_activity(self.activity, ['useradmin_test', 'test2'], [PersonalFeed])
 
-        self.assertIn(self.activity, self.all_activities(UserFeed(1)))
-        self.assertIn(self.activity, self.all_activities(UserFeed(2)))
-        self.assertNotIn(self.activity, self.all_activities(UserFeed(3)))
+        self.assertIn(self.activity, self.all_activities(UserFeed('test1')))
+        self.assertIn(self.activity, self.all_activities(UserFeed('test2')))
+        self.assertNotIn(self.activity, self.all_activities(UserFeed('useradmin_test')))
 
-        self.assertNotIn(self.activity, self.all_activities(PersonalFeed(1)))
-        self.assertIn(self.activity, self.all_activities(PersonalFeed(2)))
-        self.assertIn(self.activity, self.all_activities(PersonalFeed(3)))
+        self.assertNotIn(self.activity, self.all_activities(PersonalFeed('test1')))
+        self.assertIn(self.activity, self.all_activities(PersonalFeed('test2')))
+        self.assertIn(self.activity, self.all_activities(PersonalFeed('useradmin_test')))
 
     @mock.patch('lego.apps.feed.feed_manager.feed_manager.create_fanout_tasks')
     def test_add_activity(self, mock_create_fanout_tasks):
@@ -54,11 +54,11 @@ class ManagerTestCase(FeedTestBase):
 
         feed_manager.add_activity(
             activity_mock,
-            [1, 2],
+            ['abc', 'def'],
             [NotificationFeed]
         )
 
-        self.assertIn({1, 2}, mock_create_fanout_tasks.call_args[0])
+        self.assertIn({'abc', 'def'}, mock_create_fanout_tasks.call_args[0])
         self.assertIn(NotificationFeed, mock_create_fanout_tasks.call_args[0])
         self.assertIn(add_operation, mock_create_fanout_tasks.call_args[0])
 
@@ -71,10 +71,10 @@ class ManagerTestCase(FeedTestBase):
 
         feed_manager.remove_activity(
             activity_mock,
-            [1, 2],
+            ['abc', 'def'],
             [NotificationFeed]
         )
 
-        self.assertIn({1, 2}, mock_create_fanout_tasks.call_args[0])
+        self.assertIn({'abc', 'def'}, mock_create_fanout_tasks.call_args[0])
         self.assertIn(NotificationFeed, mock_create_fanout_tasks.call_args[0])
         self.assertIn(remove_operation, mock_create_fanout_tasks.call_args[0])

--- a/lego/apps/feed/tests/test_views.py
+++ b/lego/apps/feed/tests/test_views.py
@@ -55,7 +55,11 @@ class NotificationViewsTestCase(APITestCase, FeedTestBase):
             target=comment2.content_object,
             time=datetime.now()
         )
-        feed_manager.add_activity(self.activity1, [1, 2], [NotificationFeed])
+        feed_manager.add_activity(
+            self.activity1,
+            [self.user.username, self.second_user.username],
+            [NotificationFeed]
+        )
 
     def test_list_notifications(self):
         """Try to list user notifications."""
@@ -79,19 +83,19 @@ class NotificationViewsTestCase(APITestCase, FeedTestBase):
         self.assertEqual(res['unseenCount'], 1)
         self.assertEqual(res['unreadCount'], 1)
 
-        feed_manager.add_activity(self.activity2, [1], [NotificationFeed])
+        feed_manager.add_activity(self.activity2, [self.user.username], [NotificationFeed])
         res = self.client.get(f'{self.url}notification_data/').json()
         self.assertEqual(res['unseenCount'], 1)
         self.assertEqual(res['unreadCount'], 1)
 
-        feed_manager.add_activity(self.activity3, [1], [NotificationFeed])
+        feed_manager.add_activity(self.activity3, [self.user.username], [NotificationFeed])
         res = self.client.get(f'{self.url}notification_data/').json()
         self.assertEqual(res['unseenCount'], 2)
         self.assertEqual(res['unreadCount'], 2)
 
     def test_mark(self):
         self.client.force_login(self.user)
-        feed_manager.add_activity(self.activity3, [1], [NotificationFeed])
+        feed_manager.add_activity(self.activity3, [self.user.username], [NotificationFeed])
         res = self.client.get(f'{self.url}notification_data/').json()
         self.assertEqual(res['unseenCount'], 2)
         self.assertEqual(res['unreadCount'], 2)
@@ -154,7 +158,7 @@ class NotificationViewsTestCase(APITestCase, FeedTestBase):
         self.assertEqual(res['unseenCount'], 1)
         self.assertEqual(res['unreadCount'], 1)
 
-        feed_manager.add_activity(self.activity3, [1], [NotificationFeed])
+        feed_manager.add_activity(self.activity3, [self.user.username], [NotificationFeed])
         res = self.client.get(f'{self.url}notification_data/').json()
         self.assertEqual(res['unseenCount'], 2)
         self.assertEqual(res['unreadCount'], 2)

--- a/lego/apps/feed/views.py
+++ b/lego/apps/feed/views.py
@@ -39,10 +39,9 @@ class FeedViewSet(viewsets.GenericViewSet):
         )
 
         try:
-            feed_id = int(self.kwargs[lookup_url_kwarg])
+            feed_id = self.kwargs[lookup_url_kwarg]
         except (ValueError, TypeError):
             raise exceptions.ParseError
-
         return self.feed_class(feed_id)
 
 
@@ -88,7 +87,7 @@ class PersonalFeedViewSet(FeedViewSet, FeedListMixin):
     feed_class = PersonalFeed
 
     def get_queryset(self):
-        return self.feed_class(self.request.user.id)
+        return self.feed_class(self.request.user.username)
 
 
 class GroupFeedViewSet(FeedViewSet, FeedRetrieveMixin):
@@ -116,7 +115,7 @@ class NotificationFeedViewSet(FeedViewSet, FeedListMixin):
         """
         We select the feed with request.user
         """
-        return self.feed_class(self.request.user.id)
+        return self.feed_class(self.request.user.username)
 
     @decorators.list_route(
         permission_classes=[permissions.IsAuthenticated],


### PR DESCRIPTION
Use `username` instead of `id` for consistency with user retrieving. 