### PR TITLE
[Doppins] Upgrade dependency django-debug-toolbar to ==1.8

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,7 +1,7 @@
 -r base.txt
 -r docs.txt
 
-django-debug-toolbar==1.7
+django-debug-toolbar==1.8
 tox==2.7.0
 flake8==3.3.0
 isort==4.2.5


### PR DESCRIPTION
Hi!

A new version was just released of `django-debug-toolbar`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django-debug-toolbar from `==1.7` to `==1.8`

