### PR TITLE
[Ignore for now] Add a /mine endpoint to surveys

### DIFF
--- a/lego/apps/surveys/serializers.py
+++ b/lego/apps/surveys/serializers.py
@@ -60,7 +60,7 @@ class SurveyReadSerializer(BasisModelSerializer):
 
     class Meta:
         model = Survey
-        fields = ('id', 'title', 'active_from', 'event', 'template_type')
+        fields = ('id', 'title', 'active_from', 'event', 'template_type', 'created_by')
 
 
 class SubmissionReadSerializer(BasisModelSerializer):

--- a/lego/apps/surveys/views.py
+++ b/lego/apps/surveys/views.py
@@ -1,5 +1,6 @@
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import mixins, status, viewsets
+from rest_framework.decorators import list_route
 from rest_framework.response import Response
 
 from lego.apps.permissions.api.views import AllowedPermissionsMixin
@@ -27,6 +28,15 @@ class SurveyViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
         elif self.action in ['retrieve']:
             return SurveyReadDetailedSerializer
         return SurveyReadSerializer
+
+    @list_route(methods=['GET'])
+    def mine(self, request):
+        """
+        Read-only endpoint used to retrieve all surveys the user has created
+        """
+        queryset = self.get_queryset().filter(created_by=request.user)
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)
 
 
 class SurveyTemplateViewSet(


### PR DESCRIPTION
Currently returns all the surveys the requesting user has created, which means it's only relevant for admin users. Makes sense atm because regular users can't fetch the list endpoint. When/if we change that, this endpoint could be changed to returning all surveys the user has access to (ie all surveys for events they've attended, which usually equals all surveys they've answered)

Implemented frontend in https://github.com/webkom/lego-webapp/pull/1203