### PR TITLE
[Doppins] Upgrade dependency djangorestframework-jwt to ==1.10.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -27,7 +27,7 @@ asgi_redis==1.1.0
 daphne==1.1.0
 
 djangorestframework==3.6.2
-djangorestframework-jwt==1.9.0
+djangorestframework-jwt==1.10.0
 djangorestframework-camel-case==0.2.0
 django-extensions==1.7.7
 django-autoslug==1.9.3


### PR DESCRIPTION
Hi!

A new version was just released of `djangorestframework-jwt`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded djangorestframework-jwt from `==1.9.0` to `==1.10.0`

#### Changelog:

#### Version 1.10.0
# Changelog

## Added
- Update of django, drf, python version handling in tox.ini `#262` by `@angvp`
- Allow using a cookie as a transport for the token `#275` by `@moises-silva` | [Docs](http://getblimp.github.io/django-rest-framework-jwt/#jwt_auth_cookie)
- Allow secret to be kept on user model `#310` by `@jacoor` | [Docs](http://getblimp.github.io/django-rest-framework-jwt/#jwt_get_user_secret_key)

## Changes
- Replace login with log in when used as a verb `#295` by `@rriehle`

## Docs
- Minor typo and formatting correction index.md `#293` by `@matthewhegarty` 
- Minor fix: formatting for phrase brand-new `#301` by `@sumittada`


