### PR TITLE
[Doppins] Upgrade dependency icalendar to ==3.11.5

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -46,7 +46,7 @@ django-thumbor==0.5.6
 
 # Ical-export
 django-ical==1.4
-icalendar==3.11.4
+icalendar==3.11.5
 
 # Docs
 Pygments==2.2.0


### PR DESCRIPTION
Hi!

A new version was just released of `icalendar`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded icalendar from `==3.11.4` to `==3.11.5`

