### PR TITLE
Add weekly and hide_sender flags to Create Restricted Email

### DIFF
--- a/lego/apps/restricted/models.py
+++ b/lego/apps/restricted/models.py
@@ -7,6 +7,7 @@ from structlog import get_logger
 
 from lego.apps.notifications.constants import EMAIL, WEEKLY_MAIL
 from lego.apps.notifications.models import NotificationSetting
+from lego.apps.users.models import AbakusGroup
 from lego.utils.models import BasisModel
 
 log = get_logger()
@@ -65,6 +66,9 @@ class RestrictedMail(BasisModel):
                     users, raw_addresses = restricted_lookup()
                     all_users += list(users)
                     all_raw_addresses += list(raw_addresses)
+
+        if self.weekly:
+            all_users += (AbakusGroup.objects.get(name="Students").restricted_lookup()[0])
 
         recipients = set(all_raw_addresses)
 

--- a/lego/apps/restricted/serializers.py
+++ b/lego/apps/restricted/serializers.py
@@ -19,7 +19,7 @@ class RestrictedMailListSerializer(BasisModelSerializer):
 class RestrictedMailSerializer(RestrictedMailListSerializer):
     class Meta(RestrictedMailListSerializer.Meta):
         fields = RestrictedMailListSerializer.Meta.fields + (
-            'users', 'groups', 'events', 'meetings', 'raw_addresses'
+            'users', 'groups', 'events', 'meetings', 'raw_addresses', 'weekly', 'hide_sender'
         )
 
 

--- a/lego/apps/restricted/tests/test_models.py
+++ b/lego/apps/restricted/tests/test_models.py
@@ -4,6 +4,7 @@ from lego.apps.events.tests.utils import get_dummy_users
 from lego.apps.notifications.constants import EMAIL, PUSH, WEEKLY_MAIL
 from lego.apps.notifications.models import NotificationSetting
 from lego.apps.restricted.models import RestrictedMail
+from lego.apps.users.models import AbakusGroup
 
 
 class RestrictedMailModelTestCase(TestCase):
@@ -46,8 +47,12 @@ class RestrictedMailModelTestCase(TestCase):
         """
         restricted_mail = RestrictedMail.objects.create(from_address='test@test.no', weekly=True)
 
-        unsubscribed_one, unsubscribed_two, no_setting, subscribed = get_dummy_users(4)
-        restricted_mail.users.add(unsubscribed_one, unsubscribed_two, no_setting, subscribed)
+        users = get_dummy_users(5)
+        notAlumni = users[:4]
+
+        unsubscribed_one, unsubscribed_two, no_setting, subscribed, alumni = users
+        for user in notAlumni:
+            AbakusGroup.objects.get(name="Students").add_user(user)
 
         NotificationSetting.objects.create(
             user=unsubscribed_one, notification_type=WEEKLY_MAIL, enabled=False
@@ -57,6 +62,9 @@ class RestrictedMailModelTestCase(TestCase):
         )
         NotificationSetting.objects.create(
             user=subscribed, notification_type=WEEKLY_MAIL, enabled=True, channels=[EMAIL]
+        )
+        NotificationSetting.objects.create(
+            user=alumni, notification_type=WEEKLY_MAIL, enabled=True, channels=[EMAIL]
         )
 
         recipients = restricted_mail.lookup_recipients()

--- a/lego/apps/users/fixtures/test_abakus_groups.yaml
+++ b/lego/apps/users/fixtures/test_abakus_groups.yaml
@@ -142,3 +142,7 @@
       turopplevelser som er m\xE5let.\n\n Om du harforslag til tur eller lurer p\xE5
       om dette er noe du kan v\xE6re med p\xE5, ikke n\xF8l med \xE5 ta kontakt.",
     permissions: '[]', lft: 17, rght: 18, tree_id: 15, level: 2}
+- model: users.abakusgroup
+  pk: 25
+  fields: {deleted: false, name: Students, description: '', parent: null, logo: null,
+    type: annen, text: '', permissions: '[]', lft: 1, rght: 26, tree_id: 3, level: 0}


### PR DESCRIPTION
This supports the creation of tokens with `weekly` and `hide_sender` flags. Before you had to add this through shell.