### PR TITLE
[Doppins] Upgrade dependency cassandra-driver to ==3.9.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ whitenoise==3.3.0
 stripe==1.53.0
 structlog==16.1.0
 boto3==1.4.4
-cassandra-driver==3.8.1
+cassandra-driver==3.9.0
 prometheus-client==0.0.19
 requests==2.13.0
 slackclient==1.0.5


### PR DESCRIPTION
Hi!

A new version was just released of `cassandra-driver`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded cassandra-driver from `==3.8.1` to `==3.9.0`

