### PR TITLE
[Doppins] Upgrade dependency django-filter to ==1.0.4

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -36,7 +36,7 @@ djangorestframework-camel-case==0.2.0
 django-extensions==1.7.9
 django-autoslug==1.9.3
 django-oauth-toolkit==0.12.0
-django-filter==1.0.3
+django-filter==1.0.4
 django-cors-headers==2.0.2
 django-mptt==0.8.7
 django-environ==0.4.3


### PR DESCRIPTION
Hi!

A new version was just released of `django-filter`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django-filter from `==1.0.3` to `==1.0.4`

#### Changelog:

#### Version 1.0.4
Quick fix for verbose_field_name issue (`#722`)

