### PR TITLE
[Doppins] Upgrade dependency channels to ==1.1.7

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,7 +28,7 @@ git+https://github.com/eirsyl/analytics-python.git#master
 
 # channels
 asgi_redis==1.4.2
-channels==1.1.6
+channels==1.1.7
 daphne==1.3.0
 
 djangorestframework==3.6.4


### PR DESCRIPTION
Hi!

A new version was just released of `channels`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded channels from `==1.1.6` to `==1.1.7`

