### PR TITLE
[Doppins] Upgrade dependency djangorestframework-jwt to ==1.11.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,7 +31,7 @@ asgi_redis==1.4.1
 daphne==1.2.0
 
 djangorestframework==3.6.3
-djangorestframework-jwt==1.10.0
+djangorestframework-jwt==1.11.0
 djangorestframework-camel-case==0.2.0
 django-extensions==1.7.9
 django-autoslug==1.9.3


### PR DESCRIPTION
Hi!

A new version was just released of `djangorestframework-jwt`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded djangorestframework-jwt from `==1.10.0` to `==1.11.0`

