### PR TITLE
[Doppins] Upgrade dependency requests to ==2.18.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,7 +18,7 @@ boto3==1.4.4
 cassandra-driver==3.10
 bs4==0.0.1
 bleach==2.0.0
-requests==2.18.0
+requests==2.18.1
 slackclient==1.0.6
 ldap3==2.2.4
 google-api-python-client==1.6.2


### PR DESCRIPTION
Hi!

A new version was just released of `requests`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded requests from `==2.18.0` to `==2.18.1`

