### PR TITLE
[Do not merge] Update to python 3.7 (tox and prod)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.7
 MAINTAINER Abakus Webkom <webkom@abakus.no>
 
 ARG RELEASE

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = tests, docs, missing-migrations, isort, flake8, coverage, black
 skipsdist = True
 
 [testenv]
-basepython = python3.6
+basepython = python3.7
 deps =
     black: -r{toxinidir}/requirements/black.txt
     isort: -r{toxinidir}/requirements/isort.txt
@@ -49,7 +49,7 @@ commands =
     python manage.py missing_migrations
 
 [testenv:coverage]
-basepython = python3.6
+basepython = python3.7
 deps = -r{toxinidir}/requirements/coverage.txt
 commands =
     coverage report --fail-under=75
@@ -57,7 +57,7 @@ commands =
 
 [testenv:docs]
 basepython =
-    python3.6
+    python3.7
 changedir =
     docs
 setenv =


### PR DESCRIPTION
Updates the prod Dockerfile and tox to use Python 3.7.

However, the lego-testbase Docker image(https://github.com/webkom/lego-testbase) is based on Python 3.6, so this should not be merged without updating the test image. Works locally though!

Also this must be tested rigorously in staging to ensure everything works well with Python 3.7. Especially Celery. Perhaps we need some more methodic testing as well?

