### PR TITLE
Add successMessage to stripe payment

### DIFF
--- a/lego/apps/events/serializers/events.py
+++ b/lego/apps/events/serializers/events.py
@@ -54,7 +54,6 @@ class EventReadDetailedSerializer(TagSerializerMixin, BasisModelSerializer):
     company = CompanyField(queryset=Company.objects.all())
     pools = PoolReadSerializer(many=True)
     active_capacity = serializers.ReadOnlyField()
-    price = serializers.SerializerMethodField()
     waiting_registrations = RegistrationReadSerializer(many=True)
 
     class Meta:
@@ -62,23 +61,25 @@ class EventReadDetailedSerializer(TagSerializerMixin, BasisModelSerializer):
         fields = ('id', 'title', 'description', 'cover', 'text', 'event_type', 'location',
                   'comments', 'comment_target', 'start_time', 'end_time', 'merge_time',
                   'pools', 'company', 'active_capacity', 'feedback_description',
-                  'feedback_required', 'is_priced', 'price', 'price_member', 'price_guest',
+                  'feedback_required', 'is_priced', 'price_member', 'price_guest',
                   'use_stripe', 'use_captcha', 'waiting_registrations', 'tags', 'is_merged')
         read_only = True
-
-    def get_price(self, obj):
-        request = self.context.get('request', None)
-        if request:
-            return obj.get_price(user=request.user)
 
 
 class EventReadUserDetailedSerializer(EventReadDetailedSerializer):
     """ User specfic event serializer that appends data based on request.user """
     activation_time = ActivationTimeField()
     spots_left = SpotsLeftField()
+    price = serializers.SerializerMethodField()
 
     class Meta(EventReadDetailedSerializer.Meta):
-        fields = EventReadDetailedSerializer.Meta.fields + ('activation_time', 'spots_left')
+        fields = EventReadDetailedSerializer.Meta.fields + \
+                 ('price', 'activation_time', 'spots_left')
+
+    def get_price(self, obj):
+        request = self.context.get('request', None)
+        if request:
+            return obj.get_price(user=request.user)
 
 
 class EventAdministrateSerializer(EventReadSerializer):

--- a/lego/apps/events/serializers/sockets.py
+++ b/lego/apps/events/serializers/sockets.py
@@ -9,7 +9,8 @@ class MetaSerializer(serializers.Serializer):
     event_id = serializers.IntegerField(required=False)
     activation_time = serializers.DateTimeField(required=False)
     from_pool = serializers.IntegerField(required=False)
-    error_msg = serializers.CharField(required=False)
+    error_message = serializers.CharField(required=False)
+    success_message = serializers.CharField(required=False)
 
 
 class WebsocketSerializer(serializers.Serializer):

--- a/lego/apps/events/tests/test_payments.py
+++ b/lego/apps/events/tests/test_payments.py
@@ -5,7 +5,7 @@ from celery import chain
 from rest_framework.test import APITestCase
 
 from lego.apps.events.models import Event
-from lego.apps.events.tasks import async_payment, registration_save
+from lego.apps.events.tasks import async_payment, registration_payment_save
 from lego.apps.users.models import AbakusGroup, User
 
 from .utils import create_token
@@ -32,7 +32,7 @@ class StripePaymentTestCase(APITestCase):
         with self.assertRaises(stripe.error.StripeError):
             chain(
                 async_payment.s(registration.id, token),
-                registration_save.s(registration.id)
+                registration_payment_save.s(registration.id)
             ).delay()
 
         registration.refresh_from_db()
@@ -44,7 +44,7 @@ class StripePaymentTestCase(APITestCase):
         with self.assertRaises(stripe.error.StripeError):
             chain(
                 async_payment.s(registration.id, token),
-                registration_save.s(registration.id)
+                registration_payment_save.s(registration.id)
             ).delay()
 
         registration.refresh_from_db()
@@ -55,7 +55,7 @@ class StripePaymentTestCase(APITestCase):
         registration = self.event.get_registration(self.abakus_user)
         chain(
             async_payment.s(registration.id, token),
-            registration_save.s(registration.id)
+            registration_payment_save.s(registration.id)
         ).delay()
 
         registration.refresh_from_db()

--- a/lego/apps/events/views.py
+++ b/lego/apps/events/views.py
@@ -23,7 +23,8 @@ from lego.apps.events.serializers.registrations import (AdminRegistrationCreateA
                                                         RegistrationReadSerializer,
                                                         StripeTokenSerializer)
 from lego.apps.events.tasks import (async_payment, async_register, async_unregister,
-                                    check_for_bump_on_pool_creation_or_expansion, registration_save)
+                                    check_for_bump_on_pool_creation_or_expansion,
+                                    registration_payment_save)
 from lego.apps.permissions.api.views import AllowedPermissionsMixin
 from lego.utils.functions import verify_captcha
 
@@ -106,7 +107,7 @@ class EventViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
         registration.save()
         chain(
             async_payment.s(registration.id, serializer.data['token']),
-            registration_save.s(registration.id)
+            registration_payment_save.s(registration.id)
         ).delay()
         payment_serializer = RegistrationPaymentReadSerializer(
             registration, context={'request': request}


### PR DESCRIPTION
- Move price to userdetailserializer since it requires request.user to calculate
- Change error_msg to error_message for better consistency with the frontend
- Add success_message