### PR TITLE
[Doppins] Upgrade dependency django-redis to ==4.8.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -40,7 +40,7 @@ django-filter==1.0.2
 django-cors-headers==2.0.2
 django-mptt==0.8.7
 django-environ==0.4.3
-django-redis==4.7.0
+django-redis==4.8.0
 django-ipware==1.1.6
 django-thumbor==0.5.6
 


### PR DESCRIPTION
Hi!

A new version was just released of `django-redis`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django-redis from `==4.7.0` to `==4.8.0`

