### PR TITLE
Add new end point for public-companies

### DIFF
--- a/lego/api/v1.py
+++ b/lego/api/v1.py
@@ -3,7 +3,7 @@ from rest_framework import routers
 from lego.apps.articles.views import ArticlesViewSet
 from lego.apps.comments.views import CommentViewSet
 from lego.apps.companies.views import (CompanyContactViewSet, CompanyFilesViewSet,
-                                       CompanyInterestViewSet, CompanyViewSet,
+                                       CompanyInterestViewSet, CompanyViewSet, PublicCompanyViewSet,
                                        SemesterStatusViewSet, SemesterViewSet)
 from lego.apps.contact.views import ContactFormViewSet
 from lego.apps.email.views import AbakusGroupEmailViewSet, EmailListViewSet, UserEmailViewSet
@@ -51,6 +51,7 @@ router.register(r'companies/(?P<company_pk>\d+)/files',
                 CompanyFilesViewSet, base_name='company-files')
 router.register(r'company-interests', CompanyInterestViewSet, base_name='company-interest')
 router.register(r'company-semesters', SemesterViewSet)
+router.register(r'public-companies', PublicCompanyViewSet)
 router.register(r'events', EventViewSet, base_name='event')
 router.register(r'events/(?P<event_pk>\d+)/pools', PoolViewSet)
 router.register(r'events/(?P<event_pk>\d+)/registrations',

--- a/lego/apps/companies/serializers.py
+++ b/lego/apps/companies/serializers.py
@@ -110,7 +110,6 @@ class CompanyAdminDetailSerializer(BasisModelSerializer):
     comments = CommentSerializer(read_only=True, many=True)
     comment_target = CharField(read_only=True)
 
-    student_contact = PublicUserField(required=False, allow_null=True, queryset=User.objects.all())
     semester_statuses = SemesterStatusDetailSerializer(many=True, read_only=True)
     company_contacts = CompanyContactSerializer(many=True, read_only=True)
 
@@ -119,7 +118,7 @@ class CompanyAdminDetailSerializer(BasisModelSerializer):
 
     class Meta:
         model = Company
-        fields = ('id', 'name', 'student_contact', 'description', 'phone',
+        fields = ('id', 'name', 'description', 'phone',
                   'company_type', 'website', 'address', 'payment_mail', 'comments',
                   'comment_target', 'semester_statuses', 'active', 'admin_comment',
                   'logo', 'files', 'company_contacts')

--- a/lego/apps/companies/views.py
+++ b/lego/apps/companies/views.py
@@ -31,6 +31,16 @@ class CompanyViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
         return CompanyAdminDetailSerializer if is_admin else CompanyDetailSerializer
 
 
+class PublicCompanyViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
+    queryset = Company.objects.all().prefetch_related('semester_statuses', 'files')
+
+    def get_serializer_class(self):
+        if self.action == 'list':
+            return CompanyListSerializer
+
+        return CompanyDetailSerializer
+
+
 class CompanyFilesViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
     queryset = CompanyFile.objects.all()
     serializer_class = CompanyFileSerializer


### PR DESCRIPTION
After noticing problems with permissions, we decided to create a separate end point for companies. The purpose of this change is because the information about each company in company_view is the same for everyone and having a separate end point makes producing the front end a lot easier.