### PR TITLE
[Doppins] Upgrade dependency django-extensions to ==1.7.9

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -34,7 +34,7 @@ daphne==1.2.0
 djangorestframework==3.6.2
 djangorestframework-jwt==1.10.0
 djangorestframework-camel-case==0.2.0
-django-extensions==1.7.8
+django-extensions==1.7.9
 django-autoslug==1.9.3
 django-oauth-toolkit==0.12.0
 django-filter==1.0.2


### PR DESCRIPTION
Hi!

A new version was just released of `django-extensions`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django-extensions from `==1.7.8` to `==1.7.9`

