### PR TITLE
[Doppins] Upgrade dependency djangorestframework to ==3.6.4

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,7 +31,7 @@ asgi_redis==1.4.2
 channels==1.1.6
 daphne==1.3.0
 
-djangorestframework==3.6.3
+djangorestframework==3.6.4
 djangorestframework-jwt==1.11.0
 djangorestframework-camel-case==0.2.0
 django-extensions==1.8.1


### PR DESCRIPTION
Hi!

A new version was just released of `djangorestframework`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded djangorestframework from `==3.6.3` to `==3.6.4`

