### PR TITLE
[Doppins] Upgrade dependency ldap3 to ==2.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ bs4==0.0.1
 bleach==2.0.0
 requests==2.18.2
 slackclient==1.0.6
-ldap3==2.2.4
+ldap3==2.3
 google-api-python-client==1.6.2
 passlib==1.7.1
 premailer==3.1.1


### PR DESCRIPTION
Hi!

A new version was just released of `ldap3`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded ldap3 from `==2.2.4` to `==2.3`

