### PR TITLE
Update celery

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ redis==2.10.6
 hiredis==0.2.0
 certifi==2018.1.18
 elasticsearch==6.2.0
-celery==4.1.0
+celery==4.1.1
 stripe==1.79.1
 structlog==18.1.0
 boto3==1.7


### PR DESCRIPTION
Celery `4.1.0` broke upstream. http://www.celeryproject.org/news/celery-411-hot-fix-releaesd/