### PR TITLE
[Doppins] Upgrade dependency ipython to ==6.1.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-ipython==6.0.0
+ipython==6.1.0
 django==1.11
 
 psycopg2==2.7


### PR DESCRIPTION
Hi!

A new version was just released of `ipython`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded ipython from `==6.0.0` to `==6.1.0`

