### PR TITLE
Channels, channels_redis daphne bump at the same time

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -25,9 +25,9 @@ analytics-python==1.2.9
 libthumbor==1.3.2
 
 # channels
-channels==2.1.7
-channels_redis==2.3.3
-daphne==2.2.5
+channels==2.2.0
+channels_redis==2.4.0
+daphne==2.3.0
 # Implicit dependency
 flatbuffers==1.10
 


### PR DESCRIPTION
**Note: Might be smart to wait for https://github.com/webkom/lego/pull/1555, to limit the number of new changes done at one time**

Bump the three bastards at the same time. All three were updated last weekend, and as usuall, we got an error when only bumping one of them alone.
```
channels to 2.2.0
channels_redis to 2.4.0
daphne to 2.3.0
```
Closes https://github.com/webkom/lego/pull/1578 
Closes https://github.com/webkom/lego/pull/1577

**Our [daphne error on github](https://github.com/django/daphne/issues/256)**
> ![image](https://user-images.githubusercontent.com/23152018/56426331-3ab5ac80-62b8-11e9-9a79-a94bf5d1f22f.png)
