### PR TITLE
[Doppins] Upgrade dependency google-api-python-client to ==1.6.4

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,7 +21,7 @@ bleach==2.0.0
 slackclient==1.0.9
 requests==2.18.4
 ldap3==2.3
-google-api-python-client==1.6.3
+google-api-python-client==1.6.4
 oauth2client
 premailer==3.1.1
 git+https://github.com/eirsyl/analytics-python.git#master


### PR DESCRIPTION
Hi!

A new version was just released of `google-api-python-client`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded google-api-python-client from `==1.6.3` to `==1.6.4`

#### Changelog:

#### Version 1.6.4
  Bugfix release

  - Warn when google-auth credentials are used but google-auth-httplib2 isn't available. (`#443`)

