### PR TITLE
Add changes needed for running end to end tests with cypress in lego-webapp

### DIFF
--- a/lego/apps/users/fixtures/development_users.yaml
+++ b/lego/apps/users/fixtures/development_users.yaml
@@ -3,12 +3,12 @@
   fields:
     username: test1
     student_username: test1student
-    password: pbkdf2_sha256$24000$zowF0cRkFimt$qzeoY9hZ0X3zDhlG0FP8imaGto8S2N6ed1AMp83xcn4= # test
+    password: 'pbkdf2_sha256$120000$YKmWfcu6Hqqv$e0yZQh91HMGZQBkElS3ZjW04rs2XCCK34DqK6P73N0g=' # Webkom123
     gender: male
     first_name: test
     last_name: user1
     email: test1@user.com
-    crypt_password_hash: '$6$akKj2oBqaAp/2T5.$m73QJBWs0TiBMHTX3PSs/xhde0YKkr4PnKocXAo.T6SGz/qwhiPh0Gdo.2DTiYnNhyIifv7Fe.cTaVachdgrm.' # webkom
+    crypt_password_hash: '$6$/VqkvlFzdX7Od/MZ$7j2IPY.NIDym.ktBNHkt5o5qnZvCIkRnVX1LW4A5RNbA6Zg1Zq6pvi72NFdxy4j1wUfTpwfIe8rRO1HL3n.7R.' # Webkom123
 - model: users.User
   pk: 2
   fields:
@@ -25,8 +25,8 @@
     gender: male
     picture: 'default_other_avatar.png'
     last_name: webkom
-    email: webkom@abakus.no
-    password: pbkdf2_sha256$12000$H0aWD4yl0CVd$b0S/vVYcRRGqXygh1390tc9eyKBMyIgcp3SAbkxIBb0= # webkom
+    email: webkom@aba.wtf
+    password: 'pbkdf2_sha256$120000$YKmWfcu6Hqqv$e0yZQh91HMGZQBkElS3ZjW04rs2XCCK34DqK6P73N0g=' # Webkom123
 - model: users.User
   pk: 4
   fields:
@@ -34,8 +34,8 @@
     first_name: bedkom
     picture: default_female_avatar.png
     last_name: bedkom
-    email: bedkom@abakus.no
-    password: pbkdf2_sha256$30000$LRjfuW81G3u9$8lEi6kbgZ3ai/dBicdWi/wO1wZU93rT10WaF1vekEMs= # bedkom
+    email: bedkom@aba.wtf
+    password: 'pbkdf2_sha256$120000$rhBO1zmtTZsr$smSDnW2pSOl7kac1ErGVJnRvB5fapOFBQnKqBKr/Q8g=' # Bedkom123
 - fields:
     email: jburke186@ekrubnylcaj.com
     first_name: Jaclyn

--- a/lego/settings/production.py
+++ b/lego/settings/production.py
@@ -67,6 +67,9 @@ CHANNEL_LAYERS["default"]["CONFIG"] = {"hosts": [env("CHANNELS_REDIS_URL")]}
 ELASTICSEARCH = env("ELASTICSEARCH_HOST")
 SEARCH_INDEX = env("SEARCH_INDEX", default="lego-search")
 
+# Optional AWS entrypoint for minio
+AWS_ENTRYPOINT = env("AWS_ENTRYPOINT", default=None)
+
 # Stripe
 stripe.api_key = env("STRIPE_API_KEY")
 STRIPE_WEBHOOK_SECRET = env("STRIPE_WEBHOOK_SECRET")

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#   Use this script to test if a given TCP host/port are available
+
+WAITFORIT_cmdname=${0##*/}
+
+echoerr() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $WAITFORIT_cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    else
+        echoerr "$WAITFORIT_cmdname: waiting for $WAITFORIT_HOST:$WAITFORIT_PORT without a timeout"
+    fi
+    WAITFORIT_start_ts=$(date +%s)
+    while :
+    do
+        if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
+            nc -z $WAITFORIT_HOST $WAITFORIT_PORT
+            WAITFORIT_result=$?
+        else
+            (echo > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+            WAITFORIT_result=$?
+        fi
+        if [[ $WAITFORIT_result -eq 0 ]]; then
+            WAITFORIT_end_ts=$(date +%s)
+            echoerr "$WAITFORIT_cmdname: $WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $WAITFORIT_result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $WAITFORIT_QUIET -eq 1 ]]; then
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    else
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    fi
+    WAITFORIT_PID=$!
+    trap "kill -INT -$WAITFORIT_PID" INT
+    wait $WAITFORIT_PID
+    WAITFORIT_RESULT=$?
+    if [[ $WAITFORIT_RESULT -ne 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: timeout occurred after waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    fi
+    return $WAITFORIT_RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        WAITFORIT_hostport=(${1//:/ })
+        WAITFORIT_HOST=${WAITFORIT_hostport[0]}
+        WAITFORIT_PORT=${WAITFORIT_hostport[1]}
+        shift 1
+        ;;
+        --child)
+        WAITFORIT_CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        WAITFORIT_QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        WAITFORIT_STRICT=1
+        shift 1
+        ;;
+        -h)
+        WAITFORIT_HOST="$2"
+        if [[ $WAITFORIT_HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        WAITFORIT_HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        WAITFORIT_PORT="$2"
+        if [[ $WAITFORIT_PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        WAITFORIT_PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        WAITFORIT_TIMEOUT="$2"
+        if [[ $WAITFORIT_TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        WAITFORIT_TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        WAITFORIT_CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$WAITFORIT_HOST" == "" || "$WAITFORIT_PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+WAITFORIT_TIMEOUT=${WAITFORIT_TIMEOUT:-15}
+WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
+WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
+WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
+
+# check to see if timeout is from busybox?
+WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
+WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
+if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+        WAITFORIT_ISBUSY=1
+        WAITFORIT_BUSYTIMEFLAG="-t"
+
+else
+        WAITFORIT_ISBUSY=0
+        WAITFORIT_BUSYTIMEFLAG=""
+fi
+
+if [[ $WAITFORIT_CHILD -gt 0 ]]; then
+    wait_for
+    WAITFORIT_RESULT=$?
+    exit $WAITFORIT_RESULT
+else
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        WAITFORIT_RESULT=$?
+    else
+        wait_for
+        WAITFORIT_RESULT=$?
+    fi
+fi
+
+if [[ $WAITFORIT_CLI != "" ]]; then
+    if [[ $WAITFORIT_RESULT -ne 0 && $WAITFORIT_STRICT -eq 1 ]]; then
+        echoerr "$WAITFORIT_cmdname: strict mode, refusing to execute subprocess"
+        exit $WAITFORIT_RESULT
+    fi
+    exec "${WAITFORIT_CLI[@]}"
+else
+    exit $WAITFORIT_RESULT
+fi


### PR DESCRIPTION
- Users need to follow password and email rules
- Need to be able to use minio in the docker build (production environment)
- Need `wait-for-it.sh` to make backend wait for dependencies before starting in test run