### PR TITLE
Event celery logging

### DIFF
--- a/lego/settings/celery.py
+++ b/lego/settings/celery.py
@@ -76,6 +76,10 @@ schedule = {
         'task': 'lego.apps.events.tasks.notify_user_when_payment_overdue',
         'schedule': crontab(hour=9, minute=0)
     },
+    'notify_event_creator_when_payment_overdue': {
+        'task': 'lego.apps.events.tasks.notify_event_creator_when_payment_overdue',
+        'schedule': crontab(hour=9, minute=0)
+    },
     'sync-external-systems': {
         'task': 'lego.apps.external_sync.tasks.sync_external_systems',
         'schedule': crontab(hour='*', minute=0)


### PR DESCRIPTION
Turns out our celery beat tasks aren't running correctly – which is quite bad since they do a lot of important tasks. 

I was able to get an error when running celery beat locally, where the tasks were not sent due to `logger_context` being passed to tasks without `base=AbakusTask` – which does not make any sense. Though I cant seem to be able to reproduce that error by reverting these changes, so it might be something else. We should add these logs anyway though.