### PR TITLE
Add a decorator and class that deletes the property on save

### DIFF
--- a/lego/utils/decorators.py
+++ b/lego/utils/decorators.py
@@ -1,0 +1,7 @@
+from django.utils.functional import cached_property
+
+
+class abakus_cached_property(cached_property):
+    def __init__(self, func, name=None, delete_on_save=True):
+        super().__init__(func, name)
+        self.delete_on_save = delete_on_save


### PR DESCRIPTION
Scenario:

1. A view calls for [`user.is_abakom_member()`](https://github.com/webkom/lego/blob/fd0a900c497eddf1d8be07a1d62592605607ee31/lego/apps/users/models.py#L173) to check if the user is an Abakom member
2. `user.is_abakom_member()` calls [`user.all_groups`](https://github.com/webkom/lego/blob/fd0a900c497eddf1d8be07a1d62592605607ee31/lego/apps/users/models.py#L195), which is a `@cached_property`
3. The view then adds the user to the Webkom Abakom group: `AbakusGroup.objects.get(name='Webkom').add_user(user)`
4. It then calls `user.save()`

Issue: `user.all_groups` will have the initial data that was gathered in point 2 and will not update until the user gets reinitialized in a later call.

This PR adds a new class, `CachedModel`, and a new decorator, `@abakus_cached_property`, which deletes every single cached_property on `.save()` so that the information can be gathered again.
