### PR TITLE
[Doppins] Upgrade dependency stripe to ==1.65.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,7 @@ stream-framework==1.4.0
 certifi==2017.7.27
 elasticsearch==5.4.0
 celery==4.1.0
-stripe==1.65.0
+stripe==1.65.1
 statsd==3.2.1
 structlog==17.2.0
 boto3==1.4.7


### PR DESCRIPTION
Hi!

A new version was just released of `stripe`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded stripe from `==1.65.0` to `==1.65.1`

