### PR TITLE
[Doppins] Upgrade dependency icalendar to ==3.11.7

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -48,7 +48,7 @@ django-push-notifications==1.5.0
 
 # Ical-export
 django-ical==1.4
-icalendar==3.11.6
+icalendar==3.11.7
 
 # Docs
 Pygments==2.2.0


### PR DESCRIPTION
Hi!

A new version was just released of `icalendar`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded icalendar from `==3.11.6` to `==3.11.7`

