### PR TITLE
[Doppins] Upgrade dependency django-environ to ==0.4.4

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -40,7 +40,7 @@ django-oauth-toolkit==1.0.0
 django-filter==1.0.4
 django-cors-headers==2.1.0
 django-mptt==0.8.7
-django-environ==0.4.3
+django-environ==0.4.4
 django-redis==4.8.0
 django-ipware==1.1.6
 django-thumbor==0.5.6


### PR DESCRIPTION
Hi!

A new version was just released of `django-environ`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django-environ from `==0.4.3` to `==0.4.4`

#### Changelog:

#### Version 0.4.4


