### PR TITLE
[Doppins] Upgrade dependency channels to ==1.1.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,7 +22,7 @@ requests==2.13.0
 slackclient==1.0.5
 
 # channels:
-channels==1.1.1
+channels==1.1.2
 asgi_redis==1.1.0
 daphne==1.1.0
 


### PR DESCRIPTION
Hi!

A new version was just released of `channels`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded channels from `==1.1.1` to `==1.1.2`

