### PR TITLE
Fix meetings permission for users without auth

### DIFF
--- a/lego/apps/meetings/permissions.py
+++ b/lego/apps/meetings/permissions.py
@@ -8,6 +8,11 @@ class MeetingPermissions(AbakusPermission):
 
     force_object_permission_check = True
 
+    def has_permission(self, request, view):
+        if not request.user.is_authenticated:
+            return False
+        return super().has_permission(request, view)
+
     def has_object_permission(self, request, view, meeting):
         if super().has_object_permission(request, view, meeting):
             return True

--- a/lego/apps/meetings/tests/test_api.py
+++ b/lego/apps/meetings/tests/test_api.py
@@ -288,3 +288,19 @@ class UpdateInviteTestCase(APITestCase):
         })
         invite.refresh_from_db()
         self.assertEqual(invite.user, me)
+
+
+class UnauthorizedTestCase(APITestCase):
+    fixtures = ['initial_abakus_groups.yaml', 'test_meetings.yaml',
+                'test_users.yaml']
+
+    def setUp(self):
+        self.meeting = Meeting.objects.get(id=3)
+
+    def test_can_not_retrieve_list(self):
+        res = self.client.get(_get_list_url())
+        self.assertEqual(res.status_code, 401)
+
+    def test_can_not_retrieve_meeting(self):
+        res = self.client.get(_get_detail_url(self.meeting.id))
+        self.assertEqual(res.status_code, 401)


### PR DESCRIPTION
Addresses `issues/2917` on sentry.

Even though `auth_map` forces auth, is doesn't seem to work (because og `check_object_permission`. It may be my understanding of the flow, since there is no proper documentation. Having one variable called `check_object_permission` and another called `skip_object_permission` seem strange.


Also added some tests, to check that it works.