### PR TITLE
Sort albums by taken at

### DIFF
--- a/lego/apps/gallery/views.py
+++ b/lego/apps/gallery/views.py
@@ -14,7 +14,7 @@ class GalleryViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
     queryset = Gallery.objects.all().select_related('event', 'cover')
     filter_class = GalleryFilterSet
     serializer_class = GallerySerializer
-    ordering = '-created_at'
+    ordering = '-taken_at'
 
     def get_queryset(self):
         if self.action != 'list':


### PR DESCRIPTION
Fixes https://github.com/webkom/lego-webapp/issues/1106
Sorting albums by the time they where taken makes the most sense.
Many albums have the same created at flag (when we migrated), so taken at makes more sence