### PR TITLE
[Doppins] Upgrade dependency django-extensions to ==1.8.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -33,7 +33,7 @@ daphne==1.3.0
 djangorestframework==3.6.3
 djangorestframework-jwt==1.11.0
 djangorestframework-camel-case==0.2.0
-django-extensions==1.8.0
+django-extensions==1.8.1
 django-autoslug==1.9.3
 django-oauth-toolkit==1.0.0
 django-filter==1.0.4


### PR DESCRIPTION
Hi!

A new version was just released of `django-extensions`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django-extensions from `==1.8.0` to `==1.8.1`

