### PR TITLE
[WIP] Improve event serializers

### DIFF
--- a/lego/apps/events/search_indexes.py
+++ b/lego/apps/events/search_indexes.py
@@ -1,5 +1,5 @@
 from lego.apps.events.models import Event
-from lego.apps.events.serializers.events import EventSearchSerializer
+from lego.apps.events.serializers.events import EventReadSerializer
 from lego.apps.search import register
 from lego.apps.search.index import SearchIndex
 
@@ -7,7 +7,7 @@ from lego.apps.search.index import SearchIndex
 class EventModelIndex(SearchIndex):
 
     queryset = Event.objects.all()
-    serializer_class = EventSearchSerializer
+    serializer_class = EventReadSerializer
     result_fields = (
         "title",
         "description",

--- a/lego/apps/frontpage/views.py
+++ b/lego/apps/frontpage/views.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 from lego.apps.articles.models import Article
 from lego.apps.articles.serializers import PublicArticleSerializer
 from lego.apps.events.models import Event
-from lego.apps.events.serializers.events import EventSearchSerializer
+from lego.apps.events.serializers.events import EventReadSerializer
 from lego.apps.permissions.constants import LIST
 from lego.apps.permissions.utils import get_permission_handler
 
@@ -55,7 +55,7 @@ class FrontpageViewSet(viewsets.ViewSet):
         articles = PublicArticleSerializer(
             queryset_articles[:10], context=self.get_serializer_context(), many=True
         ).data
-        events = EventSearchSerializer(
+        events = EventReadSerializer(
             queryset_events, context=self.get_serializer_context(), many=True
         ).data
         ret = {"articles": articles, "events": events}


### PR DESCRIPTION
1) I wanted to improve the `EventReadSerializer` by removing the `company` field. We only use this serializer for the event list, and here the company field is not needed. This was creating more requests then needed. The `EventForSurveySerializer` however did extend the serializer so I moved company over there, as I do believe company is needed where that serializer is used.

2) The `EventSearchSerializer` is almost the exact same serializer as `EventReadSerializer`, except the `text`, `end_time`, `pinned` field. So I was wondering if we could just merge these two serializers into one as I've done here?

3) Start using the `EventReadSerializer` on the frontpage instead of the `EventSearchSerializer` like we do today.

