### PR TITLE
[Doppins] Upgrade dependency django to ==1.11.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 ipython==6.1.0
-django==1.11.2
+django==1.11.3
 
 psycopg2==2.7
 unicode-slugify==0.1.3


### PR DESCRIPTION
Hi!

A new version was just released of `django`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django from `==1.11.2` to `==1.11.3`

