### PR TITLE
Add feed attr-render for GalleryPicture

### DIFF
--- a/lego/apps/feed/attr_cache.py
+++ b/lego/apps/feed/attr_cache.py
@@ -25,6 +25,7 @@ class AttrCache:
         'meetings.meetinginvitation': attr_renderers.render_meeting_invitation,
         'articles.article': attr_renderers.render_article,
         'notifications.announcement': attr_renderers.render_announcement,
+        'gallery.gallerypicture': attr_renderers.render_gallery_picture,
     }
 
     RELATED_FIELDS = {

--- a/lego/apps/feed/attr_renderers.py
+++ b/lego/apps/feed/attr_renderers.py
@@ -43,3 +43,13 @@ def render_announcement(announcement):
         'id': announcement.id,
         'message': announcement.message
     }
+
+
+def render_gallery_picture(gallery_picture):
+    return {
+        'id': gallery_picture.id,
+        'gallery': {
+            'id': gallery_picture.gallery.id,
+            'title': gallery_picture.gallery.title
+        }
+    }


### PR DESCRIPTION
This fixes the issue where the `gallery_picture`-context isn't sent together with the notification content.