### PR TITLE
[Doppins] Upgrade dependency coreapi to ==2.3.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -53,4 +53,4 @@ icalendar==3.11.7
 # Docs
 Pygments==2.2.0
 Markdown==2.6.9
-coreapi==2.3.1
+coreapi==2.3.3


### PR DESCRIPTION
Hi!

A new version was just released of `coreapi`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded coreapi from `==2.3.1` to `==2.3.3`

