### PR TITLE
[Doppins] Upgrade dependency daphne to ==1.2.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,7 +24,7 @@ slackclient==1.0.5
 # channels:
 channels==1.1.1
 asgi_redis==1.1.0
-daphne==1.1.0
+daphne==1.2.0
 
 djangorestframework==3.6.2
 djangorestframework-jwt==1.10.0


### PR DESCRIPTION
Hi!

A new version was just released of `daphne`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded daphne from `==1.1.0` to `==1.2.0`

