### PR TITLE
[Doppins] Upgrade dependency certifi to ==2017.7.27

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ raven==6.1.0
 redis==2.10.5
 hiredis==0.2.0
 stream-framework==1.4.0
-certifi==2017.4.17
+certifi==2017.7.27
 elasticsearch==5.4.0
 celery==4.1.0
 stripe==1.62.0


### PR DESCRIPTION
Hi!

A new version was just released of `certifi`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded certifi from `==2017.4.17` to `==2017.7.27`

