### PR TITLE
Change HS contact form email

### DIFF
--- a/lego/apps/contact/send.py
+++ b/lego/apps/contact/send.py
@@ -9,14 +9,12 @@ def send_message(title, message, user, anonymous):
     """
     anonymous = anonymous if user.is_authenticated else True
     abakus_group = AbakusGroup.objects.get(name='Hovedstyret')
-    users = [membership.user for membership in abakus_group.memberships.select_related('user')]
-    emails = [user.email_address for user in users]
 
     from_name = 'Anonymous' if anonymous else user.full_name
     from_email = 'Unknown' if anonymous else user.email_address
 
     send_email.delay(
-        to_email=emails, context={
+        to_email=abakus_group.contact_email, context={
             'title': title,
             'message': message,
             'from_name': from_name,

--- a/lego/apps/contact/tests/test_send.py
+++ b/lego/apps/contact/tests/test_send.py
@@ -6,6 +6,13 @@ from lego.apps.contact.send import send_message
 from lego.apps.users.models import User
 from lego.utils.test_utils import BaseTestCase
 
+default_values = {
+    'from_email': None,
+    'html_template': 'contact/email/contact_form.html',
+    'plain_template': 'contact/email/contact_form.txt',
+    'subject': 'Ny henvendelse fra kontaktskjemaet'
+}
+
 
 class SendTestCase(BaseTestCase):
 
@@ -16,15 +23,72 @@ class SendTestCase(BaseTestCase):
 
     @mock.patch('lego.apps.contact.send.send_email.delay')
     def test_send_anonymous(self, mock_send_email):
-        send_message('title', 'message', AnonymousUser(), True)
+        """
+        Send in a contact form as not logged in user, set to be anonymous
+        """
+        anonymus_user = AnonymousUser()
+
+        send_message('title', 'message', anonymus_user, True)
+        mock_send_email.assert_called_with(
+            to_email="hs@abakus.no", context={
+                'title': 'title',
+                'message': 'message',
+                'from_name': "Anonymous",
+                'from_email': "Unknown"
+            }, **default_values
+        )
         mock_send_email.assert_called_once()
 
     @mock.patch('lego.apps.contact.send.send_email.delay')
     def test_send_anonymous_user(self, mock_send_email):
-        send_message('title', 'message', AnonymousUser(), False)
+        """
+        Send in a contact form as not logged in user
+        """
+        anonymus_user = AnonymousUser()
+
+        send_message('title', 'message', anonymus_user, False)
+        mock_send_email.assert_called_with(
+            to_email="hs@abakus.no", context={
+                'title': 'title',
+                'message': 'message',
+                'from_name': "Anonymous",
+                'from_email': "Unknown"
+            }, **default_values
+        )
         mock_send_email.assert_called_once()
 
     @mock.patch('lego.apps.contact.send.send_email.delay')
     def test_send_user(self, mock_send_email):
-        send_message('title', 'message', User.objects.first(), False)
+        """
+        Send in a contact form as logged in user, showing name
+        """
+        logged_in_user = User.objects.first()
+
+        send_message('title', 'message', logged_in_user, False)
+        mock_send_email.assert_called_with(
+            to_email="hs@abakus.no", context={
+                'title': 'title',
+                'message': 'message',
+                'from_name': logged_in_user.full_name,
+                'from_email': logged_in_user.email_address
+            }, **default_values
+        )
+        mock_send_email.assert_called_once()
+
+    @mock.patch('lego.apps.contact.send.send_email.delay')
+    def test_send_user_set_anonymous(self, mock_send_email):
+        """
+        Send in a contact form as logged in user, set to be anonymous
+        """
+        logged_in_user = User.objects.first()
+
+        send_message('title', 'message', logged_in_user, True)
+        mock_send_email.assert_called_with(
+            to_email="hs@abakus.no", context={
+                'title': 'title',
+                'message': 'message',
+                'from_name': "Anonymous",
+                'from_email': "Unknown"
+            }, **default_values
+        )
         mock_send_email.assert_called_once()

--- a/lego/apps/users/fixtures/initial_abakus_groups.py
+++ b/lego/apps/users/fixtures/initial_abakus_groups.py
@@ -108,11 +108,13 @@ initial_tree = {
                             'text': 'hei'
                         }, {}
                     ],
-                    'Hovedstyret':
-                    [{
-                        'logo_id': 'abakus_hs.png',
-                        'permissions': ['/sudo/admin/'],
-                    }, {}]
+                    'Hovedstyret': [
+                        {
+                            'logo_id': 'abakus_hs.png',
+                            'permissions': ['/sudo/admin/'],
+                            'contact_email': "hs@abakus.no"
+                        }, {}
+                    ]
                 }
             ],
             'Interessegrupper':

--- a/lego/apps/users/fixtures/initial_abakus_groups.yaml
+++ b/lego/apps/users/fixtures/initial_abakus_groups.yaml
@@ -68,7 +68,7 @@
     rght: 20, tree_id: 2, level: 2}
 - model: users.abakusgroup
   pk: 13
-  fields: {deleted: false, name: Hovedstyret, description: '', contact_email: '',
+  fields: {deleted: false, name: Hovedstyret, description: '', contact_email: hs@abakus.no,
     parent: 3, logo: abakus_hs.png, type: annen, text: '', permissions: '["/sudo/admin/"]',
     lft: 21, rght: 22, tree_id: 2, level: 2}
 - model: users.abakusgroup


### PR DESCRIPTION
Send email to the HS email, instead of to each member of HS individually.

Fixes #1257 
