### PR TITLE
Create a specific handler-method for interest form creation

### DIFF
--- a/lego/apps/companies/serializers.py
+++ b/lego/apps/companies/serializers.py
@@ -4,6 +4,7 @@ from rest_framework.fields import CharField
 from lego.apps.comments.serializers import CommentSerializer
 from lego.apps.companies.models import (Company, CompanyContact, CompanyFile, CompanyInterest,
                                         Semester, SemesterStatus)
+from lego.apps.feed.registry import get_handler
 from lego.apps.files.fields import FileField, ImageField
 from lego.apps.users.fields import PublicUserField
 from lego.apps.users.models import User
@@ -125,6 +126,15 @@ class CompanyInterestSerializer(serializers.ModelSerializer):
         model = CompanyInterest
         fields = ('id', 'company_name', 'contact_person', 'mail', 'semesters', 'events',
                   'other_offers', 'comment')
+
+    def create(self, validated_data):
+        semesters = validated_data.pop('semesters')
+        company_interest = CompanyInterest.objects.create(**validated_data)
+        company_interest.semesters.add(*semesters)
+        company_interest.save()
+        get_handler(CompanyInterest).handle_interest(company_interest)
+
+        return company_interest
 
 
 class CompanyInterestListSerializer(serializers.ModelSerializer):

--- a/lego/apps/feed/feed_handlers/company_interest_handler.py
+++ b/lego/apps/feed/feed_handlers/company_interest_handler.py
@@ -14,7 +14,7 @@ class CompanyInterestHandler(BaseHandler):
     model = CompanyInterest
     manager = feed_manager
 
-    def handle_create(self, company_interest):
+    def handle_interest(self, company_interest):
 
         activity = Activity(
             actor=company_interest,
@@ -37,6 +37,9 @@ class CompanyInterestHandler(BaseHandler):
                 recipient, company_interest=company_interest
             )
             notification.notify()
+
+    def handle_create(self, company_interest):
+        pass
 
     def handle_update(self, company_interest):
         pass


### PR DESCRIPTION
Closes #897 

Moves the handling of creation of a CompanyInterest to a specific handler method that is called after creation of the CompanyInterest _and_ semesters are set.