### PR TITLE
[Doppins] Upgrade dependency elasticsearch to ==5.3.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ redis==2.10.5
 hiredis==0.2.0
 stream-framework==1.4.0
 certifi==2017.1.23
-elasticsearch==5.2.0
+elasticsearch==5.3.0
 celery==4.0.2
 whitenoise==3.3.0
 stripe==1.51.0


### PR DESCRIPTION
Hi!

A new version was just released of `elasticsearch`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded elasticsearch from `==5.2.0` to `==5.3.0`

