### PR TITLE
[Doppins] Upgrade dependency slackclient to ==1.0.9

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,7 +18,7 @@ boto3==1.4.7
 cassandra-driver==3.11
 bs4==0.0.1
 bleach==2.0.0
-slackclient==1.0.8
+slackclient==1.0.9
 requests==2.18.4
 ldap3==2.3
 google-api-python-client==1.6.3


### PR DESCRIPTION
Hi!

A new version was just released of `slackclient`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded slackclient from `==1.0.7` to `==1.0.8`

#### Changelog:

#### Version 1.0.8
  - Added rtm.connect support


