### PR TITLE
[Doppins] Upgrade dependency Markdown to ==2.6.9

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -52,5 +52,5 @@ icalendar==3.11.6
 
 # Docs
 Pygments==2.2.0
-Markdown==2.6.8
+Markdown==2.6.9
 coreapi==2.3.1


### PR DESCRIPTION
Hi!

A new version was just released of `Markdown`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded Markdown from `==2.6.8` to `==2.6.9`

