### PR TITLE
Change gallery viewset ordering

### DIFF
--- a/lego/apps/gallery/views.py
+++ b/lego/apps/gallery/views.py
@@ -12,6 +12,7 @@ class GalleryViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
     queryset = Gallery.objects.all().select_related('event', 'cover')
     filter_class = GalleryFilterSet
     serializer_class = GallerySerializer
+    ordering = '-created_at'
 
     def get_queryset(self):
         if self.action != 'list':


### PR DESCRIPTION
View newest elements first, the taken_at propery may be better to sort on
but we're using created_at because it always exists and have db_index=True