### PR TITLE
Replace django-cors-headers with own fork

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -38,13 +38,14 @@ django-extensions==1.9.6
 django-autoslug==1.9.3
 django-oauth-toolkit==1.0.0
 django-filter==1.1.0
-django-cors-headers==2.1.0
 django-mptt==0.8.7
 django-environ==0.4.4
 django-redis==4.8.0
 django-ipware==1.1.6
 django-thumbor==0.5.6
 django-push-notifications==1.5.0
+# Hack to get rid of CORS problems in FF
+git+http://github.com/martinhath/django-cors-headers
 
 # Ical-export
 django-ical==1.4


### PR DESCRIPTION
The fork contains a fix for overriding CORS headers. The version on PIP
discards any CORS headers we set in `Response`s. The suggested new
version only sets the CORS headers if they are not already set, but keeps
them if they are.

Here is 128 tadas, one for each puppy that has been killed due to CORS.

🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 