### PR TITLE
Allow gif uploads, fixes #749

### DIFF
--- a/lego/apps/files/models.py
+++ b/lego/apps/files/models.py
@@ -77,6 +77,7 @@ class File(TimeStampModel):
         known_mime_types = {
             'image/jpeg': IMAGE,
             'image/png': IMAGE,
+            'image/gif': IMAGE,
             'application/pdf': DOCUMENT
         }
 


### PR DESCRIPTION
Normalizing filenames before upload makes it possible to upload files with a filename containing spaces.