### PR TITLE
[Doppins] Upgrade dependency django-filter to ==1.0.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -32,7 +32,7 @@ djangorestframework-camel-case==0.2.0
 django-extensions==1.7.7
 django-autoslug==1.9.3
 django-oauth-toolkit==0.12.0
-django-filter==1.0.1
+django-filter==1.0.2
 django-cors-headers==2.0.2
 django-mptt==0.8.7
 django-environ==0.4.1


### PR DESCRIPTION
Hi!

A new version was just released of `django-filter`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django-filter from `==1.0.1` to `==1.0.2`

#### Changelog:

#### Version 1.0.2
Updates for compatibility with Django 1.11 and Django REST Framework 3.6.

Adds CI testing against Python 3.6

See the 1.0.2 Milestone (`https://github.com/carltongibson/django-filter/milestone/12?closed=1`) for full details.



