### PR TITLE
Fix poll permissions

### DIFF
--- a/lego/apps/polls/fixtures/development_polls.yaml
+++ b/lego/apps/polls/fixtures/development_polls.yaml
@@ -14,14 +14,14 @@
   pk: 1
   fields:
     name: Skra
-    votes: 5
+    votes: 3
     poll: 1
 
 - model: polls.Option
   pk: 2
   fields:
     name: Bombom
-    votes: 15
+    votes: 25
     poll: 1
 
 - model: polls.Option

--- a/lego/apps/polls/permissions.py
+++ b/lego/apps/polls/permissions.py
@@ -3,4 +3,4 @@ from lego.apps.permissions.permissions import PermissionHandler
 
 
 class PollPermissionHandler(PermissionHandler):
-    authentication_map = {LIST: False}
+    permission_map = {LIST: [], VIEW: []}


### PR DESCRIPTION
Fix poll permissions so that they actually are correct:
anonymous user (not logged in): no permissions
All authenticated users (logged in): list, view and vote
Admin users with correct permissions: update and create

Tests are also updated to match this. (and it doesn't force authenticate all users..)

This fixes issue where users get an error when trying to access abakus.no/polls/{id}