### PR TITLE
[Doppins] Upgrade dependency cassandra-driver to ==3.10

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ stripe==1.55.2
 statsd==3.2.1
 structlog==17.2.0
 boto3==1.4.4
-cassandra-driver==3.9.0
+cassandra-driver==3.10
 bs4==0.0.1
 bleach==2.0.0
 requests==2.14.2


### PR DESCRIPTION
Hi!

A new version was just released of `cassandra-driver`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded cassandra-driver from `==3.9.0` to `==3.10`

