### PR TITLE
[Doppins] Upgrade dependency psycopg2 to ==2.7

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 ipython==5.2.2
 django==1.10.5
 
-psycopg2==2.6.2
+psycopg2==2.7
 markdown==2.6.8
 unicode-slugify==0.1.3
 pyyaml==3.12


### PR DESCRIPTION
Hi!

A new version was just released of `psycopg2`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded psycopg2 from `==2.6.2` to `==2.7`

