### PR TITLE
[Doppins] Upgrade dependency structlog to ==17.2.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,7 @@ elasticsearch==5.3.0
 celery==4.0.2
 stripe==1.55.2
 statsd==3.2.1
-structlog==17.1.0
+structlog==17.2.0
 boto3==1.4.4
 cassandra-driver==3.9.0
 bs4==0.0.1


### PR DESCRIPTION
Hi!

A new version was just released of `structlog`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded structlog from `==17.1.0` to `==17.2.0`

