### PR TITLE
Add /previous/ endpoint.

### DIFF
--- a/lego/apps/events/views.py
+++ b/lego/apps/events/views.py
@@ -201,12 +201,12 @@ class EventViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
     def previous(self, request):
         queryset = (
             self.get_queryset()
-                .filter(
+            .filter(
                 registrations__status=constants.SUCCESS_REGISTER,
                 registrations__user=request.user,
                 start_time__lt=timezone.now(),
             )
-                .prefetch_related(
+            .prefetch_related(
                 Prefetch(
                     "registrations",
                     queryset=Registration.objects.filter(


### PR DESCRIPTION
Used to fetch previous events which a user was registered for.

This is needed to support a quicker backend compared to loading all pages and then filtering on the frontend.