### PR TITLE
[Doppins] Upgrade dependency asgi_redis to ==1.1.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,7 +23,7 @@ slackclient==1.0.5
 
 # channels:
 channels==1.0.3
-asgi_redis==1.0.0
+asgi_redis==1.1.0
 daphne==1.0.3
 
 djangorestframework==3.6.2


### PR DESCRIPTION
Hi!

A new version was just released of `asgi_redis`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded asgi_redis from `==1.0.0` to `==1.1.0`

