### PR TITLE
[Doppins] Upgrade dependency elasticsearch to ==5.4.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ redis==2.10.5
 hiredis==0.2.0
 stream-framework==1.4.0
 certifi==2017.4.17
-elasticsearch==5.3.0
+elasticsearch==5.4.0
 celery==4.0.2
 stripe==1.55.2
 statsd==3.2.1


### PR DESCRIPTION
Hi!

A new version was just released of `elasticsearch`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded elasticsearch from `==5.3.0` to `==5.4.0`

