### PR TITLE
Quotes permissions

### DIFF
--- a/lego/apps/quotes/permissions.py
+++ b/lego/apps/quotes/permissions.py
@@ -1,4 +1,3 @@
-from lego.apps.permissions.constants import EDIT
 from lego.apps.permissions.permissions import PermissionHandler
 
 
@@ -9,11 +8,3 @@ class QuotePermissionHandler(PermissionHandler):
         'approve': ['/sudo/admin/quotes/change-approval/'],
         'unapprove': ['/sudo/admin/quotes/change-approval/'],
     }
-
-    def filter_queryset(self, user, queryset, **kwargs):
-        queryset = super().filter_queryset(user, queryset)
-        access_unapproved = user.has_perm(EDIT, queryset)
-
-        if not access_unapproved:
-            return queryset.filter(approved=True)
-        return queryset

--- a/lego/apps/quotes/views.py
+++ b/lego/apps/quotes/views.py
@@ -5,6 +5,7 @@ from rest_framework.decorators import detail_route, list_route
 from rest_framework.response import Response
 
 from lego.apps.permissions.api.views import AllowedPermissionsMixin
+from lego.apps.permissions.constants import EDIT
 from lego.apps.quotes.filters import QuotesFilterSet
 from lego.apps.quotes.models import Quote
 from lego.apps.quotes.serializers import QuoteCreateAndUpdateSerializer, QuoteSerializer
@@ -15,6 +16,13 @@ class QuoteViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
     queryset = Quote.objects.all().prefetch_related('tags')
     filter_class = QuotesFilterSet
     ordering = '-created_at'
+
+    def get_queryset(self):
+        access_unapproved = self.request.user.has_perm(EDIT, self.queryset)
+
+        if not access_unapproved:
+            return self.queryset.filter(approved=True)
+        return self.queryset
 
     def get_serializer_class(self):
         if self.action in ['create', 'update', 'partial_update']:


### PR DESCRIPTION
Moves the quotes permissions check for whether the user can see unapproved quotes to the viewset, because filter doesn't work well with regular permissions. 

Fixes that regular users can fetch unapproved quotes.