### PR TITLE
Fix request auth in tests

### DIFF
--- a/lego/apps/contact/tests/test_views.py
+++ b/lego/apps/contact/tests/test_views.py
@@ -53,7 +53,7 @@ class ContactViewSetTestCase(BaseAPITestCase):
     @mock.patch("lego.apps.contact.views.send_message")
     @mock.patch("lego.apps.contact.serializers.verify_captcha", return_value=True)
     def test_with_auth(self, mock_verify_captcha, mock_send_message):
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
         response = self.client.post(
             self.url,
             {
@@ -73,7 +73,7 @@ class ContactViewSetTestCase(BaseAPITestCase):
     @mock.patch("lego.apps.contact.views.send_message")
     @mock.patch("lego.apps.contact.serializers.verify_captcha", return_value=False)
     def test_with_auth_invalid_captcha(self, mock_verify_captcha, mock_send_message):
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
         response = self.client.post(
             self.url,
             {
@@ -93,7 +93,7 @@ class ContactViewSetTestCase(BaseAPITestCase):
         webkom = AbakusGroup.objects.get(name="Webkom")
         webkom_id = webkom.id
 
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
 
         response = self.client.post(
             self.url,

--- a/lego/apps/email/tests/test_views.py
+++ b/lego/apps/email/tests/test_views.py
@@ -22,7 +22,7 @@ class EmailListTestCase(BaseAPITestCase):
         self.admin_group.add_user(self.user)
         self.admin_group.add_user(self.user2, role="leader")
 
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
 
     def test_list(self):
         """The list endpoint is available"""
@@ -104,7 +104,7 @@ class UserEmailTestCase(BaseAPITestCase):
         self.admin_group = AbakusGroup.objects.get(name="EmailAdminTest")
         self.admin_group.add_user(self.user)
 
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
 
     def test_list(self):
         """The list endpoint is available"""

--- a/lego/apps/files/tests/test_api.py
+++ b/lego/apps/files/tests/test_api.py
@@ -19,13 +19,13 @@ class ListArticlesTestCase(BaseAPITestCase):
         self.assertEqual(res.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_post_with_no_key(self):
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
         res = self.client.post(f"{self.url}", data={})
         self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
 
     @mock.patch("lego.apps.files.models.File.create_file")
     def test_post_create_file_call(self, mock_create_file):
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
         key = "myfile.png"
         try:
             self.client.post(f"{self.url}", data={"key": key})

--- a/lego/apps/flatpages/tests/test_api.py
+++ b/lego/apps/flatpages/tests/test_api.py
@@ -43,7 +43,7 @@ class PageAPITestCase(BaseAPITestCase):
         slug = "webkom"
         methods = ["post", "patch", "put", "delete"]
         user = create_normal_user()
-        self.client.force_login(user)
+        self.client.force_authenticate(user)
         for method in methods:
             call = getattr(self.client, method)
             response = call("/api/v1/pages/{0}/".format(slug))
@@ -53,6 +53,6 @@ class PageAPITestCase(BaseAPITestCase):
         page = {"title": "cat", "content": "hei"}
 
         user = create_super_user()
-        self.client.force_login(user)
+        self.client.force_authenticate(user)
         response = self.client.post("/api/v1/pages/", data=page)
         self.assertEqual(response.status_code, 201)

--- a/lego/apps/followers/tests/test_views.py
+++ b/lego/apps/followers/tests/test_views.py
@@ -24,7 +24,7 @@ class FollowEventViewTestCase(BaseAPITestCase):
         response = self.client.get(self.url)
         self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
         response = self.client.get(self.url)
         self.assertEquals(response.status_code, status.HTTP_200_OK)
 
@@ -33,7 +33,7 @@ class FollowEventViewTestCase(BaseAPITestCase):
         response = self.client.post(self.url, {"target": 1})
         self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
         response = self.client.post(self.url, {"target": 1})
         self.assertEquals(response.status_code, status.HTTP_201_CREATED)
 
@@ -49,11 +49,11 @@ class FollowEventViewTestCase(BaseAPITestCase):
         self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
         denied_user = User.objects.get(id=2)
-        self.client.force_login(denied_user)
+        self.client.force_authenticate(denied_user)
         response = self.client.delete(f"{self.url}1/")
         self.assertEquals(response.status_code, status.HTTP_404_NOT_FOUND)
 
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
         response = self.client.delete(f"{self.url}1/")
         self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)
 
@@ -71,7 +71,7 @@ class FollowUserViewTestCase(BaseAPITestCase):
         response = self.client.get(self.url)
         self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
         response = self.client.get(self.url)
         self.assertEquals(response.status_code, status.HTTP_200_OK)
 
@@ -80,7 +80,7 @@ class FollowUserViewTestCase(BaseAPITestCase):
         response = self.client.post(self.url, {"target": 1})
         self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
         response = self.client.post(self.url, {"target": 1})
         self.assertEquals(response.status_code, status.HTTP_201_CREATED)
 
@@ -96,11 +96,11 @@ class FollowUserViewTestCase(BaseAPITestCase):
         self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
         denied_user = User.objects.get(id=2)
-        self.client.force_login(denied_user)
+        self.client.force_authenticate(denied_user)
         response = self.client.delete(f"{self.url}1/")
         self.assertEquals(response.status_code, status.HTTP_404_NOT_FOUND)
 
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
         response = self.client.delete(f"{self.url}1/")
         self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)
 
@@ -123,7 +123,7 @@ class FollowCompanyViewTestCase(BaseAPITestCase):
         response = self.client.get(self.url)
         self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
         response = self.client.get(self.url)
         self.assertEquals(response.status_code, status.HTTP_200_OK)
 
@@ -132,7 +132,7 @@ class FollowCompanyViewTestCase(BaseAPITestCase):
         response = self.client.post(self.url, {"target": 1})
         self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
         response = self.client.post(self.url, {"target": 1})
         self.assertEquals(response.status_code, status.HTTP_201_CREATED)
 
@@ -148,10 +148,10 @@ class FollowCompanyViewTestCase(BaseAPITestCase):
         self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
         denied_user = User.objects.get(id=2)
-        self.client.force_login(denied_user)
+        self.client.force_authenticate(denied_user)
         response = self.client.delete(f"{self.url}1/")
         self.assertEquals(response.status_code, status.HTTP_404_NOT_FOUND)
 
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
         response = self.client.delete(f"{self.url}1/")
         self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)

--- a/lego/apps/gallery/tests/test_views.py
+++ b/lego/apps/gallery/tests/test_views.py
@@ -37,7 +37,7 @@ class GalleryViewSetTestCase(BaseAPITestCase):
 
     def test_list_galleries_denied_user(self, mock_signer):
         """Permitted user should not be able to se the gallery."""
-        self.client.force_login(self.denied_user)
+        self.client.force_authenticate(self.denied_user)
 
         response = self.client.get(f"{self.url}")
         self.assertEqual(status.HTTP_200_OK, response.status_code)
@@ -45,7 +45,7 @@ class GalleryViewSetTestCase(BaseAPITestCase):
 
     def test_list_galleries_permitted_user(self, mock_signer):
         """Permitted user should see the gallery."""
-        self.client.force_login(self.permitted_user)
+        self.client.force_authenticate(self.permitted_user)
 
         response = self.client.get(f"{self.url}")
         self.assertEqual(status.HTTP_200_OK, response.status_code)
@@ -53,7 +53,7 @@ class GalleryViewSetTestCase(BaseAPITestCase):
 
     def test_detail_gallery_permitted_user(self, mock_signer):
         """Permitted user should be able to see all pictures."""
-        self.client.force_login(self.permitted_user)
+        self.client.force_authenticate(self.permitted_user)
 
         response = self.client.get(f"{self.url}1/pictures/")
         self.assertEqual(status.HTTP_200_OK, response.status_code)
@@ -61,7 +61,7 @@ class GalleryViewSetTestCase(BaseAPITestCase):
 
     def test_detail_gallery_read_user(self, mock_signer):
         """Read only user is able to fetch the gallery."""
-        self.client.force_login(self.read_only_user)
+        self.client.force_authenticate(self.read_only_user)
 
         response = self.client.get(f"{self.url}1/pictures/")
         self.assertEqual(status.HTTP_200_OK, response.status_code)
@@ -75,21 +75,21 @@ class GalleryViewSetTestCase(BaseAPITestCase):
 
     def test_detail_gallery_denied(self, mock_signer):
         """Users is not able to fetch galleries by default."""
-        self.client.force_login(self.denied_user)
+        self.client.force_authenticate(self.denied_user)
 
         response = self.client.get(f"{self.url}1/")
         self.assertEqual(status.HTTP_404_NOT_FOUND, response.status_code)
 
     def test_add_image_permitted(self, mock_signer):
         """The permitted user is able to add images"""
-        self.client.force_login(self.permitted_user)
+        self.client.force_authenticate(self.permitted_user)
 
         response = self.client.post(f"{self.url}1/pictures/", self.add_picture_data)
         self.assertEqual(status.HTTP_201_CREATED, response.status_code)
 
     def test_add_picture_read_only_user(self, mock_signer):
         """The read_only_user user is not be able to add images."""
-        self.client.force_login(self.read_only_user)
+        self.client.force_authenticate(self.read_only_user)
 
         response = self.client.post(f"{self.url}1/pictures/", self.add_picture_data)
         self.assertEqual(status.HTTP_403_FORBIDDEN, response.status_code)
@@ -100,14 +100,14 @@ class GalleryViewSetTestCase(BaseAPITestCase):
 
     def test_delete_picture_permitted(self, mock_signer):
         """The permitted user is able to delete pictures."""
-        self.client.force_login(self.permitted_user)
+        self.client.force_authenticate(self.permitted_user)
 
         response = self.client.delete(f"{self.url}1/pictures/1/")
         self.assertEqual(status.HTTP_204_NO_CONTENT, response.status_code)
 
     def test_view_picture_denied_user(self, mock_signer):
         """The permitted user is not able to view picture"""
-        self.client.force_login(self.denied_user)
+        self.client.force_authenticate(self.denied_user)
         response = self.client.get(f"{self.url}1/pictures/1/")
         self.assertEqual(status.HTTP_404_NOT_FOUND, response.status_code)
 
@@ -118,19 +118,19 @@ class GalleryViewSetTestCase(BaseAPITestCase):
 
     def test_get_picture_permitted(self, mock_signer):
         """The permitted user is able to view the image."""
-        self.client.force_login(self.permitted_user)
+        self.client.force_authenticate(self.permitted_user)
         response = self.client.get(f"{self.url}1/pictures/1/")
         self.assertEqual(status.HTTP_200_OK, response.status_code)
 
     def test_get_picture_permitted_read_only(self, mock_signer):
         """The permitted user is able to delete pictures."""
-        self.client.force_login(self.read_only_user)
+        self.client.force_authenticate(self.read_only_user)
         response = self.client.get(f"{self.url}1/pictures/1/")
         self.assertEqual(status.HTTP_200_OK, response.status_code)
 
     def test_edit_picture_permitted(self, mock_signer):
         """The permitted user is able to update pictures"""
-        self.client.force_login(self.permitted_user)
+        self.client.force_authenticate(self.permitted_user)
 
         response = self.client.patch(
             f"{self.url}1/pictures/2/",
@@ -174,7 +174,7 @@ class GalleryViewSetTestCaseRequireAuthFalse(BaseAPITestCase):
 
     def test_list_galleries_denied_user(self, mock_signer):
         """Permitted user should not be able to se the gallery."""
-        self.client.force_login(self.denied_user)
+        self.client.force_authenticate(self.denied_user)
 
         response = self.client.get(f"{self.url}")
         self.assertEqual(status.HTTP_200_OK, response.status_code)
@@ -182,7 +182,7 @@ class GalleryViewSetTestCaseRequireAuthFalse(BaseAPITestCase):
 
     def test_list_galleries_permitted_user(self, mock_signer):
         """Permitted user should see the gallery."""
-        self.client.force_login(self.permitted_user)
+        self.client.force_authenticate(self.permitted_user)
 
         response = self.client.get(f"{self.url}")
         self.assertEqual(status.HTTP_200_OK, response.status_code)
@@ -190,7 +190,7 @@ class GalleryViewSetTestCaseRequireAuthFalse(BaseAPITestCase):
 
     def test_detail_gallery_permitted_user(self, mock_signer):
         """Permitted user should be able to see all pictures."""
-        self.client.force_login(self.permitted_user)
+        self.client.force_authenticate(self.permitted_user)
 
         response = self.client.get(f"{self.url}1/pictures/")
         self.assertEqual(status.HTTP_200_OK, response.status_code)
@@ -198,7 +198,7 @@ class GalleryViewSetTestCaseRequireAuthFalse(BaseAPITestCase):
 
     def test_detail_gallery_read_user(self, mock_signer):
         """Read only user is able to fetch the gallery."""
-        self.client.force_login(self.read_only_user)
+        self.client.force_authenticate(self.read_only_user)
 
         response = self.client.get(f"{self.url}1/pictures/")
         self.assertEqual(status.HTTP_200_OK, response.status_code)
@@ -211,12 +211,12 @@ class GalleryViewSetTestCaseRequireAuthFalse(BaseAPITestCase):
         self.assertEqual(1, len(response.data["results"]))
 
     def test_active_picture_non_allowed_user(self, mock_signer):
-        self.client.force_login(self.denied_user)
+        self.client.force_authenticate(self.denied_user)
         response = self.client.get(f"{self.url}1/pictures/1/")
         self.assertEqual(status.HTTP_200_OK, response.status_code)
 
     def test_inactive_picture_non_allowed_user(self, mock_signer):
-        self.client.force_login(self.denied_user)
+        self.client.force_authenticate(self.denied_user)
         response = self.client.get(f"{self.url}1/pictures/2/")
         self.assertEqual(status.HTTP_404_NOT_FOUND, response.status_code)
 
@@ -229,7 +229,7 @@ class GalleryViewSetTestCaseRequireAuthFalse(BaseAPITestCase):
         self.assertEqual(status.HTTP_404_NOT_FOUND, response.status_code)
 
     def test_detail_gallery_denied(self, mock_signer):
-        self.client.force_login(self.denied_user)
+        self.client.force_authenticate(self.denied_user)
 
         response = self.client.get(f"{self.url}1/")
         self.assertEqual(status.HTTP_200_OK, response.status_code)
@@ -241,14 +241,14 @@ class GalleryViewSetTestCaseRequireAuthFalse(BaseAPITestCase):
 
     def test_add_image_permitted(self, mock_signer):
         """The permitted user is able to add images"""
-        self.client.force_login(self.permitted_user)
+        self.client.force_authenticate(self.permitted_user)
 
         response = self.client.post(f"{self.url}1/pictures/", self.add_picture_data)
         self.assertEqual(status.HTTP_201_CREATED, response.status_code)
 
     def test_add_picture_read_only_user(self, mock_signer):
         """The read_only_user user is not be able to add images."""
-        self.client.force_login(self.read_only_user)
+        self.client.force_authenticate(self.read_only_user)
 
         response = self.client.post(f"{self.url}1/pictures/", self.add_picture_data)
         self.assertEqual(status.HTTP_403_FORBIDDEN, response.status_code)
@@ -265,14 +265,14 @@ class GalleryViewSetTestCaseRequireAuthFalse(BaseAPITestCase):
 
     def test_delete_picture_permitted(self, mock_signer):
         """The permitted user is able to delete pictures."""
-        self.client.force_login(self.permitted_user)
+        self.client.force_authenticate(self.permitted_user)
 
         response = self.client.delete(f"{self.url}1/pictures/1/")
         self.assertEqual(status.HTTP_204_NO_CONTENT, response.status_code)
 
     def test_edit_picture_permitted2(self, mock_signer):
         """The permitted user is able to update pictures"""
-        self.client.force_login(self.read_only_user)
+        self.client.force_authenticate(self.read_only_user)
 
         response = self.client.patch(
             f"{self.url}1/pictures/1/",
@@ -282,7 +282,7 @@ class GalleryViewSetTestCaseRequireAuthFalse(BaseAPITestCase):
 
     def test_edit_picture_permitted(self, mock_signer):
         """The permitted user is able to update pictures"""
-        self.client.force_login(self.permitted_user)
+        self.client.force_authenticate(self.permitted_user)
 
         response = self.client.patch(
             f"{self.url}1/pictures/2/",

--- a/lego/apps/notifications/tests/test_views.py
+++ b/lego/apps/notifications/tests/test_views.py
@@ -32,10 +32,10 @@ class NotificationSettingsViewSetTestCase(BaseAPITestCase):
         self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_list(self):
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
 
     def test_alternatives(self):
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
         response = self.client.get(f"{self.url}alternatives/")
         self.assertEquals(
             response.data,
@@ -46,7 +46,7 @@ class NotificationSettingsViewSetTestCase(BaseAPITestCase):
         )
 
     def test_change_setting(self):
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
 
         response = self.client.post(
             self.url, {"notification_type": "weekly_mail", "enabled": True}
@@ -62,7 +62,7 @@ class NotificationSettingsViewSetTestCase(BaseAPITestCase):
 
     def test_change_setting_defaults(self):
         """Make sure a new setting is created with correct defaults"""
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
 
         response = self.client.post(
             self.url, {"notification_type": constants.MEETING_INVITE}

--- a/lego/apps/oauth/tests/test_views.py
+++ b/lego/apps/oauth/tests/test_views.py
@@ -20,7 +20,7 @@ class OauthViewsTestCase(BaseAPITestCase):
 
     def test_retrieve_tokens(self):
         """Make sure the user can access the token list and the list is filtered."""
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
 
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -34,13 +34,13 @@ class OauthViewsTestCase(BaseAPITestCase):
 
     def test_delete_token(self):
         """Make sure the client can delete a token. This is the same sa revoking it."""
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
         response = self.client.delete("{base_url}1/".format(base_url=self.url))
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
     def test_token_attached_to_different_user(self):
         """Make sure a user can't delete a token owned by a other user."""
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
         response = self.client.delete("{base_url}2/".format(base_url=self.url))
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -64,13 +64,13 @@ class OauthApplicationViewsTestCase(BaseAPITestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_list_applications(self):
         """Make sure permitted users can list applications."""
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
         Membership.objects.create(
             user=self.user,
             abakus_group=AbakusGroup.objects.get(name="APIApplicationTest"),
@@ -81,7 +81,7 @@ class OauthApplicationViewsTestCase(BaseAPITestCase):
 
     def test_create_application(self):
         """Make sure permitted users can create applications."""
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
         Membership.objects.create(
             user=self.user,
             abakus_group=AbakusGroup.objects.get(name="APIApplicationTest"),
@@ -101,7 +101,7 @@ class OauthApplicationViewsTestCase(BaseAPITestCase):
 
     def test_delete_application(self):
         """Make sure permitted users can delete applications."""
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
         Membership.objects.create(
             user=self.user,
             abakus_group=AbakusGroup.objects.get(name="APIApplicationTest"),

--- a/lego/apps/restricted/tests/test_views.py
+++ b/lego/apps/restricted/tests/test_views.py
@@ -22,14 +22,14 @@ class RestrictedViewTestCase(BaseAPITestCase):
 
     def test_list(self):
         """List instances created_by authenticated user only."""
-        self.client.force_login(self.allowed_user)
+        self.client.force_authenticate(self.allowed_user)
 
         response = self.client.get(self.url)
         self.assertEquals(len(response.data["results"]), 1)
 
     def test_list_no_perms(self):
         """A user tries to list with no permissions"""
-        self.client.force_login(self.denied_user)
+        self.client.force_authenticate(self.denied_user)
 
         response = self.client.get(self.url)
         self.assertEquals(status.HTTP_403_FORBIDDEN, response.status_code)

--- a/lego/apps/slack/tests/test_views.py
+++ b/lego/apps/slack/tests/test_views.py
@@ -24,7 +24,7 @@ class SlackInviteTestCase(BaseAPITestCase):
     )
     def test_invite_user(self, mock_post):
         user = User.objects.first()
-        self.client.force_login(user)
+        self.client.force_authenticate(user)
         response = self.client.post(self.url, {"email": "test@test.com"})
         self.assertEquals(response.json(), {"detail": "test_error"})
         self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/lego/apps/users/tests/test_membership_history.py
+++ b/lego/apps/users/tests/test_membership_history.py
@@ -26,7 +26,7 @@ class MembershipHistoryViewSetTestCase(BaseAPITestCase):
         group.add_user(user)
         group.remove_user(user)
 
-        self.client.force_login(user)
+        self.client.force_authenticate(user)
         response = self.client.get(self.url)
         self.assertEquals(status.HTTP_200_OK, response.status_code)
         self.assertEquals(1, len(response.data["results"]))
@@ -39,7 +39,7 @@ class MembershipHistoryViewSetTestCase(BaseAPITestCase):
         group.add_user(user)
         group.remove_user(user)
 
-        self.client.force_login(user)
+        self.client.force_authenticate(user)
         response = self.client.get(self.url)
         self.assertEquals(status.HTTP_200_OK, response.status_code)
         self.assertEquals(0, len(response.data["results"]))

--- a/lego/apps/users/tests/test_password_change.py
+++ b/lego/apps/users/tests/test_password_change.py
@@ -25,7 +25,7 @@ class TestPasswordChange(BaseAPITestCase):
         self.assertEquals(status.HTTP_401_UNAUTHORIZED, response.status_code)
 
     def test_invalid_password(self):
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
         response = self.client.post(
             self.url,
             {
@@ -37,7 +37,7 @@ class TestPasswordChange(BaseAPITestCase):
         self.assertEquals(status.HTTP_400_BAD_REQUEST, response.status_code)
 
     def test_not_equal_new_passwords(self):
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
         response = self.client.post(
             self.url,
             {
@@ -49,7 +49,7 @@ class TestPasswordChange(BaseAPITestCase):
         self.assertEquals(status.HTTP_400_BAD_REQUEST, response.status_code)
 
     def test_new_password_not_valid(self):
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
         response = self.client.post(
             self.url,
             {"password": "test", "new_password": "x", "retype_new_password": "x"},
@@ -57,7 +57,7 @@ class TestPasswordChange(BaseAPITestCase):
         self.assertEquals(status.HTTP_400_BAD_REQUEST, response.status_code)
 
     def test_new_password_success(self):
-        self.client.force_login(self.user)
+        self.client.force_authenticate(self.user)
         response = self.client.post(
             self.url,
             {

--- a/lego/apps/users/tests/test_users_api.py
+++ b/lego/apps/users/tests/test_users_api.py
@@ -291,7 +291,7 @@ class UpdateUsersAPITestCase(BaseAPITestCase):
         self.successful_update(self.with_perm, self.test_user)
 
     def test_update_with_invalid_email(self):
-        self.client.force_login(self.with_perm)
+        self.client.force_authenticate(self.with_perm)
         response = self.client.patch(
             _get_detail_url(self.test_user), {"email": "cat@gmail"}
         )
@@ -301,7 +301,7 @@ class UpdateUsersAPITestCase(BaseAPITestCase):
 
     def test_update_with_super_user_invalid_email(self):
         """It is not possible to set an email with our GSuite domain as the address domain."""
-        self.client.force_login(self.with_perm)
+        self.client.force_authenticate(self.with_perm)
         response = self.client.patch(
             _get_detail_url(self.test_user), {"email": "webkom@abakus.no"}
         )
@@ -314,7 +314,7 @@ class UpdateUsersAPITestCase(BaseAPITestCase):
 
     def test_update_username_used_by_other(self):
         """Try to change username to something used by another user with different casing"""
-        self.client.force_login(self.without_perm)
+        self.client.force_authenticate(self.without_perm)
         response = self.client.patch(
             _get_detail_url(self.without_perm.username),
             {"username": "usEradmin_TeSt"},  # Existing username with other casing
@@ -323,7 +323,7 @@ class UpdateUsersAPITestCase(BaseAPITestCase):
 
     def test_update_username_to_self(self):
         """Try to change casing on the current username"""
-        self.client.force_login(self.without_perm)
+        self.client.force_authenticate(self.without_perm)
         response = self.client.patch(
             _get_detail_url(self.without_perm.username),
             {"username": self.without_perm.username.upper()},
@@ -332,7 +332,7 @@ class UpdateUsersAPITestCase(BaseAPITestCase):
 
     def test_update_abakus_membership(self):
         """Try to change the is_abakus_member"""
-        self.client.force_login(self.without_perm)
+        self.client.force_authenticate(self.without_perm)
 
         response = self.client.patch(
             _get_detail_url(self.without_perm.username), {"is_abakus_member": True}
@@ -351,7 +351,7 @@ class UpdateUsersAPITestCase(BaseAPITestCase):
     def test_update_abakus_membership_when_not_student(self):
         """Try to change the is_abakus_member when user is not a student"""
         user = self.all_users.exclude(student_username__isnull=False).first()
-        self.client.force_login(user)
+        self.client.force_authenticate(user)
         response = self.client.patch(
             _get_detail_url(user.username), {"is_abakus_member": True}
         )

--- a/lego/utils/test_utils.py
+++ b/lego/utils/test_utils.py
@@ -4,11 +4,6 @@ from rest_framework.test import APITestCase, APITransactionTestCase
 
 
 class BaseTestCase(TestCase):
-    """
-    Normally we don't want to hit Cassandra in tests, so we mock out add_activity in most tests
-    to avoid this. If you want to test something using Cassandra, override FeedTestBase instead.
-    """
-
     pass
 
 

--- a/lego/utils/tests/test_views.py
+++ b/lego/utils/tests/test_views.py
@@ -16,6 +16,6 @@ class SiteMetaViewSetTestCase(BaseAPITestCase):
         self.assertEquals(status.HTTP_200_OK, response.status_code)
 
     def test_access_with_user(self):
-        self.client.force_login(User.objects.first())
+        self.client.force_authenticate(User.objects.first())
         response = self.client.get(self.url)
         self.assertEquals(status.HTTP_200_OK, response.status_code)


### PR DESCRIPTION
All tests should use force_authenticate (from DRF), not force_login (from django). Both _will_ work, but some stuff may require `force_authenticate` to be used.