### PR TITLE
Fix counter incrementing using an old counter value on unregister

### DIFF
--- a/lego/apps/events/tests/test_registrations.py
+++ b/lego/apps/events/tests/test_registrations.py
@@ -454,6 +454,9 @@ class RegistrationTestCase(TestCase):
         registration_to_unregister = Registration.objects.get(event=event, user=user_to_unregister)
         event.unregister(registration_to_unregister)
 
+        pool.refresh_from_db()
+
+        self.assertEqual(pool.counter, pool.registrations.count())
         self.assertEqual(pool.registrations.count(), pool_size_before)
         self.assertEqual(event.number_of_registrations, event_size_before)
         self.assertEqual(event.waiting_registrations.count(), waiting_list_before - 1)


### PR DESCRIPTION
https://sentry.abakus.no/webkom/lego/issues/3549/events/1992473/

The counter was incrementing an old value when people unregistered. Meaning that a full event with e.g. 9 users, was incremented to 10 on unregister with bump from waiting list. This solves the problem by fetching the pool after the unregister happened, and using pool_id property to check if it exists to avoid another query.