### PR TITLE
Fix meetings queryset

### DIFF
--- a/lego/api/v1.py
+++ b/lego/api/v1.py
@@ -61,7 +61,7 @@ router.register(r'webhooks-stripe', StripeWebhook, base_name='webhooks-stripe')
 router.register(r'groups', AbakusGroupViewSet)
 router.register(r'groups/(?P<group_pk>\d+)/memberships', MembershipViewSet,
                 base_name='abakusgroup-memberships')
-router.register(r'meetings', MeetingViewSet)
+router.register(r'meetings', MeetingViewSet, base_name='meeting')
 router.register(r'meetings/(?P<meeting_pk>\d+)/invitations',
                 MeetingInvitationViewSet, base_name='meeting-invitations')
 router.register(r'meeting-token',

--- a/lego/apps/meetings/views.py
+++ b/lego/apps/meetings/views.py
@@ -10,13 +10,23 @@ from lego.apps.meetings.serializers import (MeetingBulkInvite, MeetingGroupInvit
                                             MeetingInvitationUpdateSerializer, MeetingSerializer,
                                             MeetingUserInvite)
 from lego.apps.permissions.api.views import AllowedPermissionsMixin
+from lego.apps.permissions.utils import get_permission_handler
 
 
 class MeetingViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
 
-    queryset = Meeting.objects.prefetch_related('invitations', 'invitations__user')
     filter_class = MeetingFilterSet
     serializer_class = MeetingSerializer
+
+    def get_queryset(self):
+        permission_handler = get_permission_handler(Meeting)
+        return permission_handler.filter_queryset(
+            self.request.user,
+            Meeting.objects.prefetch_related(
+                'invitations',
+                'invitations__user'
+            )
+        )
 
     def get_ordering(self):
         ordering = self.request.query_params.get('ordering', None)


### PR DESCRIPTION
Disable keyword-permissions in meetings. We can instead add an
admin-settings at a later stage.