### PR TITLE
ObjectPermission serializer + Gallery permissions

### DIFF
--- a/lego/apps/articles/serializers.py
+++ b/lego/apps/articles/serializers.py
@@ -4,7 +4,6 @@ from lego.apps.articles.models import Article
 from lego.apps.comments.serializers import CommentSerializer
 from lego.apps.content.fields import ContentSerializerField
 from lego.apps.files.fields import ImageField
-from lego.apps.reactions.serializers import GroupedReactionSerializer, ReactionSerializer
 from lego.apps.tags.serializers import TagSerializerMixin
 from lego.apps.users.serializers.users import PublicUserSerializer
 from lego.utils.serializers import BasisModelSerializer, ObjectPermissionsSerializerMixin
@@ -13,17 +12,15 @@ from lego.utils.serializers import BasisModelSerializer, ObjectPermissionsSerial
 class DetailedArticleSerializer(TagSerializerMixin, BasisModelSerializer):
     author = PublicUserSerializer(read_only=True, source='created_by')
     comments = CommentSerializer(read_only=True, many=True)
-    reactions = ReactionSerializer(read_only=True, many=True)
     cover = ImageField(required=False, options={'height': 500})
-    reactions_grouped = GroupedReactionSerializer(read_only=True, many=True)
     comment_target = CharField(read_only=True)
     content = ContentSerializerField(source='text')
 
     class Meta:
         model = Article
         fields = (
-            'id', 'title', 'cover', 'author', 'description', 'comments', 'comment_target',
-            'reactions', 'reactions_grouped', 'tags', 'content', 'created_at', 'pinned'
+            'id', 'title', 'cover', 'author', 'description', 'comments', 'comment_target', 'tags',
+            'content', 'created_at', 'pinned'
         )
 
 

--- a/lego/apps/articles/serializers.py
+++ b/lego/apps/articles/serializers.py
@@ -7,7 +7,7 @@ from lego.apps.files.fields import ImageField
 from lego.apps.reactions.serializers import GroupedReactionSerializer, ReactionSerializer
 from lego.apps.tags.serializers import TagSerializerMixin
 from lego.apps.users.serializers.users import PublicUserSerializer
-from lego.utils.serializers import BasisModelSerializer
+from lego.utils.serializers import BasisModelSerializer, ObjectPermissionsSerializerMixin
 
 
 class DetailedArticleSerializer(TagSerializerMixin, BasisModelSerializer):
@@ -25,6 +25,12 @@ class DetailedArticleSerializer(TagSerializerMixin, BasisModelSerializer):
             'id', 'title', 'cover', 'author', 'description', 'comments', 'comment_target',
             'reactions', 'reactions_grouped', 'tags', 'content', 'created_at', 'pinned'
         )
+
+
+class DetailedArticleAdminSerializer(ObjectPermissionsSerializerMixin, DetailedArticleSerializer):
+    class Meta:
+        model = Article
+        fields = DetailedArticleSerializer.Meta.fields + ObjectPermissionsSerializerMixin.Meta.fields
 
 
 class SearchArticleSerializer(TagSerializerMixin, BasisModelSerializer):

--- a/lego/apps/gallery/serializers.py
+++ b/lego/apps/gallery/serializers.py
@@ -89,8 +89,15 @@ class GallerySerializer(BasisModelObjectPermissionSerializer):
             'event',
             'photographers',
             'cover',
-        ) + BasisModelObjectPermissionSerializer.Meta.fields
+        )
         read_only_fields = ('created_at', 'pictures')
+
+
+class GalleryAdminSerializer(GallerySerializer):
+    class Meta:
+        model = Gallery
+        fields = GallerySerializer.Meta.fields + BasisModelObjectPermissionSerializer.Meta.fields
+        read_only_fields = GallerySerializer.Meta.read_only_fields
 
 
 class GallerySearchSerializer(serializers.ModelSerializer):

--- a/lego/apps/gallery/serializers.py
+++ b/lego/apps/gallery/serializers.py
@@ -40,7 +40,7 @@ class GalleryListSerializer(BasisModelSerializer):
         fields = ('id', 'title', 'cover', 'location', 'taken_at', 'created_at', 'picture_count')
 
     def get_picture_count(self, gallery):
-        return gallery.pictures.count()
+        return gallery.picture_count
 
 
 class GalleryPictureSerializer(serializers.ModelSerializer):

--- a/lego/apps/gallery/serializers.py
+++ b/lego/apps/gallery/serializers.py
@@ -8,7 +8,7 @@ from lego.apps.files.fields import FileField, ImageField
 from lego.apps.gallery.fields import GalleryCoverField
 from lego.apps.users.fields import PublicUserField
 from lego.apps.users.models import User
-from lego.utils.serializers import BasisModelObjectPermissionSerializer, BasisModelSerializer
+from lego.utils.serializers import BasisModelSerializer, ObjectPermissionsSerializerMixin
 
 from .models import Gallery, GalleryPicture
 
@@ -71,7 +71,7 @@ class GalleryPictureSerializer(serializers.ModelSerializer):
         return {'gallery': gallery, **attrs}
 
 
-class GallerySerializer(BasisModelObjectPermissionSerializer):
+class GallerySerializer(BasisModelSerializer):
 
     cover = GalleryCoverField(queryset=GalleryPicture.objects.all(), required=False)
     photographers = PublicUserField(many=True, queryset=User.objects.all())
@@ -93,10 +93,10 @@ class GallerySerializer(BasisModelObjectPermissionSerializer):
         read_only_fields = ('created_at', 'pictures')
 
 
-class GalleryAdminSerializer(GallerySerializer):
+class GalleryAdminSerializer(ObjectPermissionsSerializerMixin, GallerySerializer):
     class Meta:
         model = Gallery
-        fields = GallerySerializer.Meta.fields + BasisModelObjectPermissionSerializer.Meta.fields
+        fields = GallerySerializer.Meta.fields + ObjectPermissionsSerializerMixin.Meta.fields
         read_only_fields = GallerySerializer.Meta.read_only_fields
 
 

--- a/lego/apps/gallery/serializers.py
+++ b/lego/apps/gallery/serializers.py
@@ -8,7 +8,7 @@ from lego.apps.files.fields import FileField, ImageField
 from lego.apps.gallery.fields import GalleryCoverField
 from lego.apps.users.fields import PublicUserField
 from lego.apps.users.models import User
-from lego.utils.serializers import BasisModelSerializer
+from lego.utils.serializers import BasisModelObjectPermissionSerializer, BasisModelSerializer
 
 from .models import Gallery, GalleryPicture
 
@@ -71,7 +71,7 @@ class GalleryPictureSerializer(serializers.ModelSerializer):
         return {'gallery': gallery, **attrs}
 
 
-class GallerySerializer(BasisModelSerializer):
+class GallerySerializer(BasisModelObjectPermissionSerializer):
 
     cover = GalleryCoverField(queryset=GalleryPicture.objects.all(), required=False)
     photographers = PublicUserField(many=True, queryset=User.objects.all())
@@ -89,7 +89,7 @@ class GallerySerializer(BasisModelSerializer):
             'event',
             'photographers',
             'cover',
-        )
+        ) + BasisModelObjectPermissionSerializer.Meta.fields
         read_only_fields = ('created_at', 'pictures')
 
 

--- a/lego/apps/gallery/tests/test_views.py
+++ b/lego/apps/gallery/tests/test_views.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 from rest_framework import status
 
-from lego.apps.gallery.models import GalleryPicture
+from lego.apps.gallery.models import Gallery, GalleryPicture
 from lego.apps.users.models import AbakusGroup, User
 from lego.utils.test_utils import BaseAPITestCase
 
@@ -64,6 +64,12 @@ class GalleryViewSetTestCase(BaseAPITestCase):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual(1, len(response.data['results']))
 
+    def test_detail_gallery_no_user(self, mock_signer):
+        """Non logged in users should not find any pictures"""
+        response = self.client.get(f'{self.url}1/pictures/')
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(0, len(response.data['results']))
+
     def test_detail_gallery_denied(self, mock_signer):
         """Users is not able to fetch galleries by default."""
         self.client.force_login(self.denied_user)
@@ -84,6 +90,132 @@ class GalleryViewSetTestCase(BaseAPITestCase):
 
         response = self.client.post(f'{self.url}1/pictures/', self.add_picture_data)
         self.assertEqual(status.HTTP_403_FORBIDDEN, response.status_code)
+
+    def test_delete_picture_permitted(self, mock_signer):
+        """The permitted user is able to delete pictures."""
+        self.client.force_login(self.permitted_user)
+
+        response = self.client.delete(f'{self.url}1/pictures/1/')
+        self.assertEqual(status.HTTP_204_NO_CONTENT, response.status_code)
+
+    def test_edit_picture_permitted(self, mock_signer):
+        """The permitted user is able to update pictures"""
+        self.client.force_login(self.permitted_user)
+
+        response = self.client.patch(
+            f'{self.url}1/pictures/2/', {
+                'active': True,
+                'description': 'Test description'
+            }
+        )
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+
+        self.assertTrue(GalleryPicture.objects.get(id=2).active)
+
+
+@mock.patch('lego.apps.files.fields.storage.generate_signed_url', return_value='signed_url')
+class GalleryViewSetTestCaseRequireAuthFalse(BaseAPITestCase):
+
+    fixtures = [
+        'test_abakus_groups.yaml', 'test_users.yaml', 'test_files.yaml', 'test_galleries.yaml',
+        'test_gallery_pictures.yaml'
+    ]
+
+    def setUp(self):
+        self.permitted_user = User.objects.get(username='test1')
+        self.read_only_user = User.objects.get(username='abakule')
+        self.denied_user = User.objects.get(username='pleb')
+        self.url = '/api/v1/galleries/'
+
+        self.admin_group = AbakusGroup.objects.get(name='GalleryAdminTest')
+        self.admin_group.add_user(self.permitted_user)
+        self.read_group = AbakusGroup.objects.get(name='GalleryTest')
+        self.read_group.add_user(self.read_only_user)
+
+        self.add_picture_data = {
+            'description': 'Test image',
+            'file': 'abakus2.png:token',
+            'active': True
+        }
+        self.gallery = Gallery.objects.get(pk=1)
+        self.gallery.require_auth = False
+        self.gallery.save()
+
+    def test_list_galleries_denied_user(self, mock_signer):
+        """Permitted user should not be able to se the gallery."""
+        self.client.force_login(self.denied_user)
+
+        response = self.client.get(f'{self.url}')
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(1, len(response.data['results']))
+
+    def test_list_galleries_permitted_user(self, mock_signer):
+        """Permitted user should see the gallery."""
+        self.client.force_login(self.permitted_user)
+
+        response = self.client.get(f'{self.url}')
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(1, len(response.data['results']))
+
+    def test_detail_gallery_permitted_user(self, mock_signer):
+        """Permitted user should be able to see all pictures."""
+        self.client.force_login(self.permitted_user)
+
+        response = self.client.get(f'{self.url}1/pictures/')
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(2, len(response.data['results']))
+
+    def test_detail_gallery_read_user(self, mock_signer):
+        """Read only user is able to fetch the gallery."""
+        self.client.force_login(self.read_only_user)
+
+        response = self.client.get(f'{self.url}1/pictures/')
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(1, len(response.data['results']))
+
+    def test_detail_gallery_no_user(self, mock_signer):
+        """Non logged in users should find active pictures"""
+        response = self.client.get(f'{self.url}1/pictures/')
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(1, len(response.data['results']))
+
+    def test_detail_gallery_denied(self, mock_signer):
+        """Users should be able to fetch gallery."""
+        self.client.force_login(self.denied_user)
+
+        response = self.client.get(f'{self.url}1/')
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+
+    def test_detail_gallery_no_user_(self, mock_signer):
+        """Non logged in user should be able to see gallery info."""
+        response = self.client.get(f'{self.url}1/')
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+
+    def test_add_image_permitted(self, mock_signer):
+        """The permitted user is able to add images"""
+        self.client.force_login(self.permitted_user)
+
+        response = self.client.post(f'{self.url}1/pictures/', self.add_picture_data)
+        self.assertEqual(status.HTTP_201_CREATED, response.status_code)
+
+    def test_add_picture_read_only_user(self, mock_signer):
+        """The read_only_user user is not be able to add images."""
+        self.client.force_login(self.read_only_user)
+
+        response = self.client.post(f'{self.url}1/pictures/', self.add_picture_data)
+        self.assertEqual(status.HTTP_403_FORBIDDEN, response.status_code)
+
+    def test_add_picture_no_user(self, mock_signer):
+        """Non logged in user is not be able to add images."""
+        self.client.force_login(self.read_only_user)
+
+        response = self.client.post(f'{self.url}1/pictures/', self.add_picture_data)
+        self.assertEqual(status.HTTP_403_FORBIDDEN, response.status_code)
+
+    def test_delete_picture_no_user(self, mock_signer):
+        """Non logged i user is not able to delete pictures."""
+        response = self.client.delete(f'{self.url}1/pictures/1/')
+        self.assertEqual(status.HTTP_401_UNAUTHORIZED, response.status_code)
 
     def test_delete_picture_permitted(self, mock_signer):
         """The permitted user is able to delete pictures."""

--- a/lego/apps/gallery/tests/test_views.py
+++ b/lego/apps/gallery/tests/test_views.py
@@ -32,6 +32,22 @@ class GalleryViewSetTestCase(BaseAPITestCase):
             'active': True
         }
 
+    def test_list_galleries_denied_user(self, mock_signer):
+        """Permitted user should not be able to se the gallery."""
+        self.client.force_login(self.denied_user)
+
+        response = self.client.get(f'{self.url}')
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(0, len(response.data['results']))
+
+    def test_list_galleries_permitted_user(self, mock_signer):
+        """Permitted user should see the gallery."""
+        self.client.force_login(self.permitted_user)
+
+        response = self.client.get(f'{self.url}')
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(1, len(response.data['results']))
+
     def test_detail_gallery_permitted_user(self, mock_signer):
         """Permitted user should be able to see all pictures."""
         self.client.force_login(self.permitted_user)

--- a/lego/apps/gallery/views.py
+++ b/lego/apps/gallery/views.py
@@ -7,7 +7,9 @@ from lego.apps.permissions.api.views import AllowedPermissionsMixin
 from lego.apps.permissions.constants import EDIT, OBJECT_PERMISSION_FIELDS
 
 from .models import Gallery, GalleryPicture
-from .serializers import GalleryListSerializer, GalleryPictureSerializer, GallerySerializer
+from .serializers import (
+    GalleryAdminSerializer, GalleryListSerializer, GalleryPictureSerializer, GallerySerializer
+)
 
 
 class GalleryViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
@@ -29,6 +31,11 @@ class GalleryViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
     def get_serializer_class(self):
         if self.action == 'list':
             return GalleryListSerializer
+
+        if self.action in ['create', 'partial_update', 'update', 'retrieve']:
+            if self.request.user.is_authenticated:
+                return GalleryAdminSerializer
+
         return super().get_serializer_class()
 
 

--- a/lego/apps/gallery/views.py
+++ b/lego/apps/gallery/views.py
@@ -4,7 +4,7 @@ from rest_framework import viewsets
 from lego.apps.gallery.filters import GalleryFilterSet
 from lego.apps.gallery.pagination import GalleryPicturePagination
 from lego.apps.permissions.api.views import AllowedPermissionsMixin
-from lego.apps.permissions.constants import EDIT, OBJECT_PERMISSION_FIELDS
+from lego.apps.permissions.constants import EDIT, OBJECT_PERMISSIONS_FIELDS
 
 from .models import Gallery, GalleryPicture
 from .serializers import (
@@ -22,7 +22,7 @@ class GalleryViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
     def get_queryset(self):
         if self.action != 'list':
             return super().get_queryset().prefetch_related(
-                'photographers', *OBJECT_PERMISSION_FIELDS
+                'photographers', *OBJECT_PERMISSIONS_FIELDS
             )
 
         return super().get_queryset().annotate(picture_count=Count('pictures')
@@ -33,7 +33,7 @@ class GalleryViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
             return GalleryListSerializer
 
         if self.action in ['create', 'partial_update', 'update', 'retrieve']:
-            if self.request.user.is_authenticated:
+            if self.request and self.request.user.is_authenticated:
                 return GalleryAdminSerializer
 
         return super().get_serializer_class()

--- a/lego/apps/permissions/constants.py
+++ b/lego/apps/permissions/constants.py
@@ -5,7 +5,7 @@ VIEW = 'view'
 EDIT = 'edit'
 DELETE = 'delete'
 
-OBJECT_PERMISSION_FIELDS = (
+OBJECT_PERMISSIONS_FIELDS = (
     'can_view_groups',
     'can_edit_groups',
     'can_edit_users',

--- a/lego/apps/permissions/constants.py
+++ b/lego/apps/permissions/constants.py
@@ -4,3 +4,9 @@ CREATE = 'create'
 VIEW = 'view'
 EDIT = 'edit'
 DELETE = 'delete'
+
+OBJECT_PERMISSION_FIELDS = (
+    'can_view_groups',
+    'can_edit_groups',
+    'can_edit_users',
+)

--- a/lego/utils/serializers.py
+++ b/lego/utils/serializers.py
@@ -39,7 +39,7 @@ class BasisModelSerializer(serializers.ModelSerializer):
         super().save(**kwargs)
 
 
-class BasisModelObjectPermissionSerializer(BasisModelSerializer):
+class ObjectPermissionsSerializerMixin(serializers.Serializer):
     class Meta:
         fields = (
             'can_edit_users',

--- a/lego/utils/serializers.py
+++ b/lego/utils/serializers.py
@@ -1,6 +1,8 @@
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from rest_framework import serializers
 
+from lego.apps.users.fields import AbakusGroupField, PublicUserField
+from lego.apps.users.models import AbakusGroup, User
 from lego.utils.content_types import string_to_instance
 
 
@@ -35,3 +37,23 @@ class BasisModelSerializer(serializers.ModelSerializer):
         request = self.context['request']
         kwargs['current_user'] = request.user
         super().save(**kwargs)
+
+
+class BasisModelObjectPermissionSerializer(BasisModelSerializer):
+    class Meta:
+        fields = (
+            'can_edit_users',
+            'can_view_groups',
+            'can_edit_groups',
+            'require_auth',
+        )
+
+    can_edit_users = PublicUserField(
+        queryset=User.objects.all(), allow_null=True, required=False, many=True
+    )
+    can_edit_groups = AbakusGroupField(
+        queryset=AbakusGroup.objects.all(), allow_null=True, required=False, many=True
+    )
+    can_view_groups = AbakusGroupField(
+        queryset=AbakusGroup.objects.all(), allow_null=True, required=False, many=True
+    )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-max-line-length = 100
+max-line-length = 101
 exclude = venv/*,.tox/*,lego/settings/local.py,migrations,wsgi.py,docs/*
 
 [isort]


### PR DESCRIPTION
## Things:
- [X] Add ObjectPermissionSerializer
- [X] Increase query performance (both list and detail)
- [X] ObjectPermission-permissions (who can see `canViewGroups` etc.) Currently as long as you are logged in.

Do we need to hide `canViewGroups` etc. for someone? We can use it to show "this gallery is owned by PR/Bedkom/Fagkom" etc.

### Gallery list view:
From:
![screenshot from 2018-04-01 11-20-28](https://user-images.githubusercontent.com/1467188/38171816-0cece696-35a1-11e8-9758-0ed0858cf298.png)
To:
![screenshot from 2018-04-01 11-31-46](https://user-images.githubusercontent.com/1467188/38171817-0d0b563a-35a1-11e8-90b9-4318c3bc493c.png)
