### PR TITLE
[Doppins] Upgrade dependency flake8 to ==3.4.1

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,5 +3,5 @@
 
 django-debug-toolbar==1.8
 tox==2.7.0
-flake8==3.4.0
+flake8==3.4.1
 isort==4.2.15


### PR DESCRIPTION
Hi!

A new version was just released of `flake8`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded flake8 from `==3.3.0` to `==3.4.0`

