### PR TITLE
Upgrade pyyaml, rip doppins

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,7 @@ ipython==7.0.1
 
 psycopg2==2.7.3.2
 unicode-slugify==0.1.3
-pyyaml==3.12
+pyyaml==3.13
 raven==6.9.0
 redis==2.10.6
 hiredis==0.2.0


### PR DESCRIPTION
Need to upgrade pyyaml for using python 3.7