### PR TITLE
Fix event payment overdue notification

### DIFF
--- a/lego/apps/events/tasks.py
+++ b/lego/apps/events/tasks.py
@@ -247,7 +247,7 @@ def bump_waiting_users_to_new_pool(self, logger_context=None):
 
 
 @celery_app.task(serializer='json', bind=True, base=AbakusTask)
-def notify_user_when_payment_overdue(self, logger_context=None):
+def notify_user_when_payment_soon_overdue(self, logger_context=None):
     self.setup_logger(logger_context)
 
     time = timezone.now()
@@ -255,7 +255,7 @@ def notify_user_when_payment_overdue(self, logger_context=None):
         payment_due_date__range=(time - timedelta(days=7), time), is_priced=True, use_stripe=True
     ).exclude(registrations=None).prefetch_related('registrations')
     for event in events:
-        for registration in event.registrations.all():
+        for registration in event.registrations.exclude(pool=None):
             if registration.should_notify(time):
                 log.info(
                     'registration_notified_overdue_payment', event_id=event.id,

--- a/lego/apps/events/tasks.py
+++ b/lego/apps/events/tasks.py
@@ -98,7 +98,7 @@ def async_unregister(self, registration_id, logger_context=None):
                 constants.SOCKET_UNREGISTRATION_SUCCESS, registration,
                 from_pool=pool_id, activation_time=activation_time
             ))
-        log.info('unregistration_success', registration_id=self.registration.id)
+        log.info('unregistration_success', registration_id=registration.id)
     except LockError as e:
         log.error('unregistration_cache_lock_error', exception=e, registration_id=registration.id)
         raise self.retry(exc=e, max_retries=3)

--- a/lego/settings/celery.py
+++ b/lego/settings/celery.py
@@ -72,8 +72,8 @@ schedule = {
         'task': 'lego.apps.events.tasks.bump_waiting_users_to_new_pool',
         'schedule': crontab(minute='*/30')
     },
-    'notify_user_when_payment_overdue': {
-        'task': 'lego.apps.events.tasks.notify_user_when_payment_overdue',
+    'notify_user_when_payment_soon_overdue': {
+        'task': 'lego.apps.events.tasks.notify_user_when_payment_soon_overdue',
         'schedule': crontab(hour=9, minute=0)
     },
     'notify_event_creator_when_payment_overdue': {


### PR DESCRIPTION
Fix bug that sent emails to a bit more users than intended by excluding those who do not have a pool designated to their registration object.

Fix the self.registration error in unregistration as well.