### PR TITLE
[Doppins] Upgrade dependency isort to ==4.2.13

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,4 +4,4 @@
 django-debug-toolbar==1.8
 tox==2.7.0
 flake8==3.3.0
-isort==4.2.12
+isort==4.2.13


### PR DESCRIPTION
Hi!

A new version was just released of `isort`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded isort from `==4.2.5` to `==4.2.8`

