### PR TITLE
Feedback portal

### DIFF
--- a/lego/apps/contact/send.py
+++ b/lego/apps/contact/send.py
@@ -1,28 +1,38 @@
 from lego.apps.users.models import AbakusGroup
+from lego.apps.users.constants import LEADER
 from lego.utils.tasks import send_email
 
 
-def send_message(title, message, user, anonymous):
+def send_message(title, message, user, anonymous, recipient_group):
     """
     Send a message to HS when users posts to the contact form.
     Don't catch AbakusGroup.DoesNotExist, this notifies us when the group doesn't exist.
     """
     anonymous = anonymous if user.is_authenticated else True
-    abakus_group = AbakusGroup.objects.get(name="Hovedstyret")
+    recipient_emails = get_recipients(recipient_group)
 
     from_name = "Anonymous" if anonymous else user.full_name
     from_email = "Unknown" if anonymous else user.email_address
 
     send_email.delay(
-        to_email=abakus_group.contact_email,
+        to_email=recipient_emails,
         context={
             "title": title,
             "message": message,
             "from_name": from_name,
             "from_email": from_email,
+            "recipient_group": recipient_group
         },
-        subject="Ny henvendelse fra kontaktskjemaet",
+        subject=f"Ny henvendelse fra kontaktskjemaet til {recipient_group}",
         plain_template="contact/email/contact_form.txt",
         html_template="contact/email/contact_form.html",
         from_email=None,
     )
+
+def get_recipients(recipient_group):
+    hs_group = AbakusGroup.objects.get(name="Hovedstyret")
+    if recipient_group == hs_group:
+        return [hs_group.contact_email]
+    recipient_leaders = [membership.user for membership in recipient_group.memberships.filter(role=LEADER).select_related('user')]
+    return [leader.email_address for leader in recipient_leaders]
+

--- a/lego/apps/contact/serializers.py
+++ b/lego/apps/contact/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import exceptions, serializers
 
 from lego.utils.functions import verify_captcha
+from lego.apps.users.serializers.abakus_groups import PublicAbakusGroupSerializer
 
 
 class ContactFormSerializer(serializers.Serializer):
@@ -9,6 +10,8 @@ class ContactFormSerializer(serializers.Serializer):
     message = serializers.CharField()
     anonymous = serializers.BooleanField()
     captcha_response = serializers.CharField()
+    recipient_group = PublicAbakusGroupSerializer()
+
 
     def validate_captcha_response(self, captcha_response):
         if not verify_captcha(captcha_response):
@@ -19,3 +22,8 @@ class ContactFormSerializer(serializers.Serializer):
         if not self.context["request"].user.is_authenticated and not anonymous:
             raise exceptions.ValidationError("anonymous_required_without_auth")
         return anonymous
+
+    def validate_recipient_group(self, recipient_group):
+        if not recipient_group.is_committee():
+            raise exceptions.ValidationError("group_not_committee")
+        return recipient_group

--- a/lego/apps/contact/templates/contact/email/contact_form.html
+++ b/lego/apps/contact/templates/contact/email/contact_form.html
@@ -4,7 +4,7 @@
 
     <tr>
         <td class="alert alert-info">
-            Kontaktskjema {{ recipient_group }}
+            Kontaktskjema - {{ recipient_group }}
         </td>
     </tr>
 

--- a/lego/apps/contact/templates/contact/email/contact_form.html
+++ b/lego/apps/contact/templates/contact/email/contact_form.html
@@ -4,7 +4,7 @@
 
     <tr>
         <td class="alert alert-info">
-            Kontaktskjema
+            Kontaktskjema {{ recipient_group }}
         </td>
     </tr>
 

--- a/lego/apps/contact/templates/contact/email/contact_form.txt
+++ b/lego/apps/contact/templates/contact/email/contact_form.txt
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-Det er sendt inn en ny henvendelse fra kontaktskjemaet.
+Det er sendt inn en ny henvendelse fra kontaktskjemaet til {{recipient_group}}.
 
 Tittel: {{title}}
 

--- a/lego/apps/contact/views.py
+++ b/lego/apps/contact/views.py
@@ -17,7 +17,8 @@ class ContactFormViewSet(viewsets.GenericViewSet):
         title = serializer.validated_data["title"]
         message = serializer.validated_data["message"]
         anonymous = serializer.validated_data["anonymous"]
+        recipient_group = serializer.validated_data["recipient_group"]
 
-        send_message(title, message, request.user, anonymous)
+        send_message(title, message, request.user, anonymous, recipient_group)
 
         return Response(serializer.validated_data, status=status.HTTP_202_ACCEPTED)

--- a/lego/apps/contact/views.py
+++ b/lego/apps/contact/views.py
@@ -21,4 +21,7 @@ class ContactFormViewSet(viewsets.GenericViewSet):
 
         send_message(title, message, request.user, anonymous, recipient_group)
 
+        if recipient_group:
+            serializer.validated_data["recipient_group"] = recipient_group.id
+
         return Response(serializer.validated_data, status=status.HTTP_202_ACCEPTED)


### PR DESCRIPTION
Makes it possible to choose a specific committee as recipient in the contact form. 

- Passing `None` as recipient group sends the message to HS.
- Choosing a specific committee, by passing the correct group ID, will send the message to the leader of the committee.

This PR breaks the webapp!