### PR TITLE
Add activeInterestForm to semester serializer

### DIFF
--- a/lego/apps/companies/serializers.py
+++ b/lego/apps/companies/serializers.py
@@ -13,7 +13,7 @@ from lego.utils.serializers import BasisModelSerializer
 class SemesterSerializer(BasisModelSerializer):
     class Meta:
         model = Semester
-        fields = ('id', 'year', 'semester')
+        fields = ('id', 'year', 'semester', 'active_interest_form')
 
 
 class SemesterStatusSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
This is needed both for client filtering (for superusers), and is
necessary for allowing users (with permissions) to change it.