### PR TITLE
Start parallelizing tests

### DIFF
--- a/lego/api/test_urls.py
+++ b/lego/api/test_urls.py
@@ -1,8 +1,9 @@
 from django.conf import settings
-from django.test import TestCase
+
+from lego.utils.test_utils import BaseTestCase
 
 
-class VersionRedirectTestCase(TestCase):
+class VersionRedirectTestCase(BaseTestCase):
     def test_redirect(self):
         response = self.client.get('/api/users/')
         self.assertEqual(response.status_code, 302)

--- a/lego/api/tests/test_authentication.py
+++ b/lego/api/tests/test_authentication.py
@@ -1,10 +1,10 @@
 from rest_framework.reverse import reverse
-from rest_framework.test import APITestCase
 
 from lego.apps.users.models import User
+from lego.utils.test_utils import BaseAPITestCase
 
 
-class JSONWebTokenTestCase(APITestCase):
+class JSONWebTokenTestCase(BaseAPITestCase):
     fixtures = ['initial_files.yaml', 'test_users.yaml']
 
     def setUp(self):

--- a/lego/api/tests/test_docs.py
+++ b/lego/api/tests/test_docs.py
@@ -1,9 +1,10 @@
-from django.test import Client, TestCase
+from django.test import Client
 
 from lego.apps.users.models import User
+from lego.utils.test_utils import BaseTestCase
 
 
-class APIDocsTestCase(TestCase):
+class APIDocsTestCase(BaseTestCase):
     """
     Make sure the api docs works like expected.
     """

--- a/lego/apps/articles/tests/test_articles_api.py
+++ b/lego/apps/articles/tests/test_articles_api.py
@@ -1,9 +1,9 @@
 from django.urls import reverse
-from rest_framework.test import APITestCase
 
 from lego.apps.articles.models import Article
 from lego.apps.articles.serializers import PublicArticleSerializer
 from lego.apps.users.models import AbakusGroup, User
+from lego.utils.test_utils import BaseAPITestCase
 
 
 def _get_list_url():
@@ -14,7 +14,7 @@ def _get_detail_url(pk):
     return reverse('api:v1:article-detail', kwargs={'pk': pk})
 
 
-class ListArticlesTestCase(APITestCase):
+class ListArticlesTestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_articles.yaml', 'test_users.yaml']
 
     def setUp(self):
@@ -46,7 +46,7 @@ class ListArticlesTestCase(APITestCase):
         self.assertEqual(len(response.data['results']), 2)
 
 
-class RetrieveArticlesTestCase(APITestCase):
+class RetrieveArticlesTestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_articles.yaml', 'test_users.yaml']
 
     def setUp(self):

--- a/lego/apps/comments/tests/test_notifications.py
+++ b/lego/apps/comments/tests/test_notifications.py
@@ -1,15 +1,14 @@
 from unittest.mock import patch
 
-from django.test import TestCase
-
 from lego.apps.articles.models import Article
 from lego.apps.comments.models import Comment
 from lego.apps.comments.notifications import CommentNotification, CommentReplyNotification
 from lego.apps.users.models import User
+from lego.utils.test_utils import BaseTestCase
 
 
 @patch('lego.utils.email.django_send_mail')
-class CommentNotificationTestCase(TestCase):
+class CommentNotificationTestCase(BaseTestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_comments.yaml', 'test_users.yaml', 'test_articles.yaml',
         'initial_files.yaml'
@@ -52,7 +51,7 @@ class CommentNotificationTestCase(TestCase):
 
 
 @patch('lego.utils.email.django_send_mail')
-class CommentReplyNotificationTestCase(TestCase):
+class CommentReplyNotificationTestCase(BaseTestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_comments.yaml', 'test_users.yaml', 'test_articles.yaml',
         'initial_files.yaml'

--- a/lego/apps/comments/tests/test_views.py
+++ b/lego/apps/comments/tests/test_views.py
@@ -1,11 +1,11 @@
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from rest_framework import status
-from rest_framework.test import APITestCase
 
 from lego.apps.articles.models import Article
 from lego.apps.comments.models import Comment
 from lego.apps.users.models import AbakusGroup, User
+from lego.utils.test_utils import BaseAPITestCase
 
 
 def _get_list_url():
@@ -16,7 +16,7 @@ def _get_detail_url(pk):
     return reverse('api:v1:comment-detail', kwargs={'pk': pk})
 
 
-class CreateCommentsAPITestCase(APITestCase):
+class CreateCommentsAPITestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml', 'test_articles.yaml']
 
     def setUp(self):
@@ -233,7 +233,7 @@ class CreateCommentsAPITestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
 
-class UpdateCommentsAPITestCase(APITestCase):
+class UpdateCommentsAPITestCase(BaseAPITestCase):
     fixtures = [
         'test_abakus_groups.yaml',
         'test_users.yaml',
@@ -298,7 +298,7 @@ class UpdateCommentsAPITestCase(APITestCase):
         self.assertEqual(comment, self.test_comment)
 
 
-class DeleteUsersAPITestCase(APITestCase):
+class DeleteUsersAPITestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml', 'test_articles.yaml']
 
     def setUp(self):

--- a/lego/apps/companies/tests/test_companies_api.py
+++ b/lego/apps/companies/tests/test_companies_api.py
@@ -1,7 +1,7 @@
 from django.urls import reverse
-from rest_framework.test import APITestCase
 
 from lego.apps.users.models import AbakusGroup, User
+from lego.utils.test_utils import BaseAPITestCase
 
 _test_company_data = [{'name': 'TEST'}, {'name': 'TEST2'}]
 
@@ -42,7 +42,7 @@ def _get_company_contacts_detail_url(company_pk, pk):
     return reverse('api:v1:company-contact-detail', kwargs={'company_pk': company_pk, 'pk': pk})
 
 
-class ListCompaniesTestCase(APITestCase):
+class ListCompaniesTestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_companies.yaml', 'test_users.yaml']
 
     def setUp(self):
@@ -62,7 +62,7 @@ class ListCompaniesTestCase(APITestCase):
         self.assertEqual(len(company_response.data['results']), 3)
 
 
-class RetrieveCompaniesTestCase(APITestCase):
+class RetrieveCompaniesTestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_companies.yaml', 'test_users.yaml']
 
     def setUp(self):
@@ -81,7 +81,7 @@ class RetrieveCompaniesTestCase(APITestCase):
         self.assertEqual(company_response.status_code, 200)
 
 
-class CreateCompaniesTestCase(APITestCase):
+class CreateCompaniesTestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_companies.yaml', 'test_users.yaml']
 
     def setUp(self):
@@ -113,7 +113,7 @@ class CreateCompaniesTestCase(APITestCase):
         self.assertEqual(company_response.data['name'], _test_company_data[1]['name'])
 
 
-class DeleteCompaniesTestCase(APITestCase):
+class DeleteCompaniesTestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_companies.yaml', 'test_users.yaml']
 
     def setUp(self):
@@ -135,7 +135,7 @@ class DeleteCompaniesTestCase(APITestCase):
         self.assertEqual(company_response.status_code, 404)
 
 
-class CreateSemesterStatusTestCase(APITestCase):
+class CreateSemesterStatusTestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_companies.yaml', 'test_users.yaml']
 
     def setUp(self):
@@ -175,7 +175,7 @@ class CreateSemesterStatusTestCase(APITestCase):
         )
 
 
-class DeleteSemesterStatusTestCase(APITestCase):
+class DeleteSemesterStatusTestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_companies.yaml', 'test_users.yaml']
 
     def setUp(self):
@@ -194,7 +194,7 @@ class DeleteSemesterStatusTestCase(APITestCase):
         self.assertEqual(response.status_code, 204)
 
 
-class CreateCompanyContactsTestCase(APITestCase):
+class CreateCompanyContactsTestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_companies.yaml', 'test_users.yaml']
 
     def setUp(self):
@@ -234,7 +234,7 @@ class CreateCompanyContactsTestCase(APITestCase):
         self.assertEqual(company_response.data['name'], _test_company_contact_data[0]['name'])
 
 
-class DeleteCompanyContacsTestCase(APITestCase):
+class DeleteCompanyContacsTestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_companies.yaml', 'test_users.yaml']
 
     def setUp(self):

--- a/lego/apps/contact/tests/test_send.py
+++ b/lego/apps/contact/tests/test_send.py
@@ -1,13 +1,13 @@
 from unittest import mock
 
 from django.contrib.auth.models import AnonymousUser
-from django.test import TestCase
 
 from lego.apps.contact.send import send_message
 from lego.apps.users.models import User
+from lego.utils.test_utils import BaseTestCase
 
 
-class SendTestCase(TestCase):
+class SendTestCase(BaseTestCase):
 
     fixtures = [
         'initial_files.yaml', 'initial_abakus_groups.yaml', 'development_users.yaml',

--- a/lego/apps/contact/tests/test_views.py
+++ b/lego/apps/contact/tests/test_views.py
@@ -1,12 +1,12 @@
 from unittest import mock
 
 from rest_framework import status
-from rest_framework.test import APITestCase
 
 from lego.apps.users.models import User
+from lego.utils.test_utils import BaseAPITestCase
 
 
-class ContactViewSetTestCase(APITestCase):
+class ContactViewSetTestCase(BaseAPITestCase):
 
     fixtures = [
         'initial_files.yaml', 'initial_abakus_groups.yaml', 'development_users.yaml',

--- a/lego/apps/content/tests.py
+++ b/lego/apps/content/tests.py
@@ -1,11 +1,11 @@
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.test import testcases
 from django.utils.text import slugify
 
 from lego.apps.articles.models import Article
 from lego.apps.content.models import SlugModel
 from lego.apps.users.models import User
+from lego.utils.test_utils import BaseTestCase
 
 
 class ExampleSlugContent(SlugModel):
@@ -13,7 +13,7 @@ class ExampleSlugContent(SlugModel):
     title = models.CharField(max_length=255)
 
 
-class SlugModelTestCase(testcases.TestCase):
+class SlugModelTestCase(BaseTestCase):
     def test_slug(self):
         item = ExampleSlugContent(title='CORRECTSLUG')
         self.assertIsNone(item.slug)
@@ -46,7 +46,7 @@ class SlugModelTestCase(testcases.TestCase):
         )
 
 
-class ContentModelTestCase(testcases.TestCase):
+class ContentModelTestCase(BaseTestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'initial_files.yaml', 'development_users.yaml',
         'test_articles.yaml'

--- a/lego/apps/email/tests/test_models.py
+++ b/lego/apps/email/tests/test_models.py
@@ -1,11 +1,11 @@
 from django.db import IntegrityError
-from django.test import TestCase
 
 from lego.apps.email.models import EmailAddress, EmailList
 from lego.apps.users.models import AbakusGroup, User
+from lego.utils.test_utils import BaseTestCase
 
 
-class EmailAddressTestCase(TestCase):
+class EmailAddressTestCase(BaseTestCase):
 
     fixtures = ['test_email_addresses.yaml', 'test_email_lists.yaml']
 
@@ -27,7 +27,7 @@ class EmailAddressTestCase(TestCase):
         self.assertFalse(address.is_assigned())
 
 
-class EmailListTestCase(TestCase):
+class EmailListTestCase(BaseTestCase):
 
     fixtures = [
         'initial_files.yaml', 'initial_abakus_groups.yaml', 'test_email_addresses.yaml',

--- a/lego/apps/email/tests/test_validators.py
+++ b/lego/apps/email/tests/test_validators.py
@@ -1,13 +1,13 @@
 from unittest import mock
 
 from django.core.exceptions import ValidationError
-from django.test import TestCase
 
 from lego.apps.email.models import EmailAddress
 from lego.apps.email.validators import validate_email_address
+from lego.utils.test_utils import BaseTestCase
 
 
-class ValidatorsTestCase(TestCase):
+class ValidatorsTestCase(BaseTestCase):
     @mock.patch('lego.apps.email.models.EmailAddress.is_assigned', return_value=True)
     def test_email_address_validator(self, mock_is_assigned):
         """The validator should raise ValidationError if is_assigned returns True"""

--- a/lego/apps/email/tests/test_views.py
+++ b/lego/apps/email/tests/test_views.py
@@ -1,11 +1,11 @@
 from rest_framework import status
-from rest_framework.test import APITestCase
 
 from lego.apps.email.models import EmailList
 from lego.apps.users.models import AbakusGroup, User
+from lego.utils.test_utils import BaseAPITestCase
 
 
-class EmailListTestCase(APITestCase):
+class EmailListTestCase(BaseAPITestCase):
 
     fixtures = [
         'test_abakus_groups.yaml', 'test_users.yaml', 'test_email_addresses.yaml',
@@ -82,7 +82,7 @@ class EmailListTestCase(APITestCase):
         self.assertEquals(status.HTTP_403_FORBIDDEN, response.status_code)
 
 
-class UserEmailTestCase(APITestCase):
+class UserEmailTestCase(BaseAPITestCase):
 
     fixtures = [
         'test_abakus_groups.yaml', 'test_email_addresses.yaml', 'test_users.yaml',

--- a/lego/apps/events/tests/test_admin_registrations.py
+++ b/lego/apps/events/tests/test_admin_registrations.py
@@ -1,16 +1,16 @@
 from datetime import timedelta
 
-from django.test import TestCase
 from django.utils import timezone
 
 from lego.apps.events.exceptions import RegistrationExists
 from lego.apps.events.models import Event, Registration
 from lego.apps.users.models import AbakusGroup, User
+from lego.utils.test_utils import BaseTestCase
 
 from .utils import get_dummy_users
 
 
-class AdminRegistrationTestCase(TestCase):
+class AdminRegistrationTestCase(BaseTestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_users.yaml', 'test_companies.yaml', 'test_events.yaml'
     ]

--- a/lego/apps/events/tests/test_async_tasks.py
+++ b/lego/apps/events/tests/test_async_tasks.py
@@ -1,9 +1,7 @@
 from datetime import timedelta
 from unittest import mock
 
-from django.test import TestCase
 from django.utils import timezone
-from rest_framework.test import APITestCase
 
 from lego.apps.events import constants
 from lego.apps.events.exceptions import PoolCounterNotEqualToRegistrationCount
@@ -16,9 +14,10 @@ from lego.apps.events.tasks import (
 )
 from lego.apps.events.tests.utils import get_dummy_users, make_penalty_expire
 from lego.apps.users.models import AbakusGroup, Penalty
+from lego.utils.test_utils import BaseAPITestCase, BaseTestCase
 
 
-class PoolActivationTestCase(APITestCase):
+class PoolActivationTestCase(BaseAPITestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_users.yaml', 'test_events.yaml', 'test_companies.yaml'
     ]
@@ -213,7 +212,7 @@ class PoolActivationTestCase(APITestCase):
         check_that_pool_counters_match_registration_number()
 
 
-class PenaltyExpiredTestCase(TestCase):
+class PenaltyExpiredTestCase(BaseTestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_users.yaml', 'test_events.yaml', 'test_companies.yaml'
     ]
@@ -347,7 +346,7 @@ class PenaltyExpiredTestCase(TestCase):
         self.assertEqual(self.event.number_of_registrations, 2)
 
 
-class PaymentDueTestCase(TestCase):
+class PaymentDueTestCase(BaseTestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_users.yaml', 'test_events.yaml', 'test_companies.yaml'
     ]

--- a/lego/apps/events/tests/test_event_methods.py
+++ b/lego/apps/events/tests/test_event_methods.py
@@ -1,15 +1,15 @@
 from datetime import timedelta
 
-from django.test import TestCase
 from django.utils import timezone
 
 from lego.apps.events.models import Event, Pool, Registration
 from lego.apps.users.models import AbakusGroup
+from lego.utils.test_utils import BaseTestCase
 
 from .utils import get_dummy_users
 
 
-class EventMethodTest(TestCase):
+class EventMethodTest(BaseTestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_users.yaml', 'test_companies.yaml', 'test_events.yaml'
     ]

--- a/lego/apps/events/tests/test_events_api.py
+++ b/lego/apps/events/tests/test_events_api.py
@@ -6,7 +6,6 @@ import stripe
 from django.urls import reverse
 from django.utils import timezone
 from djangorestframework_camel_case.render import camelize
-from rest_framework.test import APITestCase, APITransactionTestCase
 
 from lego.apps.events import constants
 from lego.apps.events.exceptions import WebhookDidNotFindRegistration
@@ -14,6 +13,7 @@ from lego.apps.events.models import Event, Pool, Registration
 from lego.apps.events.tasks import stripe_webhook_event
 from lego.apps.events.tests.utils import get_dummy_users
 from lego.apps.users.models import AbakusGroup, User
+from lego.utils.test_utils import BaseAPITestCase, BaseAPITransactionTestCase
 
 from .utils import create_token
 
@@ -141,7 +141,7 @@ def _get_upcoming_url():
     return reverse('api:v1:event-upcoming')
 
 
-class ListEventsTestCase(APITestCase):
+class ListEventsTestCase(BaseAPITestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_companies.yaml', 'test_users.yaml', 'test_events.yaml'
     ]
@@ -174,7 +174,7 @@ class ListEventsTestCase(APITestCase):
         self.assertEqual(len(event_response.data['results']), 6)
 
 
-class RetrieveEventsTestCase(APITestCase):
+class RetrieveEventsTestCase(BaseAPITestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_companies.yaml', 'test_users.yaml', 'test_events.yaml'
     ]
@@ -270,7 +270,7 @@ class RetrieveEventsTestCase(APITestCase):
                     self.assertIsNone(reg['chargeStatus'])
 
 
-class CreateEventsTestCase(APITestCase):
+class CreateEventsTestCase(BaseAPITestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_companies.yaml', 'test_users.yaml', 'test_events.yaml'
     ]
@@ -460,7 +460,7 @@ class CreateEventsTestCase(APITestCase):
         self.assertEqual(res_event['pools'], [])
 
 
-class PoolsTestCase(APITestCase):
+class PoolsTestCase(BaseAPITestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_companies.yaml', 'test_users.yaml', 'test_events.yaml'
     ]
@@ -513,7 +513,7 @@ class PoolsTestCase(APITestCase):
 
 
 @mock.patch('lego.apps.events.views.verify_captcha', return_value=True)
-class RegistrationsTransactionTestCase(APITransactionTestCase):
+class RegistrationsTransactionTestCase(BaseAPITransactionTestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_companies.yaml', 'test_users.yaml', 'test_events.yaml'
     ]
@@ -559,7 +559,7 @@ class RegistrationsTransactionTestCase(APITransactionTestCase):
 
 
 @mock.patch('lego.apps.events.views.verify_captcha', return_value=True)
-class RegistrationsTestCase(APITestCase):
+class RegistrationsTestCase(BaseAPITestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_companies.yaml', 'test_users.yaml', 'test_events.yaml'
     ]
@@ -705,7 +705,7 @@ class RegistrationsTestCase(APITestCase):
         self.assertEqual(res.status_code, 403)
 
 
-class EventAdministrateTestCase(APITestCase):
+class EventAdministrateTestCase(BaseAPITestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_companies.yaml', 'test_users.yaml', 'test_events.yaml'
     ]
@@ -729,7 +729,7 @@ class EventAdministrateTestCase(APITestCase):
         self.assertEqual(event_response.status_code, 403)
 
 
-class CreateAdminRegistrationTestCase(APITestCase):
+class CreateAdminRegistrationTestCase(BaseAPITestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_companies.yaml', 'test_users.yaml', 'test_events.yaml'
     ]
@@ -842,7 +842,7 @@ class CreateAdminRegistrationTestCase(APITestCase):
         self.assertEqual(self.event.waiting_registrations.count(), 1)
 
 
-class AdminUnregistrationTestCase(APITestCase):
+class AdminUnregistrationTestCase(BaseAPITestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_companies.yaml', 'test_users.yaml', 'test_events.yaml'
     ]
@@ -904,7 +904,7 @@ class AdminUnregistrationTestCase(APITestCase):
 
 
 @skipIf(not stripe.api_key, 'No API Key set. Set STRIPE_TEST_KEY in ENV to run test.')
-class StripePaymentTestCase(APITestCase):
+class StripePaymentTestCase(BaseAPITestCase):
     """
     Testing cards used:
     https://stripe.com/docs/testing#cards
@@ -974,7 +974,7 @@ class StripePaymentTestCase(APITestCase):
             stripe_webhook_event(event_id=stripe_event.id, event_type='charge.refunded')
 
 
-class CapacityExpansionTestCase(APITestCase):
+class CapacityExpansionTestCase(BaseAPITestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_users.yaml', 'test_events.yaml', 'test_companies.yaml'
     ]
@@ -1023,7 +1023,7 @@ class CapacityExpansionTestCase(APITestCase):
         self.assertEquals(self.event.waiting_registrations.count(), 1)
 
 
-class RegistrationSearchTestCase(APITestCase):
+class RegistrationSearchTestCase(BaseAPITestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_users.yaml', 'test_events.yaml', 'test_companies.yaml'
     ]
@@ -1103,7 +1103,7 @@ class RegistrationSearchTestCase(APITestCase):
         self.assertEquals(res.status_code, 400)
 
 
-class UpcomingEventsTestCase(APITestCase):
+class UpcomingEventsTestCase(BaseAPITestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_companies.yaml', 'test_users.yaml', 'test_events.yaml'
     ]

--- a/lego/apps/events/tests/test_payments.py
+++ b/lego/apps/events/tests/test_payments.py
@@ -2,17 +2,17 @@ from unittest import skipIf
 
 import stripe
 from celery import chain
-from rest_framework.test import APITestCase
 
 from lego.apps.events.models import Event
 from lego.apps.events.tasks import async_payment, registration_payment_save
 from lego.apps.users.models import AbakusGroup, User
+from lego.utils.test_utils import BaseAPITestCase
 
 from .utils import create_token
 
 
 @skipIf(not stripe.api_key, 'No API Key set. Set STRIPE_TEST_KEY in ENV to run test.')
-class StripePaymentTestCase(APITestCase):
+class StripePaymentTestCase(BaseAPITestCase):
     """
     Testing cards used:
     https://stripe.com/docs/testing#cards

--- a/lego/apps/events/tests/test_penalties.py
+++ b/lego/apps/events/tests/test_penalties.py
@@ -1,16 +1,16 @@
 from datetime import timedelta
 
-from django.test import TestCase
 from django.utils import timezone
 
 from lego.apps.events import constants
 from lego.apps.events.models import Event, Registration
 from lego.apps.users.models import AbakusGroup, Penalty
+from lego.utils.test_utils import BaseTestCase
 
 from .utils import get_dummy_users
 
 
-class PenaltyTestCase(TestCase):
+class PenaltyTestCase(BaseTestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_users.yaml', 'test_companies.yaml', 'test_events.yaml'
     ]

--- a/lego/apps/events/tests/test_pools.py
+++ b/lego/apps/events/tests/test_pools.py
@@ -1,13 +1,13 @@
 from datetime import timedelta
 
-from django.test import TestCase
 from django.utils import timezone
 
 from lego.apps.events.models import Event, Pool
 from lego.apps.users.models import AbakusGroup
+from lego.utils.test_utils import BaseTestCase
 
 
-class PoolMethodTest(TestCase):
+class PoolMethodTest(BaseTestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_users.yaml', 'test_companies.yaml', 'test_events.yaml'
     ]
@@ -31,7 +31,7 @@ class PoolMethodTest(TestCase):
         self.assertEqual(len(event.pools.all()), number_of_pools - 1)
 
 
-class PoolCapacityTestCase(TestCase):
+class PoolCapacityTestCase(BaseTestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_users.yaml', 'test_companies.yaml', 'test_events.yaml'
     ]

--- a/lego/apps/events/tests/test_registrations.py
+++ b/lego/apps/events/tests/test_registrations.py
@@ -1,16 +1,16 @@
 from datetime import timedelta
 
-from django.test import TestCase
 from django.utils import timezone
 
 from lego.apps.events.exceptions import EventNotReady
 from lego.apps.events.models import Event, Pool, Registration
 from lego.apps.users.models import AbakusGroup, User
+from lego.utils.test_utils import BaseTestCase
 
 from .utils import get_dummy_users
 
 
-class RegistrationMethodTest(TestCase):
+class RegistrationMethodTest(BaseTestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_users.yaml', 'test_companies.yaml', 'test_events.yaml'
     ]
@@ -42,7 +42,7 @@ class RegistrationMethodTest(TestCase):
         self.assertEqual(self.event.get_price(registration.user), 15000)
 
 
-class RegistrationTestCase(TestCase):
+class RegistrationTestCase(BaseTestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_users.yaml', 'test_companies.yaml', 'test_events.yaml'
     ]

--- a/lego/apps/events/tests/test_webhooks.py
+++ b/lego/apps/events/tests/test_webhooks.py
@@ -2,12 +2,13 @@ from unittest import mock
 
 from django.test import override_settings
 from rest_framework import status
-from rest_framework.test import APITestCase
 from stripe import SignatureVerificationError
+
+from lego.utils.test_utils import BaseAPITestCase
 
 
 @override_settings(STRIPE_WEBHOOK_SECRET='test_secret')
-class StripeWebhookTestCase(APITestCase):
+class StripeWebhookTestCase(BaseAPITestCase):
     def setUp(self):
         self.url = '/api/v1/webhooks-stripe/'
 

--- a/lego/apps/external_sync/external/tests/test_ldap.py
+++ b/lego/apps/external_sync/external/tests/test_ldap.py
@@ -1,14 +1,15 @@
 from unittest import mock
 from unittest.mock import call
 
-from django.test import TestCase, override_settings
+from django.test import override_settings
 
 from lego.apps.external_sync.external import ldap
 from lego.apps.users.constants import GROUP_COMMITTEE
 from lego.apps.users.models import AbakusGroup, User
+from lego.utils.test_utils import BaseTestCase
 
 
-class LDAPTestCase(TestCase):
+class LDAPTestCase(BaseTestCase):
 
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml']
 

--- a/lego/apps/external_sync/tests/test_sync.py
+++ b/lego/apps/external_sync/tests/test_sync.py
@@ -1,12 +1,11 @@
 from unittest import mock
 
-from django.test import TestCase
-
 from lego.apps.external_sync.sync import Sync
 from lego.apps.users.models import AbakusGroup, User
+from lego.utils.test_utils import BaseTestCase
 
 
-class SyncTestCase(TestCase):
+class SyncTestCase(BaseTestCase):
     """
     This is a simple smoke test, it just makes sure all methods on the system classes is being
     called.

--- a/lego/apps/feed/tests/test_activites.py
+++ b/lego/apps/feed/tests/test_activites.py
@@ -1,4 +1,3 @@
-from django.test import TestCase
 from django.utils.timezone import make_naive, now
 from stream_framework.verbs.base import Comment as CommentVerb
 
@@ -6,9 +5,10 @@ from lego.apps.articles.models import Article
 from lego.apps.comments.models import Comment
 from lego.apps.feed.activities import Activity
 from lego.apps.users.models import User
+from lego.utils.test_utils import BaseTestCase
 
 
-class ActivityTestCase(TestCase):
+class ActivityTestCase(BaseTestCase):
 
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml', 'test_articles.yaml']
 

--- a/lego/apps/feed/tests/test_aggregator.py
+++ b/lego/apps/feed/tests/test_aggregator.py
@@ -1,4 +1,3 @@
-from django.test import TestCase
 from stream_framework.verbs.base import Comment as CommentVerb
 from stream_framework.verbs.base import Verb, register
 
@@ -6,9 +5,10 @@ from lego.apps.articles.models import Article
 from lego.apps.comments.models import Comment
 from lego.apps.feed import activities, aggregator
 from lego.apps.users.models import User
+from lego.utils.test_utils import BaseTestCase
 
 
-class AggregatorTestCase(TestCase):
+class AggregatorTestCase(BaseTestCase):
 
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml', 'test_articles.yaml']
 

--- a/lego/apps/feed/tests/test_comment_handler.py
+++ b/lego/apps/feed/tests/test_comment_handler.py
@@ -1,4 +1,5 @@
 from django.contrib.contenttypes.models import ContentType
+from django.test import tag
 
 from lego.apps.comments.models import Comment
 from lego.apps.events.models import Event
@@ -11,6 +12,7 @@ from lego.apps.users.models import User
 from lego.utils.content_types import instance_to_string
 
 
+@tag('feed')
 class TestCommentHandler(FeedTestBase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_users.yaml', 'test_articles.yaml', 'test_comments.yaml',

--- a/lego/apps/feed/tests/test_event_handler.py
+++ b/lego/apps/feed/tests/test_event_handler.py
@@ -1,3 +1,5 @@
+from django.test import tag
+
 from lego.apps.events.models import Event
 from lego.apps.feed.feed_handlers import EventHandler
 from lego.apps.feed.feeds.company_feed import CompanyFeed
@@ -8,6 +10,7 @@ from lego.apps.users.models import User
 from lego.utils.content_types import instance_to_string
 
 
+@tag('feed')
 class TestEventHandler(FeedTestBase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_users.yaml', 'test_companies.yaml', 'test_events.yaml',

--- a/lego/apps/feed/tests/test_feed_serializers.py
+++ b/lego/apps/feed/tests/test_feed_serializers.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-from django.test import TestCase
 from stream_framework.verbs.base import Comment as CommentVerb
 
 from lego.apps.articles.models import Article
@@ -9,9 +8,10 @@ from lego.apps.feed.activities import Activity, AggregatedActivity
 from lego.apps.feed.feed_serializers import AggregatedActivitySerializer
 from lego.apps.feed.feeds.notification_feed import NotificationFeed
 from lego.apps.users.models import User
+from lego.utils.test_utils import BaseTestCase
 
 
-class FeedActivitySerializerTestCase(TestCase):
+class FeedActivitySerializerTestCase(BaseTestCase):
 
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml', 'test_articles.yaml']
 

--- a/lego/apps/feed/tests/test_manager.py
+++ b/lego/apps/feed/tests/test_manager.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+from django.test import tag
 from stream_framework.feed_managers.base import add_operation, remove_operation
 
 from lego.apps.comments.models import Comment
@@ -12,6 +13,7 @@ from lego.apps.feed.tests.feed_test_base import FeedTestBase
 from lego.apps.feed.verbs import CommentVerb
 
 
+@tag('feed')
 class ManagerTestCase(FeedTestBase):
 
     fixtures = [

--- a/lego/apps/feed/tests/test_penalty_handler.py
+++ b/lego/apps/feed/tests/test_penalty_handler.py
@@ -1,3 +1,5 @@
+from django.test import tag
+
 from lego.apps.events.models import Event
 from lego.apps.feed.feed_handlers import PenaltyHandler
 from lego.apps.feed.feeds.notification_feed import NotificationFeed
@@ -5,6 +7,7 @@ from lego.apps.feed.tests.feed_test_base import FeedTestBase
 from lego.apps.users.models import Penalty, User
 
 
+@tag('feed')
 class TestPenaltyHandler(FeedTestBase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_users.yaml', 'test_companies.yaml', 'test_events.yaml'

--- a/lego/apps/feed/tests/test_registration_handler.py
+++ b/lego/apps/feed/tests/test_registration_handler.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 
+from django.test import tag
 from django.utils import timezone
 
 from lego.apps.events.models import Event, Registration
@@ -9,6 +10,7 @@ from lego.apps.feed.tests.feed_test_base import FeedTestBase
 from lego.apps.users.models import AbakusGroup, User
 
 
+@tag('feed')
 class TestRegistrationHandler(FeedTestBase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_users.yaml', 'test_companies.yaml', 'test_events.yaml'

--- a/lego/apps/feed/tests/test_views.py
+++ b/lego/apps/feed/tests/test_views.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 
+from django.test import tag
 from rest_framework import status
 from rest_framework.test import APITestCase
 from stream_framework.storage.redis.connection import get_redis_connection
@@ -14,6 +15,7 @@ from lego.apps.feed.tests.feed_test_base import FeedTestBase
 from lego.apps.users.models import User
 
 
+@tag('feed')
 class NotificationViewsTestCase(APITestCase, FeedTestBase):
 
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml', 'test_articles.yaml']

--- a/lego/apps/files/tests/test_api.py
+++ b/lego/apps/files/tests/test_api.py
@@ -1,12 +1,12 @@
 from unittest import mock
 
 from rest_framework import status
-from rest_framework.test import APITestCase
 
 from lego.apps.users.models import User
+from lego.utils.test_utils import BaseAPITestCase
 
 
-class ListArticlesTestCase(APITestCase):
+class ListArticlesTestCase(BaseAPITestCase):
     fixtures = ['test_users.yaml']
 
     url = '/api/v1/files/'

--- a/lego/apps/files/tests/test_fields.py
+++ b/lego/apps/files/tests/test_fields.py
@@ -1,13 +1,13 @@
 from unittest import mock
 
-from django.test import TestCase
 from rest_framework.exceptions import ValidationError
 
 from lego.apps.files.fields import FileField
 from lego.apps.files.models import File
+from lego.utils.test_utils import BaseTestCase
 
 
-class FileFieldTestCase(TestCase):
+class FileFieldTestCase(BaseTestCase):
 
     fixtures = ['test_users.yaml', 'test_files.yaml']
 

--- a/lego/apps/files/tests/test_models.py
+++ b/lego/apps/files/tests/test_models.py
@@ -1,13 +1,12 @@
 from unittest import mock
 
-from django.test import TestCase
-
 from lego.apps.files.exceptions import UnknownFileType
 from lego.apps.files.models import File
 from lego.apps.users.models import User
+from lego.utils.test_utils import BaseTestCase
 
 
-class FileModelTestCase(TestCase):
+class FileModelTestCase(BaseTestCase):
 
     fixtures = ['test_users.yaml', 'test_files.yaml']
 

--- a/lego/apps/flatpages/tests/test_api.py
+++ b/lego/apps/flatpages/tests/test_api.py
@@ -1,10 +1,9 @@
-from rest_framework.test import APITestCase
-
 from lego.apps.flatpages.models import Page
 from lego.apps.users.tests.utils import create_normal_user, create_super_user
+from lego.utils.test_utils import BaseAPITestCase
 
 
-class PageAPITestCase(APITestCase):
+class PageAPITestCase(BaseAPITestCase):
     fixtures = ['test_pages.yaml']
 
     def setUp(self):

--- a/lego/apps/followers/tests/test_views.py
+++ b/lego/apps/followers/tests/test_views.py
@@ -1,11 +1,11 @@
 from rest_framework import status
-from rest_framework.test import APITestCase
 
 from lego.apps.followers.models import FollowCompany, FollowEvent, FollowUser
 from lego.apps.users.models import User
+from lego.utils.test_utils import BaseAPITestCase
 
 
-class FollowEventViewTestCase(APITestCase):
+class FollowEventViewTestCase(BaseAPITestCase):
 
     fixtures = [
         'test_abakus_groups.yaml', 'test_users.yaml', 'test_companies.yaml', 'test_events.yaml',
@@ -55,7 +55,7 @@ class FollowEventViewTestCase(APITestCase):
         self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)
 
 
-class FollowUserViewTestCase(APITestCase):
+class FollowUserViewTestCase(BaseAPITestCase):
 
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml', 'test_followuser.yaml']
     url = '/api/v1/followers-user/'
@@ -102,7 +102,7 @@ class FollowUserViewTestCase(APITestCase):
         self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)
 
 
-class FollowCompanyViewTestCase(APITestCase):
+class FollowCompanyViewTestCase(BaseAPITestCase):
 
     fixtures = [
         'test_abakus_groups.yaml', 'test_users.yaml', 'test_companies.yaml',

--- a/lego/apps/frontpage/tests.py
+++ b/lego/apps/frontpage/tests.py
@@ -1,14 +1,14 @@
 from django.urls import reverse
-from rest_framework.test import APITestCase
 
 from lego.apps.users.models import AbakusGroup, User
+from lego.utils.test_utils import BaseAPITestCase
 
 
 def _get_frontpage():
     return reverse('api:v1:frontpage-list')
 
 
-class FrontpageAPITestCase(APITestCase):
+class FrontpageAPITestCase(BaseAPITestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_companies.yaml', 'test_users.yaml', 'test_events.yaml'
     ]

--- a/lego/apps/gallery/tests/test_views.py
+++ b/lego/apps/gallery/tests/test_views.py
@@ -1,14 +1,14 @@
 from unittest import mock
 
 from rest_framework import status
-from rest_framework.test import APITestCase
 
 from lego.apps.gallery.models import GalleryPicture
 from lego.apps.users.models import AbakusGroup, User
+from lego.utils.test_utils import BaseAPITestCase
 
 
 @mock.patch('lego.apps.files.fields.storage.generate_signed_url', return_value='signed_url')
-class GalleryViewSetTestCase(APITestCase):
+class GalleryViewSetTestCase(BaseAPITestCase):
 
     fixtures = [
         'test_abakus_groups.yaml', 'test_users.yaml', 'test_files.yaml', 'test_galleries.yaml',

--- a/lego/apps/health/tests/test_permissions.py
+++ b/lego/apps/health/tests/test_permissions.py
@@ -1,11 +1,12 @@
-from django.test import TestCase, override_settings
+from django.test import override_settings
 from django.test.client import RequestFactory
 
 from lego.apps.health.permissions import HealthPermission
+from lego.utils.test_utils import BaseTestCase
 
 
 @override_settings(HEALTH_CHECK_REMOTE_IPS=['129.241.', '127.0.0.'])
-class HealthPermissionTestCase(TestCase):
+class HealthPermissionTestCase(BaseTestCase):
     def setUp(self):
         self.factory = RequestFactory()
         self.permission_class = HealthPermission()

--- a/lego/apps/ical/tests/test_api.py
+++ b/lego/apps/ical/tests/test_api.py
@@ -143,7 +143,7 @@ class IcalAuthenticationTestCase(BaseAPITestCase):
             self.assertEqual(res.status_code, 401)
 
 
-class IcalPersonalTestCase(BaseAPITestCase:
+class IcalPersonalTestCase(BaseAPITestCase):
     fixtures = [
         'test_abakus_groups.yaml',
         'test_users.yaml',

--- a/lego/apps/ical/tests/test_api.py
+++ b/lego/apps/ical/tests/test_api.py
@@ -4,13 +4,13 @@ from datetime import timedelta
 from django.urls import reverse
 from django.utils import timezone
 from icalendar import Calendar
-from rest_framework.test import APITestCase
 
 from lego.apps.events.models import Event, Pool
 from lego.apps.ical.models import ICalToken
 from lego.apps.meetings.models import Meeting
 from lego.apps.permissions.constants import VIEW
 from lego.apps.users.models import AbakusGroup, User
+from lego.utils.test_utils import BaseAPITestCase
 
 
 def _get_token_url():
@@ -67,7 +67,7 @@ def _get_ical_events(url, client):
     return _get_ical(url, client).subcomponents
 
 
-class IcalAuthenticationTestCase(APITestCase):
+class IcalAuthenticationTestCase(BaseAPITestCase):
     fixtures = [
         'test_abakus_groups.yaml',
         'test_users.yaml',
@@ -143,7 +143,7 @@ class IcalAuthenticationTestCase(APITestCase):
             self.assertEqual(res.status_code, 401)
 
 
-class IcalPersonalTestCase(APITestCase):
+class IcalPersonalTestCase(BaseAPITestCase:
     fixtures = [
         'test_abakus_groups.yaml',
         'test_users.yaml',
@@ -177,7 +177,7 @@ class IcalPersonalTestCase(APITestCase):
         self.assertEqual(int(pk), meeting.pk)
 
 
-class IcalEventsTestCase(APITestCase):
+class IcalEventsTestCase(BaseAPITestCase):
     fixtures = [
         'test_abakus_groups.yaml',
         'test_users.yaml',
@@ -241,7 +241,7 @@ class IcalEventsTestCase(APITestCase):
             self.assertEqual(int(pk), self.event.pk)
 
 
-class ICalTokenGenerateTestCase(APITestCase):
+class ICalTokenGenerateTestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml']
 
     def setUp(self):
@@ -256,7 +256,7 @@ class ICalTokenGenerateTestCase(APITestCase):
         self.assertEqual(res.data['token'], token.token)
 
 
-class ICalTokenRegenerateTestCase(APITestCase):
+class ICalTokenRegenerateTestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml']
 
     def setUp(self):

--- a/lego/apps/ical/tests/test_models.py
+++ b/lego/apps/ical/tests/test_models.py
@@ -1,10 +1,9 @@
-from django.test import TestCase
-
 from lego.apps.ical.models import ICalToken
 from lego.apps.users.models import User
+from lego.utils.test_utils import BaseTestCase
 
 
-class TokenTestCase(TestCase):
+class TokenTestCase(BaseTestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_meetings.yaml', 'test_users.yaml']
 
     def setUp(self):

--- a/lego/apps/joblistings/tests/test_joblistings_api.py
+++ b/lego/apps/joblistings/tests/test_joblistings_api.py
@@ -2,10 +2,10 @@ from datetime import timedelta
 
 from django.urls import reverse
 from django.utils import timezone
-from rest_framework.test import APITestCase
 
 from lego.apps.joblistings.models import Joblisting
 from lego.apps.users.models import AbakusGroup, User
+from lego.utils.test_utils import BaseAPITestCase
 
 _test_joblistings_data = [
     {
@@ -67,7 +67,7 @@ def _get_detail_url(pk):
     return reverse('api:v1:joblisting-detail', kwargs={'pk': pk})
 
 
-class ListJoblistingsTestCase(APITestCase):
+class ListJoblistingsTestCase(BaseAPITestCase):
     fixtures = [
         'development_joblistings.yaml', 'test_users.yaml', 'development_companies.yaml',
         'test_abakus_groups.yaml'
@@ -105,7 +105,7 @@ class ListJoblistingsTestCase(APITestCase):
         self.assertEqual(len(joblisting_response.data['results']), 2)
 
 
-class RetrieveJoblistingsTestCase(APITestCase):
+class RetrieveJoblistingsTestCase(BaseAPITestCase):
     fixtures = [
         'development_joblistings.yaml', 'test_users.yaml', 'development_companies.yaml',
         'test_abakus_groups.yaml'
@@ -136,7 +136,7 @@ class RetrieveJoblistingsTestCase(APITestCase):
         self.assertEqual(joblisting_response.status_code, 200)
 
 
-class CreateJoblistingsTestCase(APITestCase):
+class CreateJoblistingsTestCase(BaseAPITestCase):
     fixtures = [
         'development_joblistings.yaml', 'test_users.yaml', 'development_companies.yaml',
         'test_abakus_groups.yaml'
@@ -166,7 +166,7 @@ class CreateJoblistingsTestCase(APITestCase):
         self.assertEqual(res.status_code, 403)
 
 
-class EditJoblistingsTestCase(APITestCase):
+class EditJoblistingsTestCase(BaseAPITestCase):
     fixtures = [
         'development_joblistings.yaml', 'test_users.yaml', 'development_companies.yaml',
         'test_abakus_groups.yaml'
@@ -205,7 +205,7 @@ class EditJoblistingsTestCase(APITestCase):
         self.assertEqual(res.status_code, 403)
 
 
-class DeleteJoblistingsTestCase(APITestCase):
+class DeleteJoblistingsTestCase(BaseAPITestCase):
     fixtures = [
         'development_joblistings.yaml', 'test_users.yaml', 'development_companies.yaml',
         'test_abakus_groups.yaml'

--- a/lego/apps/meetings/tests/test_api.py
+++ b/lego/apps/meetings/tests/test_api.py
@@ -1,9 +1,9 @@
 from django.urls import reverse
-from rest_framework.test import APITestCase
 
 from lego.apps.meetings import constants
 from lego.apps.meetings.models import Meeting
 from lego.apps.users.models import AbakusGroup, User
+from lego.utils.test_utils import BaseAPITestCase
 
 test_meeting_data = [
     {
@@ -28,7 +28,7 @@ def _get_invitations_list_url(pk):
     return reverse('api:v1:meeting-invitations-list', kwargs={'meeting_pk': pk})
 
 
-class CreateMeetingTestCase(APITestCase):
+class CreateMeetingTestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_meetings.yaml', 'test_users.yaml']
 
     def setUp(self):
@@ -50,7 +50,7 @@ class CreateMeetingTestCase(APITestCase):
         self.assertEqual(res.status_code, 403)
 
 
-class RetrieveMeetingTestCase(APITestCase):
+class RetrieveMeetingTestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_meetings.yaml', 'test_users.yaml']
 
     def setUp(self):
@@ -104,7 +104,7 @@ class RetrieveMeetingTestCase(APITestCase):
             self.assertEqual(len(no_answer), 1)
 
 
-class DeleteMeetingTestCase(APITestCase):
+class DeleteMeetingTestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_meetings.yaml', 'test_users.yaml']
 
     def setUp(self):
@@ -135,7 +135,7 @@ class DeleteMeetingTestCase(APITestCase):
         self.assertEqual(res.status_code, 404)
 
 
-class InviteToMeetingTestCase(APITestCase):
+class InviteToMeetingTestCase(BaseAPITestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_meetings.yaml', 'test_users.yaml', 'initial_files.yaml'
     ]
@@ -252,7 +252,7 @@ class InviteToMeetingTestCase(APITestCase):
             self.assertTrue(present)
 
 
-class UpdateInviteTestCase(APITestCase):
+class UpdateInviteTestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_meetings.yaml', 'test_users.yaml']
 
     def setUp(self):
@@ -305,7 +305,7 @@ class UpdateInviteTestCase(APITestCase):
         self.assertEqual(invite.user, me)
 
 
-class UnauthorizedTestCase(APITestCase):
+class UnauthorizedTestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_meetings.yaml', 'test_users.yaml']
 
     def setUp(self):

--- a/lego/apps/meetings/tests/test_models.py
+++ b/lego/apps/meetings/tests/test_models.py
@@ -1,10 +1,9 @@
-from django.test import TestCase
-
 from lego.apps.meetings.models import Meeting
 from lego.apps.users.models import User
+from lego.utils.test_utils import BaseTestCase
 
 
-class MeetingTestCase(TestCase):
+class MeetingTestCase(BaseTestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_meetings.yaml', 'test_users.yaml']
 
     def setUp(self):

--- a/lego/apps/meetings/tests/test_notifications.py
+++ b/lego/apps/meetings/tests/test_notifications.py
@@ -1,14 +1,13 @@
 from unittest.mock import patch
 
-from django.test import TestCase
-
 from lego.apps.meetings.models import Meeting
 from lego.apps.meetings.notifications import MeetingInvitationNotification
 from lego.apps.users.models import User
+from lego.utils.test_utils import BaseTestCase
 
 
 @patch('lego.utils.email.django_send_mail')
-class MeetingInvitationNotificationTestCase(TestCase):
+class MeetingInvitationNotificationTestCase(BaseTestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_meetings.yaml', 'test_users.yaml', 'initial_files.yaml'
     ]

--- a/lego/apps/notifications/tests/test_models.py
+++ b/lego/apps/notifications/tests/test_models.py
@@ -1,11 +1,10 @@
-from django.test import TestCase
-
 from lego.apps.notifications import constants
 from lego.apps.notifications.models import NotificationSetting
 from lego.apps.users.models import User
+from lego.utils.test_utils import BaseTestCase
 
 
-class NotificationSettingTestCase(TestCase):
+class NotificationSettingTestCase(BaseTestCase):
 
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml', 'test_notification_settings.yaml']
 

--- a/lego/apps/notifications/tests/test_views.py
+++ b/lego/apps/notifications/tests/test_views.py
@@ -1,11 +1,11 @@
 from rest_framework import status
-from rest_framework.test import APITestCase
 
 from lego.apps.notifications import constants
 from lego.apps.users.models import User
+from lego.utils.test_utils import BaseAPITestCase
 
 
-class NotificationSettingsViewSetTestCase(APITestCase):
+class NotificationSettingsViewSetTestCase(BaseAPITestCase):
 
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml', 'test_notification_settings.yaml']
 

--- a/lego/apps/oauth/tests/test_models.py
+++ b/lego/apps/oauth/tests/test_models.py
@@ -1,10 +1,10 @@
-from django.test import TestCase
 from oauth2_provider.models import Application
 
 from lego.apps.oauth.models import APIApplication
+from lego.utils.test_utils import BaseTestCase
 
 
-class APIApplicationTestCase(TestCase):
+class APIApplicationTestCase(BaseTestCase):
     fixtures = ['test_users.yaml', 'test_applications.yaml']
 
     def test_initial_application(self):

--- a/lego/apps/oauth/tests/test_views.py
+++ b/lego/apps/oauth/tests/test_views.py
@@ -1,11 +1,11 @@
 from oauth2_provider.models import AccessToken
 from rest_framework import status
-from rest_framework.test import APITestCase
 
 from lego.apps.users.models import AbakusGroup, Membership, User
+from lego.utils.test_utils import BaseAPITestCase
 
 
-class OauthViewsTestCase(APITestCase):
+class OauthViewsTestCase(BaseAPITestCase):
 
     fixtures = ['test_users.yaml', 'test_applications.yaml', 'test_access_tokens.yaml']
 
@@ -45,7 +45,7 @@ class OauthViewsTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
 
-class OauthApplicationViewsTestCase(APITestCase):
+class OauthApplicationViewsTestCase(BaseAPITestCase):
 
     fixtures = [
         'test_users.yaml', 'test_abakus_groups.yaml', 'test_applications.yaml',

--- a/lego/apps/permissions/tests/test_backends.py
+++ b/lego/apps/permissions/tests/test_backends.py
@@ -1,11 +1,10 @@
-from django.test import TestCase
-
 from lego.apps.events.models import Event
 from lego.apps.permissions.constants import EDIT, LIST
 from lego.apps.users.models import AbakusGroup, User
+from lego.utils.test_utils import BaseTestCase
 
 
-class AbakusBackendTestCase(TestCase):
+class AbakusBackendTestCase(BaseTestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml']
 
     def setUp(self):

--- a/lego/apps/permissions/tests/test_keyword.py
+++ b/lego/apps/permissions/tests/test_keyword.py
@@ -1,10 +1,9 @@
-from django.test import TestCase
-
 from lego.apps.permissions.keyword import KeywordPermissions
 from lego.apps.users.models import AbakusGroup, User
+from lego.utils.test_utils import BaseTestCase
 
 
-class KeywordPermissionsTestCase(TestCase):
+class KeywordPermissionsTestCase(BaseTestCase):
 
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml']
 

--- a/lego/apps/permissions/tests/test_model.py
+++ b/lego/apps/permissions/tests/test_model.py
@@ -1,12 +1,11 @@
-from django.test import TestCase
-
 from lego.apps.permissions.constants import EDIT
 from lego.apps.permissions.models import ObjectPermissionsModel
 from lego.apps.permissions.tests.models import TestModel
 from lego.apps.users.models import AbakusGroup, User
+from lego.utils.test_utils import BaseTestCase
 
 
-class ObjectPermissionsModelTestCase(TestCase):
+class ObjectPermissionsModelTestCase(BaseTestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml']
 
     def setUp(self):

--- a/lego/apps/permissions/tests/test_permissions.py
+++ b/lego/apps/permissions/tests/test_permissions.py
@@ -1,11 +1,12 @@
-from rest_framework.test import APIRequestFactory, APITestCase, force_authenticate
+from rest_framework.test import APIRequestFactory, force_authenticate
 
 from lego.apps.permissions.tests.models import TestModel
 from lego.apps.permissions.tests.view import TestViewSet
 from lego.apps.users.models import AbakusGroup, User
+from lego.utils.test_utils import BaseAPITestCase
 
 
-class PermissionTestCase(APITestCase):
+class PermissionTestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml']
 
     test_update_object = {'name': 'new_test_object'}

--- a/lego/apps/permissions/tests/test_validators.py
+++ b/lego/apps/permissions/tests/test_validators.py
@@ -1,10 +1,10 @@
 from django.core.exceptions import ValidationError
-from django.test import TestCase
 
 from lego.apps.permissions.validators import KeywordPermissionValidator
+from lego.utils.test_utils import BaseTestCase
 
 
-class KeywordPermissionValidatorTestCase(TestCase):
+class KeywordPermissionValidatorTestCase(BaseTestCase):
     def test_regex_validator_non_letters(self):
         validator = KeywordPermissionValidator()
         self.assertRaises(ValidationError, validator.__call__, '/1234/')

--- a/lego/apps/quotes/tests/test_api_quotes.py
+++ b/lego/apps/quotes/tests/test_api_quotes.py
@@ -1,9 +1,9 @@
 from django.urls import reverse
 from rest_framework import status
-from rest_framework.test import APITestCase
 
 from lego.apps.quotes.models import Quote
 from lego.apps.users.models import AbakusGroup, User
+from lego.utils.test_utils import BaseAPITestCase
 
 
 def _get_list_url():
@@ -30,7 +30,7 @@ def _get_unapprove_url(pk):
     return reverse('api:v1:quote-unapprove', kwargs={'pk': pk})
 
 
-class QuoteViewSetTestCase(APITestCase):
+class QuoteViewSetTestCase(BaseAPITestCase):
     fixtures = ['test_users.yaml', 'test_abakus_groups.yaml', 'test_quotes.yaml']
 
     def setUp(self):

--- a/lego/apps/quotes/tests/test_models.py
+++ b/lego/apps/quotes/tests/test_models.py
@@ -1,10 +1,9 @@
-from django.test import TestCase
-
 from lego.apps.quotes.models import Quote
 from lego.apps.users.models import AbakusGroup, User
+from lego.utils.test_utils import BaseTestCase
 
 
-class QuoteMethodTest(TestCase):
+class QuoteMethodTest(BaseTestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml', 'test_quotes.yaml']
 
     def setUp(self):

--- a/lego/apps/reactions/tests/test_api.py
+++ b/lego/apps/reactions/tests/test_api.py
@@ -1,10 +1,10 @@
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
-from rest_framework.test import APITestCase
 
 from lego.apps.articles.models import Article
 from lego.apps.reactions.models import Reaction, ReactionType
 from lego.apps.users.models import AbakusGroup, User
+from lego.utils.test_utils import BaseAPITestCase
 
 
 def _get_list_url():
@@ -15,7 +15,7 @@ def _get_detail_url(pk):
     return reverse('api:v1:reaction-detail', kwargs={'pk': pk})
 
 
-class CreateReactionsAPITestCase(APITestCase):
+class CreateReactionsAPITestCase(BaseAPITestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_users.yaml', 'test_reaction_types.yaml',
         'test_articles.yaml'
@@ -66,7 +66,7 @@ class CreateReactionsAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 400)
 
 
-class DeleteReactionsAPITestCase(APITestCase):
+class DeleteReactionsAPITestCase(BaseAPITestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_users.yaml', 'test_reaction_types.yaml',
         'test_articles.yaml'

--- a/lego/apps/restricted/tests/test_message.py
+++ b/lego/apps/restricted/tests/test_message.py
@@ -1,11 +1,10 @@
 from email.message import Message
 
-from django.test import TestCase
-
 from lego.apps.restricted.message import EmailMessage
+from lego.utils.test_utils import BaseTestCase
 
 
-class MessageTestCase(TestCase):
+class MessageTestCase(BaseTestCase):
     def setUp(self):
         self.message = EmailMessage(recipient='recipient', sender='sender', message=Message())
 

--- a/lego/apps/restricted/tests/test_models.py
+++ b/lego/apps/restricted/tests/test_models.py
@@ -1,13 +1,12 @@
-from django.test import TestCase
-
 from lego.apps.events.tests.utils import get_dummy_users
 from lego.apps.notifications.constants import EMAIL, PUSH, WEEKLY_MAIL
 from lego.apps.notifications.models import NotificationSetting
 from lego.apps.restricted.models import RestrictedMail
 from lego.apps.users.models import AbakusGroup
+from lego.utils.test_utils import BaseTestCase
 
 
-class RestrictedMailModelTestCase(TestCase):
+class RestrictedMailModelTestCase(BaseTestCase):
 
     fixtures = [
         'test_abakus_groups.yaml', 'test_users.yaml', 'test_companies.yaml', 'test_events.yaml',

--- a/lego/apps/restricted/tests/test_parser.py
+++ b/lego/apps/restricted/tests/test_parser.py
@@ -1,14 +1,14 @@
 from email.message import Message
 
 from django.conf import settings
-from django.test import TestCase
 
 from lego.apps.restricted.parser import EmailParser, ParserMessageType
+from lego.utils.test_utils import BaseTestCase
 
 from .utils import read_file
 
 
-class EmailParserTestCase(TestCase):
+class EmailParserTestCase(BaseTestCase):
     def test_parse_valid_email(self):
         """Try to parse a valid message, make sure we add the correct properties to the message."""
         raw_message = read_file(f'{settings.BASE_DIR}/apps/restricted/fixtures/emails/valid.txt')

--- a/lego/apps/restricted/tests/test_processor.py
+++ b/lego/apps/restricted/tests/test_processor.py
@@ -2,15 +2,16 @@ from unittest import mock
 
 from django.conf import settings
 from django.core import mail
-from django.test import TestCase, override_settings
+from django.test import override_settings
 
 from lego.apps.restricted.message_processor import MessageProcessor
 from lego.apps.restricted.models import RestrictedMail
 from lego.apps.restricted.parser import EmailParser, ParserMessageType
 from lego.apps.restricted.tests.utils import read_file
+from lego.utils.test_utils import BaseTestCase
 
 
-class MessageProcessorTestCase(TestCase):
+class MessageProcessorTestCase(BaseTestCase):
 
     fixtures = [
         'test_abakus_groups.yaml', 'test_users.yaml', 'test_companies.yaml', 'test_events.yaml',

--- a/lego/apps/restricted/tests/test_utils.py
+++ b/lego/apps/restricted/tests/test_utils.py
@@ -1,13 +1,13 @@
 from django.conf import settings
-from django.test import TestCase
 
 from lego.apps.restricted.parser import EmailParser, ParserMessageType
 from lego.apps.restricted.utils import get_mail_token
+from lego.utils.test_utils import BaseTestCase
 
 from .utils import read_file
 
 
-class EmailTokenTestCase(TestCase):
+class EmailTokenTestCase(BaseTestCase):
     def test_parse_valid_message(self):
         """Try to parse a valid message and make sure ve remove the token payload"""
         raw_message = read_file(f'{settings.BASE_DIR}/apps/restricted/fixtures/emails/valid.txt')

--- a/lego/apps/restricted/tests/test_views.py
+++ b/lego/apps/restricted/tests/test_views.py
@@ -1,11 +1,11 @@
 from rest_framework import status
-from rest_framework.test import APITestCase
 
 from lego.apps.restricted.models import RestrictedMail
 from lego.apps.users.models import AbakusGroup, User
+from lego.utils.test_utils import BaseAPITestCase
 
 
-class RestrictedViewTestCase(APITestCase):
+class RestrictedViewTestCase(BaseAPITestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_users.yaml', 'test_companies.yaml', 'test_events.yaml',
         'test_restricted_mails.yaml'

--- a/lego/apps/slack/tests/test_views.py
+++ b/lego/apps/slack/tests/test_views.py
@@ -1,13 +1,13 @@
 from unittest import mock
 
 from rest_framework import status
-from rest_framework.test import APITestCase
 
 from lego.apps.slack.utils import SlackException
 from lego.apps.users.models import User
+from lego.utils.test_utils import BaseAPITestCase
 
 
-class SlackInviteTestCase(APITestCase):
+class SlackInviteTestCase(BaseAPITestCase):
 
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml']
 

--- a/lego/apps/tags/tests/test_api.py
+++ b/lego/apps/tags/tests/test_api.py
@@ -1,12 +1,11 @@
-from rest_framework.test import APITestCase
-
 import lego.apps.events.tests.test_events_api as event_api
 from lego.apps.events.models import Event
 from lego.apps.tags.models import Tag
 from lego.apps.users.models import User
+from lego.utils.test_utils import BaseAPITestCase
 
 
-class TagsTestCase(APITestCase):
+class TagsTestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_tags_data.yaml', 'initial_tags.yaml']
 
     def setUp(self):

--- a/lego/apps/users/tests/test_abakusgroup_api.py
+++ b/lego/apps/users/tests/test_abakusgroup_api.py
@@ -1,5 +1,4 @@
 from django.urls import reverse
-from rest_framework.test import APITestCase
 
 from lego.apps.users import constants
 from lego.apps.users.constants import LEADER
@@ -7,6 +6,7 @@ from lego.apps.users.models import AbakusGroup, User
 from lego.apps.users.serializers.abakus_groups import (
     DetailedAbakusGroupSerializer, PublicAbakusGroupSerializer
 )
+from lego.utils.test_utils import BaseAPITestCase
 
 _test_group_data = {
     'name': 'testgroup',
@@ -35,7 +35,7 @@ def _get_detail_url(pk):
     return reverse('api:v1:abakusgroup-detail', kwargs={'pk': pk})
 
 
-class ListAbakusGroupAPITestCase(APITestCase):
+class ListAbakusGroupAPITestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml']
 
     def setUp(self):
@@ -61,7 +61,7 @@ class ListAbakusGroupAPITestCase(APITestCase):
         self.successful_list(self.user)
 
 
-class RetrieveAbakusGroupAPITestCase(APITestCase):
+class RetrieveAbakusGroupAPITestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml']
 
     def setUp(self):
@@ -116,7 +116,7 @@ class RetrieveAbakusGroupAPITestCase(APITestCase):
         self.assertEqual(keys, set(PublicAbakusGroupSerializer.Meta.fields))
 
 
-class CreateAbakusGroupAPITestCase(APITestCase):
+class CreateAbakusGroupAPITestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml']
 
     def setUp(self):
@@ -173,7 +173,7 @@ class CreateAbakusGroupAPITestCase(APITestCase):
         )
 
 
-class UpdateAbakusGroupAPITestCase(APITestCase):
+class UpdateAbakusGroupAPITestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml']
 
     def setUp(self):
@@ -223,7 +223,7 @@ class UpdateAbakusGroupAPITestCase(APITestCase):
         self.successful_update(self.leader)
 
 
-class InterestGroupAPITestCase(APITestCase):
+class InterestGroupAPITestCase(BaseAPITestCase):
     fixtures = ['initial_files.yaml', 'test_abakus_groups.yaml', 'test_users.yaml']
 
     def setUp(self):

--- a/lego/apps/users/tests/test_membership_history.py
+++ b/lego/apps/users/tests/test_membership_history.py
@@ -1,11 +1,11 @@
 from rest_framework import status
-from rest_framework.test import APITestCase
 
 from lego.apps.users.constants import GROUP_OTHER
 from lego.apps.users.models import AbakusGroup, User
+from lego.utils.test_utils import BaseAPITestCase
 
 
-class MembershipHistoryViewSetTestCase(APITestCase):
+class MembershipHistoryViewSetTestCase(BaseAPITestCase):
 
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml']
 

--- a/lego/apps/users/tests/test_models.py
+++ b/lego/apps/users/tests/test_models.py
@@ -1,17 +1,17 @@
 from datetime import timedelta
 from unittest import mock
 
-from django.test import TestCase, override_settings
+from django.test import override_settings
 
 from lego.apps.events.models import Event
 from lego.apps.files.models import File
 from lego.apps.users import constants
 from lego.apps.users.models import AbakusGroup, Membership, Penalty, User
 from lego.apps.users.registrations import Registrations
-from lego.utils.test_utils import fake_time
+from lego.utils.test_utils import BaseTestCase, fake_time
 
 
-class AbakusGroupTestCase(TestCase):
+class AbakusGroupTestCase(BaseTestCase):
     fixtures = ['test_abakus_groups.yaml']
 
     def setUp(self):
@@ -23,7 +23,7 @@ class AbakusGroupTestCase(TestCase):
         self.assertEqual(self.non_committee, found_group)
 
 
-class AbakusGroupHierarchyTestCase(TestCase):
+class AbakusGroupHierarchyTestCase(BaseTestCase):
     fixtures = ['initial_files.yaml', 'initial_abakus_groups.yaml']
 
     def setUp(self):
@@ -81,7 +81,7 @@ class AbakusGroupHierarchyTestCase(TestCase):
         self.assertEqual(set(AbakusGroup.objects.all()), union)
 
 
-class UserTestCase(TestCase):
+class UserTestCase(BaseTestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml', 'test_files.yaml']
 
     def setUp(self):
@@ -185,7 +185,7 @@ class UserTestCase(TestCase):
         self.assertNotEqual(token['member'], False)
 
 
-class MembershipTestCase(TestCase):
+class MembershipTestCase(BaseTestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml']
 
     def setUp(self):
@@ -211,7 +211,7 @@ class MembershipTestCase(TestCase):
         self.assertEqual(self.test_membership, found_membership)
 
 
-class PenaltyTestCase(TestCase):
+class PenaltyTestCase(BaseTestCase):
     fixtures = [
         'test_users.yaml', 'test_abakus_groups.yaml', 'test_companies.yaml', 'test_events.yaml'
     ]

--- a/lego/apps/users/tests/test_password_change.py
+++ b/lego/apps/users/tests/test_password_change.py
@@ -1,11 +1,11 @@
 from django.contrib.auth import authenticate
 from rest_framework import status
-from rest_framework.test import APITestCase
 
 from lego.apps.users.models import User
+from lego.utils.test_utils import BaseAPITestCase
 
 
-class TestPasswordChange(APITestCase):
+class TestPasswordChange(BaseAPITestCase):
 
     fixtures = ['test_users.yaml']
 

--- a/lego/apps/users/tests/test_registration_api.py
+++ b/lego/apps/users/tests/test_registration_api.py
@@ -1,9 +1,9 @@
 from unittest import mock
 
 from django.urls import reverse
-from rest_framework.test import APITestCase
 
 from lego.apps.users.registrations import Registrations
+from lego.utils.test_utils import BaseAPITestCase
 
 
 def _get_list_url():
@@ -14,7 +14,7 @@ def _get_registration_token_url(token):
     return f'{_get_list_url()}?token={token}'
 
 
-class RetrieveRegistrationAPITestCase(APITestCase):
+class RetrieveRegistrationAPITestCase(BaseAPITestCase):
     def test_without_token(self):
         response = self.client.get(_get_list_url())
         self.assertEqual(response.status_code, 400)
@@ -37,7 +37,7 @@ class RetrieveRegistrationAPITestCase(APITestCase):
         self.assertEqual(response.data.get('email'), 'test1@user.com')
 
 
-class CreateRegistrationAPITestCase(APITestCase):
+class CreateRegistrationAPITestCase(BaseAPITestCase):
 
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml']
 

--- a/lego/apps/users/tests/test_student_confirmation_api.py
+++ b/lego/apps/users/tests/test_student_confirmation_api.py
@@ -1,11 +1,11 @@
 from unittest import mock
 
 from django.urls import reverse
-from rest_framework.test import APITestCase
 
 from lego.apps.users import constants
 from lego.apps.users.models import AbakusGroup, User
 from lego.apps.users.registrations import Registrations
+from lego.utils.test_utils import BaseAPITestCase
 
 
 def _get_list_request_url():
@@ -24,7 +24,7 @@ def _get_student_confirmation_token_perform_url(token):
     return f'{_get_list_perform_url()}?token={token}'
 
 
-class RetrieveStudentConfirmationAPITestCase(APITestCase):
+class RetrieveStudentConfirmationAPITestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml']
 
     def setUp(self):
@@ -84,7 +84,7 @@ class RetrieveStudentConfirmationAPITestCase(APITestCase):
         self.assertEqual(response.data.get('member'), True)
 
 
-class CreateStudentConfirmationAPITestCase(APITestCase):
+class CreateStudentConfirmationAPITestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml']
 
     _test_student_confirmation_data = {
@@ -205,7 +205,7 @@ class CreateStudentConfirmationAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 204)
 
 
-class UpdateStudentConfirmationAPITestCase(APITestCase):
+class UpdateStudentConfirmationAPITestCase(BaseAPITestCase):
     fixtures = ['initial_files.yaml', 'initial_abakus_groups.yaml', 'test_users.yaml']
 
     def setUp(self):

--- a/lego/apps/users/tests/test_users_api.py
+++ b/lego/apps/users/tests/test_users_api.py
@@ -4,14 +4,13 @@ from unittest import mock
 from django.contrib.auth import authenticate
 from django.urls import reverse
 from rest_framework import status
-from rest_framework.test import APITestCase
 
 from lego.apps.events.models import Event
 from lego.apps.users import constants
 from lego.apps.users.models import AbakusGroup, Penalty, User
 from lego.apps.users.registrations import Registrations
 from lego.apps.users.serializers.users import MeSerializer
-from lego.utils.test_utils import fake_time
+from lego.utils.test_utils import BaseAPITestCase, fake_time
 
 _test_user_data = {
     'username': 'new_testuser',
@@ -41,7 +40,7 @@ def get_test_user():
     return user
 
 
-class ListUsersAPITestCase(APITestCase):
+class ListUsersAPITestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml']
 
     def setUp(self):
@@ -75,7 +74,7 @@ class ListUsersAPITestCase(APITestCase):
         self.successful_list(self.with_permission)
 
 
-class RetrieveUsersAPITestCase(APITestCase):
+class RetrieveUsersAPITestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml']
 
     def setUp(self):
@@ -111,7 +110,7 @@ class RetrieveUsersAPITestCase(APITestCase):
         self.successful_retrieve(self.with_perm)
 
 
-class CreateUsersAPITestCase(APITestCase):
+class CreateUsersAPITestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml']
 
     _test_registration_data = {
@@ -223,7 +222,7 @@ class CreateUsersAPITestCase(APITestCase):
         self.assertTrue(authenticate(username='test_username', password='TestPassord'))
 
 
-class UpdateUsersAPITestCase(APITestCase):
+class UpdateUsersAPITestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml']
 
     modified_user = {
@@ -331,7 +330,7 @@ class UpdateUsersAPITestCase(APITestCase):
         self.successful_update(user, user)
 
 
-class DeleteUsersAPITestCase(APITestCase):
+class DeleteUsersAPITestCase(BaseAPITestCase):
     fixtures = ['test_abakus_groups.yaml', 'test_users.yaml']
 
     _test_user_data = {
@@ -370,7 +369,7 @@ class DeleteUsersAPITestCase(APITestCase):
         self.successful_delete(self.with_perm)
 
 
-class RetrieveSelfTestCase(APITestCase):
+class RetrieveSelfTestCase(BaseAPITestCase):
     fixtures = [
         'test_abakus_groups.yaml', 'test_users.yaml', 'test_companies.yaml', 'test_events.yaml'
     ]

--- a/lego/settings/test.py
+++ b/lego/settings/test.py
@@ -3,10 +3,23 @@ import os
 
 import stripe
 from cassandra import ConsistencyLevel
+from django.db import connection
 
 from .base import CASSANDRA_DRIVER_KWARGS, CHANNEL_LAYERS, INSTALLED_APPS
 
 logging.disable(logging.CRITICAL)
+
+# Disable migrations for all apps:
+MIGRATION_MODULES = {
+    'auth': None,
+    'contenttypes': None,
+    'default': None,
+    'sessions': None,
+    'tests': None,
+}
+
+for app in INSTALLED_APPS:
+    MIGRATION_MODULES[app.split('.')[-1]] = None
 
 DEBUG = False
 SERVER_URL = 'http://127.0.0.1:8000'
@@ -15,6 +28,9 @@ SERVER_EMAIL = 'Abakus Webkom <webkom@abakus.no>'
 
 SECRET_KEY = 'secret'
 stripe.api_key = os.environ.get('STRIPE_TEST_KEY')
+
+# Work-around for a weird bug where the tests would crash with -v=3 (verbosity):
+OAUTH2_PROVIDER_ACCESS_TOKEN_MODEL = 'oauth2_provider.AccessToken'
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 

--- a/lego/settings/test.py
+++ b/lego/settings/test.py
@@ -3,7 +3,6 @@ import os
 
 import stripe
 from cassandra import ConsistencyLevel
-from django.db import connection
 
 from .base import CASSANDRA_DRIVER_KWARGS, CHANNEL_LAYERS, INSTALLED_APPS
 

--- a/lego/settings/test.py
+++ b/lego/settings/test.py
@@ -8,17 +8,18 @@ from .base import CASSANDRA_DRIVER_KWARGS, CHANNEL_LAYERS, INSTALLED_APPS
 
 logging.disable(logging.CRITICAL)
 
-# Disable migrations for all apps:
-MIGRATION_MODULES = {
-    'auth': None,
-    'contenttypes': None,
-    'default': None,
-    'sessions': None,
-    'tests': None,
-}
+# Disable migrations for all apps (not on CI):
+if 'DRONE' not in os.environ:
+    MIGRATION_MODULES = {
+        'auth': None,
+        'contenttypes': None,
+        'default': None,
+        'sessions': None,
+        'tests': None,
+    }
 
-for app in INSTALLED_APPS:
-    MIGRATION_MODULES[app.split('.')[-1]] = None
+    for app in INSTALLED_APPS:
+        MIGRATION_MODULES[app.split('.')[-1]] = None
 
 DEBUG = False
 SERVER_URL = 'http://127.0.0.1:8000'

--- a/lego/utils/test_utils.py
+++ b/lego/utils/test_utils.py
@@ -1,8 +1,49 @@
+from unittest.mock import patch
+
 from django.test import TestCase
 from django.utils import timezone
+from rest_framework.test import APITestCase, APITransactionTestCase
 
 
-class ViewTestCase(TestCase):
+class BaseTestCase(TestCase):
+    """
+    Normally we don't want to hit Cassandra in tests, so we mock out add_activity in most tests
+    to avoid this. If you want to test something using Cassandra, override FeedTestBase instead.
+    """
+
+    def _pre_setup(self):
+        super()._pre_setup()
+        self._add_activity_mock = patch('lego.apps.feed.feed_manager.feed_manager.add_activity')
+        self._add_activity_mock.start()
+
+    def _post_teardown(self):
+        super()._post_teardown()
+        self._add_activity_mock.stop()
+
+
+class BaseAPITestCase(APITestCase):
+    def _pre_setup(self):
+        super()._pre_setup()
+        self._add_activity_mock = patch('lego.apps.feed.feed_manager.feed_manager.add_activity')
+        self._add_activity_mock.start()
+
+    def _post_teardown(self):
+        super()._post_teardown()
+        self._add_activity_mock.stop()
+
+
+class BaseAPITransactionTestCase(APITransactionTestCase):
+    def _pre_setup(self):
+        super()._pre_setup()
+        self._add_activity_mock = patch('lego.apps.feed.feed_manager.feed_manager.add_activity')
+        self._add_activity_mock.start()
+
+    def _post_teardown(self):
+        super()._post_teardown()
+        self._add_activity_mock.stop()
+
+
+class ViewTestCase(BaseTestCase):
     def assertStatusCode(self, response, code=200):
         self.assertEqual(response.status_code, code)
 

--- a/lego/utils/tests/test_content_types.py
+++ b/lego/utils/tests/test_content_types.py
@@ -1,12 +1,11 @@
 from unittest import mock
 
-from django.test import TestCase
-
 from lego.apps.users.models import User
 from lego.utils import content_types
+from lego.utils.test_utils import BaseTestCase
 
 
-class ContentTypesTestCase(TestCase):
+class ContentTypesTestCase(BaseTestCase):
     def setUp(self):
         self.instance = mock.Mock()
         self.instance.pk = '10'

--- a/lego/utils/tests/test_models.py
+++ b/lego/utils/tests/test_models.py
@@ -1,11 +1,10 @@
 from unittest import mock
 
-from django.test import TestCase
-
 from lego.utils.models import PersistentModel, TimeStampModel
+from lego.utils.test_utils import BaseTestCase
 
 
-class TimeStampModelTestCase(TestCase):
+class TimeStampModelTestCase(BaseTestCase):
     def setUp(self):
         self.instance = TimeStampModel()
 
@@ -17,7 +16,7 @@ class TimeStampModelTestCase(TestCase):
         mock_save.assert_called_once_with()
 
 
-class PersistentModelTestCase(TestCase):
+class PersistentModelTestCase(BaseTestCase):
     def setUp(self):
         self.instance = PersistentModel()
 

--- a/lego/utils/tests/test_renderers.py
+++ b/lego/utils/tests/test_renderers.py
@@ -1,9 +1,8 @@
-from django.test import TestCase
-
 from lego.utils.renderers import JSONRenderer
+from lego.utils.test_utils import BaseTestCase
 
 
-class JSONRendererTestCase(TestCase):
+class JSONRendererTestCase(BaseTestCase):
     def setUp(self):
         self.renderer = JSONRenderer()
 

--- a/lego/utils/tests/test_views.py
+++ b/lego/utils/tests/test_views.py
@@ -1,10 +1,10 @@
 from rest_framework import status
-from rest_framework.test import APITestCase
 
 from lego.apps.users.models import User
+from lego.utils.test_utils import BaseAPITestCase
 
 
-class SiteMetaViewSetTestCase(APITestCase):
+class SiteMetaViewSetTestCase(BaseAPITestCase):
 
     fixtures = ['test_users.yaml']
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,1 +1,3 @@
 -r base.txt
+# Stack traces for --parallel tests:
+tblib


### PR DESCRIPTION
This makes it possible to run most tests (not the Cassandra ones) in parallel by running: `python manage.py test --parallel --exclude-tag feed`. This makes the 637 non-feed tests run in ~35 seconds, instead of 100 seconds on my machine. To be able to run the rest of the tests in parallel as well we'll have to figure out how to isolate the different test processes to different Cassandra key spaces.

It does so by adding a few new base test classes that mock out Cassandra, and forces tests that want to hit Cassandra to inherit `FeedTestBase`. This also stops a bunch of tests that didn't need to hit Cassandra from doing so.

It also disables migrations in tests, which speeds up the initial test load time.
