### PR TITLE
Add abakus groups to user serializers

### DIFF
--- a/lego/apps/users/serializers/users.py
+++ b/lego/apps/users/serializers/users.py
@@ -2,13 +2,15 @@ from rest_framework import exceptions, serializers
 
 from lego.apps.files.fields import ImageField
 from lego.apps.ical.models import ICalToken
-from lego.apps.users.fields import AbakusGroupField, AbakusGroupListField
+from lego.apps.users.fields import AbakusGroupField
 from lego.apps.users.models import AbakusGroup, Penalty, User
+from lego.apps.users.serializers.abakus_groups import PublicAbakusGroupSerializer
 from lego.apps.users.serializers.penalties import PenaltySerializer
 
 
 class DetailedUserSerializer(serializers.ModelSerializer):
 
+    abakus_groups = PublicAbakusGroupSerializer(many=True)
     penalties = serializers.SerializerMethodField('get_valid_penalties')
     profile_picture = ImageField(required=False, options={'height': 200, 'width': 200})
 
@@ -46,7 +48,8 @@ class DetailedUserSerializer(serializers.ModelSerializer):
             'allergies',
             'is_staff',
             'is_active',
-            'penalties'
+            'penalties',
+            'abakus_groups'
         )
 
 
@@ -66,6 +69,13 @@ class PublicUserSerializer(serializers.ModelSerializer):
             'profile_picture'
         )
         read_only_fields = ('username',)
+
+
+class PublicUserWithGroupsSerializer(PublicUserSerializer):
+    abakus_groups = PublicAbakusGroupSerializer(many=True)
+
+    class Meta(PublicUserSerializer.Meta):
+        fields = PublicUserSerializer.Meta.fields + ('abakus_groups',)
 
 
 class AdministrateUserSerializer(PublicUserSerializer):
@@ -108,7 +118,7 @@ class MeSerializer(serializers.ModelSerializer):
     Also used by our JWT handler and returned to the user when a user obtains a JWT token.
     """
 
-    abakus_groups = AbakusGroupListField()
+    abakus_groups = PublicAbakusGroupSerializer(many=True)
     profile_picture = ImageField(required=False, options={'height': 200, 'width': 200})
     ical_token = serializers.SerializerMethodField('get_user_ical_token')
     penalties = serializers.SerializerMethodField('get_valid_penalties')

--- a/lego/apps/users/views/users.py
+++ b/lego/apps/users/views/users.py
@@ -13,7 +13,7 @@ from lego.apps.users.models import AbakusGroup, User
 from lego.apps.users.registrations import Registrations
 from lego.apps.users.serializers.registration import RegistrationConfirmationSerializer
 from lego.apps.users.serializers.users import (DetailedUserSerializer, MeSerializer,
-                                               PublicUserSerializer)
+                                               PublicUserWithGroupsSerializer)
 
 log = get_logger()
 
@@ -22,8 +22,13 @@ class UsersViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
 
     queryset = User.objects.all()
     lookup_field = 'username'
-    serializer_class = PublicUserSerializer
+    serializer_class = PublicUserWithGroupsSerializer
     ordering = 'id'
+
+    def get_queryset(self):
+        if self.action in ['list', 'retrieve']:
+            return self.queryset.prefetch_related('abakus_groups')
+        return self.queryset
 
     def get_serializer_class(self):
         """


### PR DESCRIPTION
Add abakus groups to user serializer to be able to show comittees and groups on users profiles. I introduced a new serializer, `PublicUserWithGroupsSerializer` to avoid having to fetch groups all the places the PublicUser serializer is used - like event registrations.

The field introduces two more queries from 10 to 12, but does not increase based on the number of groups.