### PR TITLE
Hide memberships of deleted groups

### DIFF
--- a/lego/apps/users/models.py
+++ b/lego/apps/users/models.py
@@ -194,20 +194,24 @@ class PermissionsMixin(CachedModel):
     @abakus_cached_property
     def memberships(self):
         return Membership.objects.filter(
-            deleted=False,
+            abakus_group__deleted=False,
             is_active=True,
             user=self,
         )
 
     @abakus_cached_property
     def past_memberships(self):
-        return MembershipHistory.objects.filter(user=self).select_related('abakus_group')
+        return MembershipHistory.objects.filter(
+            user=self,
+            abakus_group__deleted=False,
+        ).select_related('abakus_group')
 
     @abakus_cached_property
     def all_groups(self):
         groups = set()
 
         memberships = self.memberships.filter(
+            abakus_group__deleted=False,
             deleted=False,
             is_active=True,
         ).select_related('abakus_group')

--- a/lego/apps/users/tests/test_models.py
+++ b/lego/apps/users/tests/test_models.py
@@ -137,13 +137,40 @@ class UserTestCase(BaseTestCase):
 
     def test_add_remove_user(self):
         abakus = AbakusGroup.objects.get(name='Abakus')
+        self.assertEqual(self.user.memberships.count(), 0)
+        self.assertEqual(self.user.past_memberships.count(), 0)
 
         abakus.add_user(self.user)
         self.assertEqual(abakus.number_of_users, 1)
+        self.assertEqual(self.user.memberships.count(), 1)
 
         abakus = AbakusGroup.objects.get(name='Abakus')
         abakus.remove_user(self.user)
         self.assertEqual(abakus.number_of_users, 0)
+        self.assertEqual(self.user.memberships.count(), 0)
+        self.assertEqual(self.user.past_memberships.count(), 1)
+
+    def test_add_user_delete_group(self):
+        abakus = AbakusGroup.objects.get(name='Abakus')
+        self.assertEqual(self.user.memberships.count(), 0)
+        self.assertEqual(self.user.past_memberships.count(), 0)
+
+        abakus.add_user(self.user)
+        self.assertEqual(abakus.number_of_users, 1)
+        self.assertEqual(self.user.memberships.count(), 1)
+
+        abakus = AbakusGroup.objects.get(name='Abakus')
+        abakus.remove_user(self.user)
+        self.assertEqual(self.user.memberships.count(), 0)
+        self.assertEqual(self.user.past_memberships.count(), 1)
+
+        abakus.add_user(self.user)
+        self.assertEqual(self.user.memberships.count(), 1)
+        self.assertEqual(self.user.past_memberships.count(), 1)
+
+        abakus.delete()
+        self.assertEqual(self.user.memberships.count(), 0)
+        self.assertEqual(self.user.past_memberships.count(), 0)
 
     def test_add_user_to_two_groups(self):
         AbakusGroup.objects.get(name='Abakus').add_user(self.user)

--- a/lego/apps/users/views/membership_history.py
+++ b/lego/apps/users/views/membership_history.py
@@ -17,7 +17,9 @@ class MembershipHistoryViewSet(
     ordering = 'id'
 
     def get_queryset(self):
-        queryset = MembershipHistory.objects.all().select_related('user', 'abakus_group')
+        queryset = MembershipHistory.objects.filter(
+            abakus_group__deleted=False,
+        ).select_related('user', 'abakus_group')
 
         if not self.request.user.has_perm(EDIT, Membership):
             return queryset.filter(abakus_group__type__in=(GROUP_COMMITTEE, GROUP_INTEREST))


### PR DESCRIPTION
This fixes https://sentry.abakus.no/webkom/lego-webapp/issues/6016/?query=is:unresolved, since all memberships will now have a valid group.