### PR TITLE
Include registration_count in event detail serializer

### DIFF
--- a/lego/apps/events/serializers/events.py
+++ b/lego/apps/events/serializers/events.py
@@ -81,7 +81,7 @@ class EventReadDetailedSerializer(TagSerializerMixin, BasisModelSerializer):
             'unregistration_deadline', 'company', 'responsible_group', 'active_capacity',
             'feedback_description', 'feedback_required', 'is_priced', 'price_member', 'price_guest',
             'use_stripe', 'payment_due_date', 'use_captcha', 'waiting_registration_count', 'tags',
-            'is_merged', 'heed_penalties', 'created_by', 'is_abakom_only'
+            'is_merged', 'heed_penalties', 'created_by', 'is_abakom_only', 'registration_count'
         )
         read_only = True
 


### PR DESCRIPTION
Couldn't think of a reason not to have it there, since it was in the list serializer.