### PR TITLE
Update minor dependencies

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 django==2.1.7
-ipython==7.3.0
+ipython==7.4.0
 
 
 psycopg2==2.7.3.2
@@ -19,7 +19,7 @@ bleach==3.1.0
 slackclient==1.3.0
 requests==2.21.0
 ldap3==2.5
-google-api-python-client==1.7.4
+google-api-python-client==1.7.8
 oauth2client
 premailer==3.2.0
 analytics-python==1.2.9
@@ -32,15 +32,15 @@ daphne==2.2.5
 # Implicit dependency
 flatbuffers==1.10
 
-djangorestframework==3.9.0
+djangorestframework==3.9.2
 djangorestframework-jwt==1.11.0
 djangorestframework-camel-case==0.2.0
-django-extensions==2.1.4
-django-autoslug==1.9.3
+django-extensions==2.1.6
+django-autoslug==1.9.4
 django-oauth-toolkit==1.1.0
-django-cors-headers==2.4.0
+django-cors-headers==2.5.2
 django-mptt==0.9.1
-django-filter==2.0.0
+django-filter==2.1.0
 django-environ==0.4.5
 django-redis==4.10.0
 django-ipware==2.1.0
@@ -50,9 +50,9 @@ odinuge-django-push-notifications==1.6.0.post3
 
 # Ical-export
 django-ical==1.5
-icalendar==4.0
+icalendar==4.0.3
 
 # Docs
 Pygments==2.3.1
-Markdown==3.0.1
+Markdown==3.1
 coreapi==2.3.3


### PR DESCRIPTION
I've gone through the changelogs for the following version bumps and looked at what's been done. I think it looks good, and everything still runs great.

Closes #1518 
Closes #1334 
Closes #1535 

### ipython==7.4.0
- Fix improper acceptation of return outside of functions. PR #11641.
- Fixed PyQt 5.11 backwards incompatibility causing sip import failure. PR #11613.
- Fix Bug where type? woudl crash IPython. PR #1608.
- Allow to apply @needs_local_scope to cell magics for convenience. PR #11542.

`shell_plus still works nice`

### ~slackclient==1.3.1~
- Lock websocket-client version to < 0.55.0: temp fix for #385

`We dont use this module`

### google-api-python-client==1.7.8
- Fix the client to respect the passed in developerKey and credentials
- Add client-side limit for batch requests (#585)
- Change xrange to range (#601)
- Typo in http.py exception message. (#602)
- Announce deprecation of Python 2.7 (#603)
- Updates documentation for stopping channel subscriptions (#598)
- Adding example for searchAppearance (#414)
- Add badges (#455)
- Convert '$' in method name to '_' (#616)
- Alias unitest2 import as unittest in test__auth.py (#613)

`All changes marked as minor bugfixes`

### djangorestframework==3.9.2
- Resolve XSS issue in browsable API. #6330
- Upgrade Bootstrap to 3.4.0 to resolve XSS issue.
- Resolve issues with composable permissions. #6299
- Respect limit_choices_to on foreign keys. #6371
- Routers: invalidate _urls cache on register() #6407
- Deferred schema renderer creation to avoid requiring pyyaml. #6416
- Added 'request_forms' block to base.html #6340
- Fixed SchemaView to reset renderer on exception. #6429
- Update Django Guardian dependency. #6430
- Ensured support for Django 2.2 #6422 & #6455
- Made templates compatible with session-based CSRF. #6207
- Adjusted field validators to accept non-list iterables. #6282
- Added SearchFilter.get_search_fields() hook. #6279
- Fix DeprecationWarning when accessing collections.abc classes via collections #6268
- Allowed Q objects in limit_choices_to introspection. #6472
- Added lazy evaluation to composed permissions. #6463
- Add negation ~ operator to permissions composition #6361
- Avoided calling distinct on annotated fields in SearchFilter. #6240
- Introduced RemovedInDRF…Warning classes to simplify deprecations. #6480

`Nothing marked as breaking changes, and still runs locally`

### ~djangorestframework-camel-case==1.0.3~

This is an unmaintained repo with no changes in the last 5 years. New repo is djangorestframework-camel-case2. All he did in this update was to run BLACK on the project

### django-extensions==2.1.6
- New: ipdb, pdb and wdb filters
- Fix: ForeignKeySearchInput, error with widget render(...) parameters on Django 2.1
- Fix: pipchecker, unsupported format string passed to NoneType.format error
- Tests: bunch of new test cases
- runserver_plus, auto_reloader fix for compatibility with Django 2.2
- test, many many more tests :-) thanks @kuter

`4 new filtes, tests and Django 2.2 compatibility`

### django-autoslug==1.9.4
- Add manager_name kwarg to enable using custom managers from abstract models.
- Django 1.10 compatibility.

`New kwarg and django1.1 compatibility`

### django-cors-headers==2.5.2
- Fix DeprecationWarning from importing collections.abc.Sequence on Python 3.7.
- Drop Django 1.8, 1.9, and 1.10 support. Only Django 1.11+ is supported now.
- Include test infrastructure in sdist to allow consumers to use it.
- Improve inclusion of tests in sdist to ignore .pyc files.

`Dropped support for versions we don't have, and add new tests`

### django-filter==2.1.0
- Fixed a regression in FilterView introduced in 2.0. An empty QuerySet was incorrectly used whenever the FilterSet was unbound (i.e. when there were no GET parameters). The correct, pre-2.0 behaviour is now restored.
- A workaround was to set strict=False on the FilterSet. This is no longer necessary, so you may restore strict behaviour as desired.
- Added IsoDateTimeFromToRangeFilter. Allows From-To filtering using ISO-8601 formatted dates.

`We don't use strict=False`

### icalendar==4.0.3
- Added rudimentary command line interface. [jfjlaros]
- Readme, setup and travis updates. [jdufresne, PabloCastellano]
- Update all pypi.python.org URLs to pypi.org [jon.dufresne]
- Categories are comma separated not 1 per line #265. [cleder]
- mark test with mixed timezoneaware and naive datetimes as an expected failure. [cleder]

`Minor changes, our exporter still works`

### Markdown==3.1
- Update CLI to support PyYAML 5.1.
- Overlapping raw HTML matches no longer leave placeholders behind (#458).
- Emphasis patterns now recognize newline characters as whitespace (#783).
- Version format had been updated to be PEP 440 compliant (#736).
- Block level elements are defined per instance, not as class attributes (#731).
- Double escaping of block code has been eliminated (#725).
- Problems with newlines in references has been fixed (#742).
- Escaped # are now handled in header syntax (#762).

`We have not bumped to PyYAML 5.1 yet, rest are minor bug fixes`