### PR TITLE
[Doppins] Upgrade dependency django-debug-toolbar to ==1.7

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 -r base.txt
 -r docs.txt
 
-django-debug-toolbar==1.6
+django-debug-toolbar==1.7


### PR DESCRIPTION
Hi!

A new version was just released of `django-debug-toolbar`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django-debug-toolbar from `==1.6` to `==1.7`

