### PR TITLE
Revert "[Doppins] Upgrade dependency pyyaml to ==4.1"

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,7 @@ ipython==6.4.0
 
 psycopg2==2.7.3.2
 unicode-slugify==0.1.3
-pyyaml==4.1
+pyyaml==3.12
 raven==6.9.0
 redis==2.10.6
 hiredis==0.2.0


### PR DESCRIPTION
Reverts webkom/lego#1237

pyyaml==4.1 is missing from pypi :cry: 