### PR TITLE
[Doppins] Upgrade dependency cassandra-driver to ==3.8.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ whitenoise==3.3.0
 stripe==1.49.0
 structlog==16.1.0
 boto3==1.4.4
-cassandra-driver==3.8.0
+cassandra-driver==3.8.1
 prometheus-client==0.0.19
 requests==2.13.0
 slackclient==1.0.5


### PR DESCRIPTION
Hi!

A new version was just released of `cassandra-driver`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded cassandra-driver from `==3.8.0` to `==3.8.1`

