### PR TITLE
Pin boto3 to version 1.6

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,7 @@ elasticsearch==6.1.1
 celery==4.1.0
 stripe==1.79.1
 structlog==18.1.0
-boto3==1.6.9
+boto3==1.6
 cassandra-driver==3.13
 bs4==0.0.1
 bleach==2.1.3


### PR DESCRIPTION
Since our tests never hit AWS we're never gonna see test failures from non-breaking changes to boto3, so might as well leave it pinned to a slightly more relaxed version to save us some upgrade noise.