### PR TITLE
[Doppins] Upgrade dependency djangorestframework to ==3.6.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,7 +24,7 @@ channels==1.0.3
 asgi_redis==1.0.0
 daphne==1.0.3
 
-djangorestframework==3.6.0
+djangorestframework==3.6.1
 djangorestframework-jwt==1.9.0
 djangorestframework-camel-case==0.2.0
 django-extensions==1.7.7


### PR DESCRIPTION
Hi!

A new version was just released of `djangorestframework`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded djangorestframework from `==3.5.4` to `==3.6.0`

