### PR TITLE
Bulk set membership endpoint

### DIFF
--- a/lego/api/v1.py
+++ b/lego/api/v1.py
@@ -27,7 +27,7 @@ from lego.apps.search.views import AutocompleteViewSet, SearchViewSet
 from lego.apps.slack.views import SlackInviteViewSet
 from lego.apps.social_groups.views import InterestGroupViewSet
 from lego.apps.users.views.abakus_groups import AbakusGroupViewSet
-from lego.apps.users.views.memberships import MembershipViewSet
+from lego.apps.users.views.memberships import MembershipSetViewSet, MembershipViewSet
 from lego.apps.users.views.password_change import ChangePasswordViewSet
 from lego.apps.users.views.password_reset import (PasswordResetPerformViewSet,
                                                   PasswordResetRequestViewSet)
@@ -60,6 +60,8 @@ router.register(r'meetings/(?P<meeting_pk>\d+)/invitations',
 router.register(r'meeting-token',
                 MeetingInvitationTokenViewSet, base_name='meeting-token')
 router.register(r'memberships', MembershipViewSet)
+router.register(r'memberships/(?P<group_pk>\d+)/set-all',
+                MembershipSetViewSet, base_name='membership-set-all')
 router.register(
     r'notification-settings', NotificationSettingsViewSet, base_name='notifications-settings'
 )

--- a/lego/apps/users/fixtures/development_memberships.yaml
+++ b/lego/apps/users/fixtures/development_memberships.yaml
@@ -108,6 +108,24 @@
     start_date: 1994-01-01
 
 - model: users.Membership
+  pk: 12
+  fields:
+    user: 1
+    role: member
+    abakus_group:
+      - AbaBrygg
+    start_date: 1994-01-01
+
+- model: users.Membership
+  pk: 12
+  fields:
+    user: 2
+    role: member
+    abakus_group:
+      - AbaBrygg
+    start_date: 1994-01-01
+
+- model: users.Membership
   pk: 13
   fields:
     user:

--- a/lego/apps/users/fixtures/test_abakus_groups.py
+++ b/lego/apps/users/fixtures/test_abakus_groups.py
@@ -88,6 +88,11 @@ test_tree = {
             '/sudo/admin/emaillists/'
         ]
     }, {}],
+    'Webkom': [{
+        'permissions': [
+            '/sudo/'
+        ]
+    }]
 }
 
 

--- a/lego/apps/users/fixtures/test_users.yaml
+++ b/lego/apps/users/fixtures/test_users.yaml
@@ -72,3 +72,12 @@
     first_name: interestgroup
     last_name: admin
     email: interestgroup@admin.com
+
+- model: users.User
+  pk: 9
+  fields:
+    username: webkommer
+    gender: female
+    first_name: Web
+    last_name: Commer
+    email: webk@m.no

--- a/lego/apps/users/models.py
+++ b/lego/apps/users/models.py
@@ -40,7 +40,7 @@ class Membership(BasisModel):
         unique_together = ('user', 'abakus_group')
 
     def delete(self, using=None, force=False):
-        super(Membership, self).delete(using, force=True)
+        super(Membership, self).delete(using=using, force=True)
 
     def __str__(self):
         return f'{self.user} is {self.get_role_display()} in {self.abakus_group}'

--- a/lego/apps/users/serializers/memberships.py
+++ b/lego/apps/users/serializers/memberships.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from lego.apps.users.fields import PublicUserField
-from lego.apps.users.models import Membership, User
+from lego.apps.users.models import AbakusGroup, Membership, User
 
 
 class MembershipSerializer(serializers.ModelSerializer):
@@ -17,4 +17,24 @@ class MembershipSerializer(serializers.ModelSerializer):
             'is_active',
             'start_date',
             'end_date',
+        )
+
+
+class MembershipGroupSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Membership
+        fields = (
+            'user',
+            'role',
+        )
+
+
+class MembershipSetMembershipSerializer(serializers.ModelSerializer):
+    memberships = MembershipGroupSerializer(many=True)
+
+    class Meta:
+        model = AbakusGroup
+        fields = (
+            'memberships'
         )

--- a/lego/apps/users/tests/test_membership.py
+++ b/lego/apps/users/tests/test_membership.py
@@ -1,0 +1,73 @@
+from django.core.urlresolvers import reverse
+from rest_framework.test import APITestCase
+
+from lego.apps.users.models import AbakusGroup, Membership, User
+
+
+def _get_hest_detail_url(group_pk):
+    return reverse('api:v1:membership-set-all-list', kwargs={'group_pk': group_pk})
+
+
+class SetMembershipAPITestCase(APITestCase):
+    fixtures = ['test_abakus_groups.yaml', 'test_users.yaml']
+
+    def setUp(self):
+        self.group = AbakusGroup.objects.get(name='Abakus')
+        self.user = User.objects.get(username='pleb')
+        self.group.add_user(self.user)
+        webkom = AbakusGroup.objects.get(name='Webkom')
+        self.webkommer = User.objects.get(username='webkommer')
+        webkom.add_user(self.webkommer)
+
+    def test_post_empty(self):
+        self.client.force_authenticate(self.webkommer)
+        before_count = Membership.objects.filter(abakus_group=self.group.pk).count()
+        self.assertLess(0, before_count)
+        res = self.client.post(_get_hest_detail_url(self.group.pk), {
+            'memberships': []
+        })
+        self.assertEquals(res.status_code, 201)
+        after_count = Membership.objects.filter(abakus_group=self.group.pk).count()
+        self.assertEqual(0, after_count)
+
+    def test_post_two_new(self):
+        self.client.force_authenticate(self.webkommer)
+        before_count = Membership.objects.filter(abakus_group=self.group.pk).count()
+        self.assertLess(0, before_count)
+        memberships = [{
+            'user': User.objects.get(username='test1').pk,
+            'role': 'member'
+        }, {
+            'user': User.objects.get(username='test2').pk,
+        }]
+        res = self.client.post(_get_hest_detail_url(self.group.pk), {
+            'memberships': memberships
+        })
+        self.assertEquals(res.status_code, 201)
+        after_count = Membership.objects.filter(abakus_group=self.group.pk).count()
+        self.assertEqual(2, after_count)
+
+    def test_post_with_existing(self):
+        # self.user is already member of self.group
+        self.client.force_authenticate(self.webkommer)
+        before_count = Membership.objects.filter(abakus_group=self.group.pk).count()
+        self.assertLess(0, before_count)
+        memberships = [{
+            'user': User.objects.get(username='test1').pk,
+            'role': 'member'
+        }, {
+            'user': User.objects.get(username='test2').pk,
+        }, {
+            'user': self.user.pk,
+            'role': 'leader'
+        }]
+        res = self.client.post(_get_hest_detail_url(self.group.pk), {
+            'memberships': memberships
+        })
+        self.assertEquals(res.status_code, 201)
+        after_count = Membership.objects.filter(abakus_group=self.group.pk).count()
+        self.assertEqual(3, after_count)
+        leader_memberships = Membership.objects.filter(abakus_group=self.group.pk, role='leader')
+        self.assertEqual(leader_memberships.count(), 1)
+        leader = leader_memberships[0].user
+        self.assertEqual(leader, self.user)

--- a/lego/apps/users/views/memberships.py
+++ b/lego/apps/users/views/memberships.py
@@ -1,9 +1,11 @@
-from rest_framework import viewsets
+from rest_framework import mixins, status, viewsets
+from rest_framework.response import Response
 
 from lego.apps.permissions.api.views import AllowedPermissionsMixin
 from lego.apps.users.filters import MembershipFilterSet
-from lego.apps.users.models import Membership
-from lego.apps.users.serializers.memberships import MembershipSerializer
+from lego.apps.users.models import AbakusGroup, Membership, User
+from lego.apps.users.serializers.memberships import (MembershipSerializer,
+                                                     MembershipSetMembershipSerializer)
 
 
 class MembershipViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
@@ -11,3 +13,39 @@ class MembershipViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
     serializer_class = MembershipSerializer
     filter_class = MembershipFilterSet
     ordering = 'id'
+
+
+class MembershipSetViewSet(AllowedPermissionsMixin, mixins.CreateModelMixin,
+                           viewsets.GenericViewSet):
+    """We only use `CreateModelMixin, since we only want POSTs to be allowed.
+    If one want to remove a membership or add a single membership, use
+    the `/memberships/` endpoint."""
+    queryset = Membership.objects.all().select_related('user')
+    serializer_class = MembershipSetMembershipSerializer
+    filter_class = MembershipFilterSet
+    ordering = 'id'
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        group_pk = self.kwargs.get('group_pk', None)
+        if group_pk:
+            return queryset.filter(pk=group_pk)
+        return Membership.objects.none()
+
+    def create(self, request, *args, **kwargs):
+        group_pk = kwargs.get('group_pk', None)
+        group = AbakusGroup.objects.get(pk=group_pk)
+        if not group:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+        # delete all meberships
+        group.memberships.delete(force=True)
+        # and make new ones
+        for membership in request.data['memberships']:
+            obj = {
+                'user': User.objects.get(pk=membership['user']),
+                'abakus_group': group,
+                'role': membership.get('role', 'member')
+            }
+            Membership.objects.get_or_create(**obj)
+        # TODO: what to return here?
+        return Response(status=status.HTTP_201_CREATED)


### PR DESCRIPTION
We'd like an endpoint we can use to set all memberships of a group. The motivating use case for this is group management: if we add users, remove users, and change the leader of the group, we need a lot of logic to handle the transition. If we can simply *set* the memberships (we have already fetched all memberships in the edit page), we save ourselves for a lot of hairy logic in the frontend. 

We also want to use a new endpoint for this, instead of passing `memberships` with the group objects, since passing `[]` as memberships would cause all members to be removed from the group. A new and more explicit endpoint is far less error prone.

