### PR TITLE
Add proper description to oauth scope

### DIFF
--- a/lego/settings/base.py
+++ b/lego/settings/base.py
@@ -122,7 +122,8 @@ OAUTH2_PROVIDER_APPLICATION_MODEL = 'oauth.APIApplication'
 OAUTH2_PROVIDER = {
     'ACCESS_TOKEN_EXPIRE_SECONDS': 86400 * 7,
     'SCOPES': {
-        'user': 'Grants access to the user profile'
+        'user':
+        'Grants access to the user profile. IMPORTANT: Currently grants access to everything'
     }
 }
 


### PR DESCRIPTION
We currently don't check scopes, and 'User' will therefore
grant access to all the data :rip: