### PR TITLE
[Doppins] Upgrade dependency coreapi to ==2.3.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -51,4 +51,4 @@ icalendar==3.11.4
 # Docs
 Pygments==2.2.0
 Markdown==2.6.8
-coreapi==2.3.0
+coreapi==2.3.1


### PR DESCRIPTION
Hi!

A new version was just released of `coreapi`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded coreapi from `==2.3.0` to `==2.3.1`

