### PR TITLE
 Add filter to Survey for finding a user's Submission, plus more Submission tests

### DIFF
--- a/lego/apps/surveys/filters.py
+++ b/lego/apps/surveys/filters.py
@@ -1,0 +1,11 @@
+from django_filters import CharFilter, FilterSet
+
+from lego.apps.surveys.models import Submission
+
+
+class SubmissionFilterSet(FilterSet):
+    user = CharFilter('user')
+
+    class Meta:
+        model = Submission
+        fields = ('user', )

--- a/lego/apps/surveys/tests/test_surveys_api.py
+++ b/lego/apps/surveys/tests/test_surveys_api.py
@@ -233,7 +233,6 @@ class SurveyViewSetTestCase(APITestCase):
 
         # Then test that old questions get deleted when not included, and that new ones are added
         response = self.client.patch(_get_detail_url(1), _test_surveys[2])
-        response.render()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response_questions = response.data['questions']

--- a/lego/apps/surveys/views.py
+++ b/lego/apps/surveys/views.py
@@ -1,6 +1,7 @@
 from rest_framework import viewsets
 
 from lego.apps.permissions.api.views import AllowedPermissionsMixin
+from lego.apps.surveys.filters import SubmissionFilterSet
 from lego.apps.surveys.models import Submission, Survey
 from lego.apps.surveys.permissions import SubmissionPermissions, SurveyPermissions
 from lego.apps.surveys.serializers import (
@@ -26,6 +27,7 @@ class SurveyViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
 class SubmissionViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
     queryset = Submission.objects.all()
     permission_classes = [SubmissionPermissions]
+    filter_class = SubmissionFilterSet
 
     def get_queryset(self):
         survey_id = self.kwargs['survey_pk']


### PR DESCRIPTION
Adds a filter to Survey (more specifically, Submissions) that lets you find a submission from a particular user: `/surveys/someID/submissions/?user=1`

Used to determine whether the user should see a "You have already answered this survey" page or not. If they should, I figured it was nice to let them see what they answered on that page. Implemented front-end in https://github.com/webkom/lego-webapp/pull/1116.

Also adds a test to make sure answering surveys works as intended, along with some bugfixes.