### PR TITLE
Add user id to stripe charge metadata

### DIFF
--- a/lego/apps/events/tasks.py
+++ b/lego/apps/events/tasks.py
@@ -127,8 +127,9 @@ def async_payment(self, registration_id, token, logger_context=None):
             amount=event.get_price(self.registration.user), currency='NOK', source=token,
             description=event.slug, metadata={
                 'EVENT_ID': event.id,
+                'USER_ID': self.registration.user.id,
                 'USER': self.registration.user.full_name,
-                'EMAIL': self.registration.user.email
+                'EMAIL': self.registration.user.email,
             }
         )
         log.info('stripe_payment_success', registration_id=self.registration.id)


### PR DESCRIPTION
This makes it easier to track charges in our analytics platform.

Fixes #981