### PR TITLE
Check for keyword permissions on group when we get Membership perms.

### DIFF
--- a/lego/apps/users/permissions.py
+++ b/lego/apps/users/permissions.py
@@ -102,7 +102,7 @@ class MembershipPermissionHandler(PermissionHandler):
 
         group_permission_handler = get_permission_handler(AbakusGroup)
         has_perm = perm == group_permission_handler.has_perm(
-            user, perm, obj=group, queryset=AbakusGroup.objects.none()
-        )
+            user, 'edit', obj=group, queryset=AbakusGroup.objects.none()
+        ) or group_permission_handler.keyword_permission(group, 'edit')
 
         return has_perm or perm in self.safe_methods or is_self


### PR DESCRIPTION
Intuitively, if you have permission to edit a group you should have
permission to handle memberships of that group. This was intended to be
handeled by the `has_perm` call, but this doesn't check keyword
permissions, which eg. Webkom only have.

@eirsyl 