### PR TITLE
Temporary disable pagination for survey submissions

### DIFF
--- a/lego/apps/surveys/views.py
+++ b/lego/apps/surveys/views.py
@@ -78,6 +78,7 @@ class SubmissionViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
     queryset = Submission.objects.all()
     permission_classes = [SubmissionPermissions]
     filter_class = SubmissionFilterSet
+    pagination_class = None
     filter_backends = (DjangoFilterBackend, )
 
     def get_queryset(self):


### PR DESCRIPTION
Temporary fix for this (about 80 submissions).

![screenshot from 2018-05-23 13-39-00](https://user-images.githubusercontent.com/1467188/40422174-ba9dcce0-5e8e-11e8-8739-3dbe2c9f7da4.png)

We should instead use the aggregated view, and maybe use infinite scroll on the different questions. No big deal tho, becuase of the small amount of data :smile: 
