### PR TITLE
[Doppins] Upgrade dependency premailer to ==3.1.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,7 +23,7 @@ slackclient==1.0.6
 ldap3==2.2.4
 google-api-python-client==1.6.2
 passlib==1.7.1
-premailer==3.1.0
+premailer==3.1.1
 
 # channels
 asgi_redis==1.4.2


### PR DESCRIPTION
Hi!

A new version was just released of `premailer`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded premailer from `==3.1.0` to `==3.1.1`

