### PR TITLE
[Doppins] Upgrade dependency requests to ==2.18.4

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,7 +19,7 @@ cassandra-driver==3.11
 bs4==0.0.1
 bleach==2.0.0
 slackclient==1.0.7
-requests==2.18.3
+requests==2.18.4
 ldap3==2.3
 google-api-python-client==1.6.2
 oauth2client


### PR DESCRIPTION
Hi!

A new version was just released of `requests`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded requests from `==2.18.3` to `==2.18.4`

