### PR TITLE
[Doppins] Upgrade dependency stripe to ==1.48.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,7 @@ certifi==2017.1.23
 elasticsearch==5.2.0
 celery==4.0.2
 whitenoise==3.3.0
-stripe==1.48.0
+stripe==1.48.1
 structlog==16.1.0
 boto3==1.4.4
 cassandra-driver==3.7.1


### PR DESCRIPTION
Hi!

A new version was just released of `stripe`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded stripe from `==1.46.0` to `==1.48.0`

