### PR TITLE
Increase the ExpiresIn property on upload urls

### DIFF
--- a/lego/apps/files/storage.py
+++ b/lego/apps/files/storage.py
@@ -40,7 +40,7 @@ class Storage:
                 'acl': 'private',
                 'Content-Type': mime_type
             },
-            ExpiresIn=30
+            ExpiresIn=60*10
         )
         return signed
 


### PR DESCRIPTION
30 seconds isn't enough if a client tries to upload several large files. 10 minutes should be enough, the browser almost dies if a user try to upload 10+ large images anyway...