### PR TITLE
[Doppins] Upgrade dependency daphne to ==1.3.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,7 +28,7 @@ premailer==3.0.1
 # channels
 channels==1.1.4
 asgi_redis==1.4.1
-daphne==1.2.0
+daphne==1.3.0
 
 djangorestframework==3.6.3
 djangorestframework-jwt==1.10.0


### PR DESCRIPTION
Hi!

A new version was just released of `daphne`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded daphne from `==1.2.0` to `==1.3.0`

