### PR TITLE
[Doppins] Upgrade dependency icalendar to ==3.11.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -42,4 +42,4 @@ django-thumbor==0.5.6
 
 # Ical-export
 django-ical==1.4
-icalendar==3.11.2
+icalendar==3.11.3


### PR DESCRIPTION
Hi!

A new version was just released of `icalendar`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded icalendar from `==3.11.2` to `==3.11.3`

