### PR TITLE
Run rebalance-check on every pool after expansion

### DIFF
--- a/lego/apps/events/models.py
+++ b/lego/apps/events/models.py
@@ -338,7 +338,7 @@ class Event(Content, BasisModel, ObjectPermissionsModel):
                     reg.pool = pool
                     reg.save()
                     get_handler(Registration).handle_bump(reg)
-        self.check_for_bump_or_rebalance(pool)
+            self.check_for_bump_or_rebalance(pool)
 
     def try_to_rebalance(self, open_pool):
         """


### PR DESCRIPTION
Fixes https://sentry.abakus.no/webkom/lego/issues/3525/

The error did not show up in tests, because Celery doesn't propagate the error for some reason. After debugging manually I managed to recreate the error when calling the method directly, i.e. without actually calling it from celery-task.

When it comes to the fix itself, I'm not really sure of the repercussions it will have. The check is now done several times if several pools are open. Is this really necessary? On the other hand, we already do it this way here: https://github.com/webkom/lego/blob/master/lego/apps/events/tasks.py#L189