### PR TITLE
[Doppins] Upgrade dependency django-filter to ==1.1.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -37,7 +37,7 @@ djangorestframework-camel-case==0.2.0
 django-extensions==1.9.6
 django-autoslug==1.9.3
 django-oauth-toolkit==1.0.0
-django-filter==1.0.4
+django-filter==1.1.0
 django-cors-headers==2.1.0
 django-mptt==0.8.7
 django-environ==0.4.4


### PR DESCRIPTION
Hi!

A new version was just released of `django-filter`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded django-filter from `==1.0.4` to `==1.1.0`

#### Changelog:

#### Version 1.1.0


