### PR TITLE
[Doppins] Upgrade dependency redis to ==2.10.6

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@ psycopg2==2.7
 unicode-slugify==0.1.3
 pyyaml==3.12
 raven==6.1.0
-redis==2.10.5
+redis==2.10.6
 hiredis==0.2.0
 stream-framework==1.4.0
 certifi==2017.7.27


### PR DESCRIPTION
Hi!

A new version was just released of `redis`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded redis from `==2.10.5` to `==2.10.6`

