### PR TITLE
Add support for admin registration to waiting list

### DIFF
--- a/lego/apps/events/serializers/registrations.py
+++ b/lego/apps/events/serializers/registrations.py
@@ -13,7 +13,7 @@ from lego.utils.serializers import BasisModelSerializer
 
 class AdminRegistrationCreateAndUpdateSerializer(serializers.Serializer):
     user = PrimaryKeyRelatedFieldNoPKOpt(queryset=User.objects.all())
-    pool = PrimaryKeyRelatedFieldNoPKOpt(queryset=Pool.objects.all())
+    pool = PrimaryKeyRelatedFieldNoPKOpt(queryset=Pool.objects.all(), required=False)
     feedback = serializers.CharField(required=False)
     admin_reason = serializers.CharField(required=True)
 

--- a/lego/apps/events/tests/test_admin_registrations.py
+++ b/lego/apps/events/tests/test_admin_registrations.py
@@ -28,7 +28,7 @@ class AdminRegistrationTestCase(TestCase):
         no_of_regs_before = event.number_of_registrations
         pool_no_of_regs_before = pool.registrations.count()
 
-        event.admin_register(user, pool, admin_reason='test')
+        event.admin_register(user, admin_reason='test', pool=pool)
         self.assertEqual(event.number_of_registrations, no_of_regs_before + 1)
         self.assertEqual(pool.registrations.count(), pool_no_of_regs_before + 1)
 
@@ -44,7 +44,7 @@ class AdminRegistrationTestCase(TestCase):
         pool_no_of_regs_before = wrong_pool.registrations.count()
 
         with self.assertRaises(ValueError):
-            event_one.admin_register(user, wrong_pool, admin_reason='test')
+            event_one.admin_register(user, admin_reason='test', pool=wrong_pool)
         self.assertEqual(event_one.number_of_registrations, e1_no_of_regs_before)
         self.assertEqual(event_two.number_of_registrations, e2_no_of_regs_before)
         self.assertEqual(wrong_pool.registrations.count(), pool_no_of_regs_before)
@@ -59,7 +59,7 @@ class AdminRegistrationTestCase(TestCase):
         e1_no_of_regs_before = event.number_of_registrations
         pool_no_of_regs_before = pool.registrations.count()
 
-        event.admin_register(user, pool, admin_reason='test')
+        event.admin_register(user, admin_reason='test', pool=pool)
         self.assertEqual(event.number_of_registrations, e1_no_of_regs_before+1)
         self.assertEqual(pool.registrations.count(), pool_no_of_regs_before+1)
 
@@ -73,7 +73,7 @@ class AdminRegistrationTestCase(TestCase):
         e1_no_of_regs_before = event.number_of_registrations
         pool_no_of_regs_before = pool.registrations.count()
 
-        event.admin_register(user, pool, admin_reason='test')
+        event.admin_register(user, admin_reason='test', pool=pool)
         self.assertEqual(event.number_of_registrations, e1_no_of_regs_before+1)
         self.assertEqual(pool.registrations.count(), pool_no_of_regs_before+1)
 
@@ -91,7 +91,7 @@ class AdminRegistrationTestCase(TestCase):
         e1_no_of_regs_before = event.number_of_registrations
         pool_no_of_regs_before = pool.registrations.count()
 
-        event.admin_register(user, pool, admin_reason='test')
+        event.admin_register(user, admin_reason='test', pool=pool)
         self.assertEqual(event.number_of_registrations, e1_no_of_regs_before+1)
         self.assertEqual(pool.registrations.count(), pool_no_of_regs_before+1)
 
@@ -109,7 +109,7 @@ class AdminRegistrationTestCase(TestCase):
         e1_no_of_regs_before = event.number_of_registrations
         pool_no_of_regs_before = pool.registrations.count()
 
-        event.admin_register(user, pool, admin_reason='test')
+        event.admin_register(user, admin_reason='test', pool=pool)
         self.assertEqual(event.number_of_registrations, e1_no_of_regs_before+1)
         self.assertEqual(pool.registrations.count(), pool_no_of_regs_before+1)
 
@@ -122,6 +122,17 @@ class AdminRegistrationTestCase(TestCase):
 
         e1_no_of_regs_before = event.number_of_registrations
 
-        event.admin_register(user, pool, admin_reason='test')
-        event.admin_register(user, pool, admin_reason='test')
+        event.admin_register(user, admin_reason='test', pool=pool)
+        event.admin_register(user, admin_reason='test', pool=pool)
         self.assertEqual(event.number_of_registrations, e1_no_of_regs_before+1)
+
+    def test_ar_without_pool(self):
+        """Test that user is not registered twice when admin registered is run twice"""
+        event = Event.objects.get(title='POOLS_NO_REGISTRATIONS')
+        user = get_dummy_users(1)[0]
+        AbakusGroup.objects.get(name='Abakus').add_user(user)
+
+        waiting_regs_before = event.waiting_registrations.count()
+
+        event.admin_register(user, admin_reason='test')
+        self.assertEqual(event.waiting_registrations.count(), waiting_regs_before+1)

--- a/lego/apps/events/tests/test_admin_registrations.py
+++ b/lego/apps/events/tests/test_admin_registrations.py
@@ -127,7 +127,7 @@ class AdminRegistrationTestCase(TestCase):
         self.assertEqual(event.number_of_registrations, e1_no_of_regs_before+1)
 
     def test_ar_without_pool(self):
-        """Test that user is not registered twice when admin registered is run twice"""
+        """Test that admin registration without pool puts the registration in the waiting list"""
         event = Event.objects.get(title='POOLS_NO_REGISTRATIONS')
         user = get_dummy_users(1)[0]
         AbakusGroup.objects.get(name='Abakus').add_user(user)

--- a/lego/apps/events/tests/test_events_api.py
+++ b/lego/apps/events/tests/test_events_api.py
@@ -654,6 +654,19 @@ class CreateAdminRegistrationTestCase(APITestCase):
 
         self.assertEqual(registration_response.status_code, 400)
 
+    def test_ar_to_waiting_list(self):
+        AbakusGroup.objects.get(name='Webkom').add_user(self.request_user)
+        self.client.force_authenticate(self.request_user)
+        self.assertEqual(self.event.waiting_registrations.count(), 0)
+
+        registration_response = self.client.post(
+            f'{_get_registrations_list_url(self.event.id)}admin_register/',
+            {'user': self.user.id, 'admin_reason': 'test'}
+        )
+
+        self.assertEqual(registration_response.status_code, 201)
+        self.assertEqual(self.event.waiting_registrations.count(), 1)
+
 
 @skipIf(not stripe.api_key, 'No API Key set. Set STRIPE_TEST_KEY in ENV to run test.')
 class StripePaymentTestCase(APITestCase):

--- a/lego/apps/events/tests/test_registrations.py
+++ b/lego/apps/events/tests/test_registrations.py
@@ -473,10 +473,10 @@ class RegistrationTestCase(TestCase):
 
         for user in abakus_users:
             AbakusGroup.objects.get(name='Abakus').add_user(user)
-            event.admin_register(user, pool_one, admin_reason='test')
+            event.admin_register(user, pool=pool_one, admin_reason='test')
         for user in webkom_users:
             AbakusGroup.objects.get(name='Webkom').add_user(user)
-            event.admin_register(user, pool_two, admin_reason='test')
+            event.admin_register(user, pool=pool_two, admin_reason='test')
 
         AbakusGroup.objects.get(name='Abakus').add_user(users[5])
         registration = Registration.objects.get_or_create(event=event, user=users[5])[0]


### PR DESCRIPTION
Adds support for admin registrations to the waiting list by allowing `pool=None` in the admin registration method, and making the pool not required in the serializer.

Closes #890 