### PR TITLE
Fix broken fixture in flatpages

### DIFF
--- a/lego/apps/flatpages/fixtures/initial_pages.yaml
+++ b/lego/apps/flatpages/fixtures/initial_pages.yaml
@@ -2,6 +2,5 @@
   pk: 1
   fields:
     title: Om oss
-    cover: page_cover.png
     slug: om-oss
     content: <p>Om oss</p>


### PR DESCRIPTION
This fixture is broken in two ways:
- The cover value is renamed to picture.
- The filename isn't in the assets folder (its been deleted)


Guess we also can add a proper example (like events and articles), or use some of the existing ones.