### PR TITLE
Switch to user id lookup when retrieving the user feed

### DIFF
--- a/lego/apps/feed/tests/test_views.py
+++ b/lego/apps/feed/tests/test_views.py
@@ -186,10 +186,3 @@ class NotificationViewsTestCase(APITestCase, FeedTestBase):
         notification = self.client.get(f'{self.url}').json()['results'][0]
         self.assertTrue(notification['read'])
         self.assertTrue(notification['seen'])
-
-
-class GroupFeedViewsTestCase(APITestCase, FeedTestBase):
-    '''
-    TODO: Test permissions for group feeds before granting users access
-    '''
-    pass

--- a/lego/apps/feed/views.py
+++ b/lego/apps/feed/views.py
@@ -7,7 +7,6 @@ from lego.apps.feed.feeds.notification_feed import NotificationFeed
 from lego.apps.feed.feeds.personal_feed import PersonalFeed
 from lego.apps.feed.feeds.user_feed import UserFeed
 from lego.apps.stats.statsd_client import statsd
-from lego.apps.users.models import User
 
 from .attr_cache import AttrCache
 from .serializers import AggregatedFeedSerializer, MarkSerializer, NotificationFeedSerializer
@@ -120,29 +119,6 @@ class FeedListMixin:
 class UserFeedViewSet(FeedViewSet, FeedRetrieveMixin):
 
     feed_class = UserFeed
-
-    def get_queryset(self):
-        # Perform the lookup filtering.
-        lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
-
-        assert lookup_url_kwarg in self.kwargs, (
-            'Expected view %s to be called with a URL keyword argument '
-            'named "%s". Fix your URL conf, or set the `.lookup_field` '
-            'attribute on the view correctly.' %
-            (self.__class__.__name__, lookup_url_kwarg)
-        )
-
-        try:
-            feed_id = self.kwargs[lookup_url_kwarg]
-        except (ValueError, TypeError):
-            raise exceptions.ParseError
-
-        try:
-            feed_id = User.objects.values('id').get(username=feed_id)['id']
-        except (User.DoesNotExist, User.MultipleObjectsReturned):
-            raise exceptions.NotFound
-
-        return self.feed_class(feed_id)
 
 
 class PersonalFeedViewSet(FeedViewSet, FeedListMixin):


### PR DESCRIPTION
This may remove confusion when adding elements to the feed.