### PR TITLE
[Doppins] Upgrade dependency structlog to ==17.1.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,7 @@ certifi==2017.4.17
 elasticsearch==5.3.0
 celery==4.0.2
 stripe==1.53.0
-structlog==16.1.0
+structlog==17.1.0
 boto3==1.4.4
 cassandra-driver==3.9.0
 prometheus-client==0.0.19


### PR DESCRIPTION
Hi!

A new version was just released of `structlog`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded structlog from `==16.1.0` to `==17.1.0`

