### PR TITLE
[Doppins] Upgrade dependency channels to ==1.1.5

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,7 +26,7 @@ passlib==1.7.1
 premailer==3.0.1
 
 # channels
-channels==1.1.4
+channels==1.1.5
 asgi_redis==1.4.1
 daphne==1.2.0
 


### PR DESCRIPTION
Hi!

A new version was just released of `channels`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded channels from `==1.1.4` to `==1.1.5`

