### PR TITLE
Change serializer and exceptions

### DIFF
--- a/lego/apps/events/exceptions.py
+++ b/lego/apps/events/exceptions.py
@@ -1,25 +1,24 @@
 from rest_framework.exceptions import APIException
 
 
-class NoAvailablePools(APIException):
-    status_code = 400
-    default_detail = 'No available pools.'
-
-
-class NoSuchPool(APIException):
+class APINoSuchPool(APIException):
     status_code = 400
     default_detail = 'No such pool for this event.'
 
 
-class RegistrationException(APIException):
-    status_code = 403
-
-
-class PaymentExists(APIException):
+class APIPaymentExists(APIException):
     status_code = 403
     default_detail = 'Payment already exist.'
 
 
-class RegistrationsExistsInPool(APIException):
+class APIRegistrationsExistsInPool(APIException):
     status_code = 409
     default_detail = 'Registrations exists within this pool'
+
+
+class NoSuchPool(ValueError):
+    pass
+
+
+class EventHasStarted(ValueError):
+    pass


### PR DESCRIPTION
- Change serializer to detailed on admin_register to avoid an extra api call on administrate page
- Change event exceptions to API<Name> for rest_framework exceptions
- Add a few regular exceptions such as `NoSuchPool` to distinguish between them instead of `ValueError`.