### PR TITLE
[Doppins] Upgrade dependency certifi to ==2017.4.17

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ raven==6.0.0
 redis==2.10.5
 hiredis==0.2.0
 stream-framework==1.4.0
-certifi==2017.1.23
+certifi==2017.4.17
 elasticsearch==5.3.0
 celery==4.0.2
 whitenoise==3.3.0


### PR DESCRIPTION
Hi!

A new version was just released of `certifi`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded certifi from `==2017.1.23` to `==2017.4.17`

