### PR TITLE
[WIP] Add can_register to Event model and serializers 

### DIFF
--- a/lego/apps/events/fields.py
+++ b/lego/apps/events/fields.py
@@ -78,6 +78,17 @@ class IsAdmittedField(serializers.Field):
         return value.is_admitted(request.user)
 
 
+class CanRegisterField(serializers.Field):
+    def get_attribute(self, instance):
+        return instance
+
+    def to_representation(self, value):
+        request = self.context.get("request", None)
+        if not request or not request.user.is_authenticated:
+            return False
+        return value.can_register(request.user)
+
+
 class ActivationTimeField(serializers.Field):
     def get_attribute(self, instance):
         return instance

--- a/lego/apps/events/serializers/events.py
+++ b/lego/apps/events/serializers/events.py
@@ -8,7 +8,12 @@ from lego.apps.companies.models import Company
 from lego.apps.content.fields import ContentSerializerField
 from lego.apps.events import constants
 from lego.apps.events.constants import PRESENT
-from lego.apps.events.fields import ActivationTimeField, IsAdmittedField, SpotsLeftField
+from lego.apps.events.fields import (
+    ActivationTimeField,
+    CanRegisterField,
+    IsAdmittedField,
+    SpotsLeftField,
+)
 from lego.apps.events.models import Event, Pool
 from lego.apps.events.serializers.pools import (
     PoolAdministrateSerializer,
@@ -61,6 +66,7 @@ class EventReadSerializer(TagSerializerMixin, BasisModelSerializer):
     )
     activation_time = ActivationTimeField()
     is_admitted = IsAdmittedField()
+    can_register = CanRegisterField()
 
     class Meta:
         model = Event
@@ -81,6 +87,7 @@ class EventReadSerializer(TagSerializerMixin, BasisModelSerializer):
             "tags",
             "activation_time",
             "is_admitted",
+            "can_register",
         )
         read_only = True
 
@@ -178,6 +185,7 @@ class EventReadUserDetailedSerializer(EventReadDetailedSerializer):
 
     activation_time = ActivationTimeField()
     is_admitted = IsAdmittedField()
+    can_register = CanRegisterField()
     spots_left = SpotsLeftField()
     price = serializers.SerializerMethodField()
 
@@ -186,6 +194,7 @@ class EventReadUserDetailedSerializer(EventReadDetailedSerializer):
             "price",
             "activation_time",
             "is_admitted",
+            "can_register",
             "spots_left",
         )
 
@@ -356,6 +365,7 @@ class FrontpageEventSerializer(serializers.ModelSerializer):
     text = ContentSerializerField()
     activation_time = ActivationTimeField()
     is_admitted = IsAdmittedField()
+    can_register = CanRegisterField()
 
     class Meta:
         model = Event
@@ -377,6 +387,7 @@ class FrontpageEventSerializer(serializers.ModelSerializer):
             "tags",
             "activation_time",
             "is_admitted",
+            "can_register",
             "pinned",
         )
         read_only = True

--- a/lego/apps/events/tests/test_events_api.py
+++ b/lego/apps/events/tests/test_events_api.py
@@ -1142,7 +1142,7 @@ class CreateAdminRegistrationTestCase(BaseAPITestCase):
         AbakusGroup.objects.get(name="Webkom").add_user(self.request_user)
         pool_two = self.event.pools.get(name="Webkom")
 
-        self.assertFalse(self.event.can_register(self.user, self.pool))
+        self.assertFalse(self.event.can_register_to_pool(self.user, self.pool))
         self.client.force_authenticate(self.request_user)
 
         registration_response = self.client.post(
@@ -1161,7 +1161,7 @@ class CreateAdminRegistrationTestCase(BaseAPITestCase):
     def test_without_admin_permission(self):
         AbakusGroup.objects.get(name="Abakus").add_user(self.user)
 
-        self.assertTrue(self.event.can_register(self.user, self.pool))
+        self.assertTrue(self.event.can_register_to_pool(self.user, self.pool))
         self.client.force_authenticate(self.request_user)
 
         registration_response = self.client.post(
@@ -1181,7 +1181,7 @@ class CreateAdminRegistrationTestCase(BaseAPITestCase):
         AbakusGroup.objects.get(name="Abakus").add_user(self.user)
         nonexistant_pool_id = len(self.event.pools.all())
 
-        self.assertTrue(self.event.can_register(self.user, self.pool))
+        self.assertTrue(self.event.can_register_to_pool(self.user, self.pool))
         self.client.force_authenticate(self.request_user)
 
         registration_response = self.client.post(


### PR DESCRIPTION
`can_register` has be renamed to `can_register_to_pool` and a new `can_register` has been created that uses the old logic.
 `can_register` (`canRegister` in the API) will return `True` if the user can register now or in the future. It will, however, return `False` if the user is admitted (`is_admitted = True`), so the combination of `isAdmitted` and `canRegister` needs to be used in the frontend.

This is needed for issue #1526.