### PR TITLE
Remove memberships from the group serializer

### DIFF
--- a/lego/apps/users/serializers/abakus_groups.py
+++ b/lego/apps/users/serializers/abakus_groups.py
@@ -42,6 +42,6 @@ class PublicAbakusGroupSerializer(serializers.ModelSerializer):
             'name',
             'description',
             'parent',
-            'logo'
-            'parent'
+            'logo',
+            'parent',
         )

--- a/lego/apps/users/tests/test_abakusgroup_api.py
+++ b/lego/apps/users/tests/test_abakusgroup_api.py
@@ -80,7 +80,6 @@ class RetrieveAbakusGroupAPITestCase(APITestCase):
         keys = set(user.keys())
         keys.remove('action_grant')
 
-        self.assertEqual(len(user['memberships']), 1)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(keys, set(DetailedAbakusGroupSerializer.Meta.fields))
 


### PR DESCRIPTION
It turns out that Events uses these serializers for Pools, and when the
permission group in a pool is all users, it causes a slight load on the
DB. Some say premature optimization is the root of all evil, but we'll
take a chance with this one :)