### PR TITLE
[Doppins] Upgrade dependency slackclient to ==1.0.6

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,7 +19,7 @@ cassandra-driver==3.10
 bs4==0.0.1
 bleach==2.0.0
 requests==2.17.3
-slackclient==1.0.5
+slackclient==1.0.6
 ldap3==2.2.4
 google-api-python-client==1.6.2
 passlib==1.7.1


### PR DESCRIPTION
Hi!

A new version was just released of `slackclient`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded slackclient from `==1.0.5` to `==1.0.6`

