### PR TITLE
[Doppins] Upgrade dependency raven to ==6.2.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@ django==1.11.5
 psycopg2==2.7
 unicode-slugify==0.1.3
 pyyaml==3.12
-raven==6.1.0
+raven==6.2.0
 redis==2.10.6
 hiredis==0.2.0
 stream-framework==1.4.0


### PR DESCRIPTION
Hi!

A new version was just released of `raven`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded raven from `==6.1.0` to `==6.2.0`

