### PR TITLE
[Doppins] Upgrade dependency boto3 to ==1.4.5

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,7 +14,7 @@ celery==4.1.0
 stripe==1.62.0
 statsd==3.2.1
 structlog==17.2.0
-boto3==1.4.4
+boto3==1.4.5
 cassandra-driver==3.11
 bs4==0.0.1
 bleach==2.0.0


### PR DESCRIPTION
Hi!

A new version was just released of `boto3`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded boto3 from `==1.4.4` to `==1.4.5`

