### PR TITLE
Change AbakusGroup API to send memberships instead of users

### DIFF
--- a/lego/apps/users/serializers/abakus_groups.py
+++ b/lego/apps/users/serializers/abakus_groups.py
@@ -1,12 +1,11 @@
 from rest_framework import serializers
 
 from lego.apps.users.models import AbakusGroup
-
-from .users import PublicUserSerializer
+from lego.apps.users.serializers.memberships import MembershipSerializer
 
 
 class DetailedAbakusGroupSerializer(serializers.ModelSerializer):
-    users = PublicUserSerializer(many=True, read_only=True)
+    memberships = MembershipSerializer(many=True, read_only=True)
 
     class Meta:
         model = AbakusGroup
@@ -16,7 +15,7 @@ class DetailedAbakusGroupSerializer(serializers.ModelSerializer):
             'description',
             'parent',
             'permissions',
-            'users'
+            'memberships'
         )
 
 

--- a/lego/apps/users/tests/test_abakusgroup_api.py
+++ b/lego/apps/users/tests/test_abakusgroup_api.py
@@ -71,7 +71,7 @@ class RetrieveAbakusGroupAPITestCase(APITestCase):
         keys = set(user.keys())
         keys.remove('action_grant')
 
-        self.assertEqual(len(user['users']), 1)
+        self.assertEqual(len(user['memberships']), 1)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(keys, set(DetailedAbakusGroupSerializer.Meta.fields))
 


### PR DESCRIPTION
We need memberships instead of users in order to get roles.

1 request get all data master race