### PR TITLE
Add unregistered field to administrate serializer

### DIFF
--- a/lego/apps/events/models.py
+++ b/lego/apps/events/models.py
@@ -445,6 +445,14 @@ class Event(Content, BasisModel, ObjectPermissionsModel):
         ).exclude(pool=None).count()
 
     @property
+    def unregistered(self):
+        return self.registrations.filter(
+            pool=None,
+            unregistration_date__isnull=False,
+            status=constants.SUCCESS_UNREGISTER
+        )
+
+    @property
     def waiting_registrations(self):
         return self.registrations.filter(
             pool=None,

--- a/lego/apps/events/serializers.py
+++ b/lego/apps/events/serializers.py
@@ -120,10 +120,12 @@ class EventReadDetailedSerializer(TagSerializerMixin, BasisModelSerializer):
 
 class EventAdministrateSerializer(EventReadSerializer):
     pools = PoolAdministrateSerializer(many=True)
+    unregistered = RegistrationReadDetailedSerializer(many=True)
     waiting_registrations = RegistrationReadDetailedSerializer(many=True)
 
     class Meta(EventReadSerializer.Meta):
-        fields = EventReadSerializer.Meta.fields + ('pools', 'waiting_registrations')
+        fields = EventReadSerializer.Meta.fields + ('pools', 'unregistered',
+                                                    'waiting_registrations')
 
 
 class PoolCreateAndUpdateSerializer(BasisModelSerializer):


### PR DESCRIPTION
Add the unregistered users to the administrate endpoint, so that unregistered users are available to list in the frontend.