### PR TITLE
Send company interest mail to mail list

### DIFF
--- a/lego/apps/companies/notifications.py
+++ b/lego/apps/companies/notifications.py
@@ -7,13 +7,8 @@ class CompanyInterestNotification(Notification):
     name = COMPANY_INTEREST_CREATED
 
     def generate_mail(self):
-
-        company_interest = self.kwargs['company_interest']
-
-        return self._delay_mail(
-            to_email=self.user.email,
-            context=company_interest.generate_mail_context(),
-            subject='En ny bedrift har meldt sin interesse',
-            plain_template='companies/email/company_interest.txt',
-            html_template='companies/email/company_interest.html',
-        )
+        """
+        The email for this notication is sent in the handler.
+        This allows us to send it to a mailing list, instead of specific users.
+        """
+        pass

--- a/lego/apps/feed/feed_handlers/company_interest_handler.py
+++ b/lego/apps/feed/feed_handlers/company_interest_handler.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+
 from lego.apps.companies.models import CompanyInterest
 from lego.apps.companies.notifications import CompanyInterestNotification
 from lego.apps.feed.activities import Activity
@@ -7,6 +9,7 @@ from lego.apps.feed.feeds.notification_feed import NotificationFeed
 from lego.apps.feed.registry import register_handler
 from lego.apps.feed.verbs import CompanyInterestVerb
 from lego.apps.users.models import AbakusGroup
+from lego.utils.tasks import send_email
 
 
 class CompanyInterestHandler(BaseHandler):
@@ -37,6 +40,14 @@ class CompanyInterestHandler(BaseHandler):
                 recipient, company_interest=company_interest
             )
             notification.notify()
+
+        send_email.delay(
+                to_email=f'bedriftskontakt@{settings.GSUITE_DOMAIN}',
+                context=company_interest.generate_mail_context(),
+                subject='En ny bedrift har meldt sin interesse',
+                plain_template='companies/email/company_interest.txt',
+                html_template='companies/email/company_interest.html',
+            )
 
     def handle_create(self, company_interest):
         pass


### PR DESCRIPTION
Bedkom wanted this to be sent to a specific mailing list, instead of sending it to each individual member of this group.