### PR TITLE
Change webhooks to use metadata

### DIFF
--- a/lego/apps/events/exceptions.py
+++ b/lego/apps/events/exceptions.py
@@ -37,3 +37,10 @@ class PoolCounterNotEqualToRegistrationCount(ValueError):
         message = f'Pool {pool.id} for event {event.id} was supposed to have {pool.capacity} ' \
                   f'registrations, but has {pool.counter}!'
         super().__init__(message)
+
+
+class WebhookDidNotFindRegistration(ValueError):
+    def __init__(self, event_id, metadata):
+        message = f'Stripe webhook with ID: {event_id} for event {metadata["EVENT_ID"]} tried ' \
+                  f'getting registration for user {metadata["USER"]}, but did not find any!'
+        super().__init__(message)

--- a/lego/apps/events/serializers/registrations.py
+++ b/lego/apps/events/serializers/registrations.py
@@ -76,8 +76,15 @@ class StripeTokenSerializer(serializers.Serializer):
     token = serializers.CharField()
 
 
+class StripeMetaSerializer(serializers.Serializer):
+    EVENT_ID = serializers.IntegerField()
+    USER = serializers.CharField()
+    EMAIL = serializers.EmailField()
+
+
 class StripeObjectSerializer(serializers.Serializer):
     id = serializers.CharField()
     amount = serializers.IntegerField()
     amount_refunded = serializers.IntegerField()
     status = serializers.CharField()
+    metadata = StripeMetaSerializer()

--- a/lego/apps/events/tasks.py
+++ b/lego/apps/events/tasks.py
@@ -169,7 +169,11 @@ def stripe_webhook_event(event_id, event_type):
         serializer = StripeObjectSerializer(data=event.data['object'])
         serializer.is_valid(raise_exception=True)
 
-        registration = Registration.objects.get(charge_id=serializer.data['id'])
+        metadata = serializer.data['metadata']
+        registration = Registration.objects.get(
+            event_id=metadata['EVENT_ID'], user__email=metadata['EMAIL']
+        )
+        registration.charge_id = serializer.data['id']
         registration.charge_amount = serializer.data['amount']
         registration.charge_amount_refunded = serializer.data['amount_refunded']
         registration.charge_status = serializer.data['status']


### PR DESCRIPTION
- Use metadata to find registration
- Raise specific exception when not found

Our code for handling webhooks was failing when celery retried stripe charges, since we were using `charge_id`. I changed it into using the provided metadata and added an exception that hopefully will never be raised 😂