### PR TITLE
[Doppins] Upgrade dependency tox to ==2.8.0

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,6 +2,6 @@
 -r docs.txt
 
 django-debug-toolbar==1.8
-tox==2.7.0
+tox==2.8.0
 flake8==3.4.1
 isort==4.2.15


### PR DESCRIPTION
Hi!

A new version was just released of `tox`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded tox from `==2.7.0` to `==2.8.0`

