### PR TITLE
[Doppins] Upgrade dependency djangorestframework to ==3.7.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,7 +31,7 @@ channels==1.1.8
 asgi_redis==1.4.3
 daphne==1.3.0
 
-djangorestframework==3.6.4
+djangorestframework==3.7.0
 djangorestframework-jwt==1.11.0
 djangorestframework-camel-case==0.2.0
 django-extensions==1.9.1


### PR DESCRIPTION
Hi!

A new version was just released of `djangorestframework`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded djangorestframework from `==3.6.4` to `==3.7.0`

