### PR TITLE
[Doppins] Upgrade dependency bleach to ==2.0.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,7 +18,7 @@ boto3==1.4.4
 cassandra-driver==3.9.0
 prometheus-client==0.0.19
 bs4==0.0.1
-bleach==1.5.0
+bleach==2.0.0
 requests==2.13.0
 slackclient==1.0.5
 ldap3==2.2.1


### PR DESCRIPTION
Hi!

A new version was just released of `bleach`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded bleach from `==1.5.0` to `==2.0.0`

