### PR TITLE
[Doppins] Upgrade dependency django-oauth-toolkit to ==0.12.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,7 +29,7 @@ djangorestframework-jwt==1.9.0
 djangorestframework-camel-case==0.2.0
 django-extensions==1.7.6
 django-autoslug==1.9.3
-django-oauth-toolkit==0.11.0
+django-oauth-toolkit==0.12.0
 django-filter==1.0.1
 django-cors-headers==2.0.2
 django-mptt==0.8.7


### PR DESCRIPTION
Hi!

A new version was just released of `django-oauth-toolkit`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django-oauth-toolkit from `==0.11.0` to `==0.12.0`

