### PR TITLE
[Doppins] Upgrade dependency asgi_redis to ==1.4.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -27,7 +27,7 @@ premailer==3.0.1
 
 # channels
 channels==1.1.3
-asgi_redis==1.4.0
+asgi_redis==1.4.1
 daphne==1.2.0
 
 djangorestframework==3.6.3


### PR DESCRIPTION
Hi!

A new version was just released of `asgi_redis`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded asgi_redis from `==1.4.0` to `==1.4.1`

