### PR TITLE
Force delete `Membership`s.

### DIFF
--- a/lego/apps/users/models.py
+++ b/lego/apps/users/models.py
@@ -39,6 +39,9 @@ class Membership(BasisModel):
     class Meta:
         unique_together = ('user', 'abakus_group')
 
+    def delete(self, using=None, force=False):
+        super(Membership, self).delete(using, force=True)
+
     def __str__(self):
         return f'{self.user} is {self.get_role_display()} in {self.abakus_group}'
 


### PR DESCRIPTION
The model is persistent, so ungeristering and registering again triggers
an error. Since we don't really care about the member history, we simply
delete the entire thing.

This was in another branch, but got lost in a rebase.