### PR TITLE
Add CORS_ORIGIN_DOMAINS to use with CORS_ORIGIN_REGEX_WHITELIST

### DIFF
--- a/lego/settings/production.py
+++ b/lego/settings/production.py
@@ -12,6 +12,7 @@ from lego.settings import (
     MIDDLEWARE,
     PUSH_NOTIFICATIONS_SETTINGS,
 )
+from lego.utils.cors import generate_cors_origin_regex_list
 
 from .secure import *  # noqa
 
@@ -90,11 +91,9 @@ ANALYTICS_HOST = env("ANALYTICS_HOST", default=None)
 ANALYTICS_WRITE_KEY = env("ANALYTICS_WRITE_KEY", default="")
 
 # CORS
-CORS_FRONTEND_URL = urlparse(FRONTEND_URL).netloc
 CORS_ORIGIN_WHITELIST = ["http://127.0.0.1:3000", "http://localhost:3000"]
-CORS_ORIGIN_REGEX_WHITELIST = (
-    r"^(https?://)?(.*\.)?{0}$".format(re.escape(CORS_FRONTEND_URL)),
-)
+CORS_ORIGIN_DOMAINS = env("CORS_ORIGIN_DOMAINS", default=["abakus.no"])
+CORS_ORIGIN_REGEX_WHITELIST = generate_cors_origin_regex_list(CORS_ORIGIN_DOMAINS)
 
 # Restricted
 RESTRICTED_ADDRESS = env("RESTRICTED_ADDRESS", default="restricted")

--- a/lego/utils/cors.py
+++ b/lego/utils/cors.py
@@ -1,0 +1,8 @@
+import re
+
+
+def generate_cors_origin_regex_list(domains):
+    regex_list = []
+    for domain in domains:
+        regex_list.append(r"^(https?://)?(.*\.)?{0}$".format(re.escape(domain)))
+    return regex_list

--- a/lego/utils/tests/test_cors.py
+++ b/lego/utils/tests/test_cors.py
@@ -1,0 +1,84 @@
+from datetime import timedelta
+
+from django.test.utils import override_settings
+from django.utils import timezone
+
+from corsheaders.middleware import (
+    ACCESS_CONTROL_ALLOW_CREDENTIALS,
+    ACCESS_CONTROL_ALLOW_HEADERS,
+    ACCESS_CONTROL_ALLOW_METHODS,
+    ACCESS_CONTROL_ALLOW_ORIGIN,
+    ACCESS_CONTROL_EXPOSE_HEADERS,
+    ACCESS_CONTROL_MAX_AGE,
+)
+
+from lego.utils.cors import generate_cors_origin_regex_list
+from lego.utils.test_utils import BaseTestCase
+
+cors_origin_domains = ["abakus.no", "webkom.dev"]
+
+valid_origins = [
+    # For abakus.no
+    "http://abakus.no",
+    "http://www.abakus.no",
+    "http://webkom.abakus.no",
+    "http://webapp-staging.abakus.no",
+    "http://long.webkom.abakus.no",
+    "https://abakus.no",
+    "https://www.abakus.no",
+    "https://webkom.abakus.no",
+    "https://webapp-staging.abakus.no",
+    "https://long.webkom.abakus.no",
+    # For webkom.dev
+    "http://webkom.dev",
+    "http://www.webkom.dev",
+    "http://webkom.webkom.dev",
+    "http://long.webkom.webkom.dev",
+    "https://webkom.dev",
+    "https://www.webkom.dev",
+    "https://webkom.webkom.dev",
+    "https://long.webkom.webkom.dev",
+]
+
+invalid_origins = [
+    "http://random-website.no",
+    "http://invalid.random-website.no",
+    "http://randomdomain.no",
+    "https://www.test.012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789",
+    "https://012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789.com",
+    "http://m*y.example.com",
+    "http://*my.example.com",
+    "http://.example.com",
+    "http://example.com*",
+    "http://-.com",
+    "http://z-.com",
+    "https://my.best-example*.best-example*.com",
+    "http://127*.0.0.1",
+    "https://my.*.com",
+]
+
+
+class CorsTest(BaseTestCase):
+    @override_settings(
+        CORS_ALLOW_METHODS=["OPTIONS"],
+        CORS_ALLOW_CREDENTIALS=True,
+        CORS_ORIGIN_REGEX_WHITELIST=generate_cors_origin_regex_list(
+            cors_origin_domains
+        ),
+    )
+    def test_valid_cors_origins(self):
+        for valid_origin in valid_origins:
+            resp = self.client.options("/", HTTP_ORIGIN=valid_origin)
+            assert resp[ACCESS_CONTROL_ALLOW_ORIGIN] == valid_origin
+
+    @override_settings(
+        CORS_ALLOW_METHODS=["OPTIONS"],
+        CORS_ALLOW_CREDENTIALS=True,
+        CORS_ORIGIN_REGEX_WHITELIST=generate_cors_origin_regex_list(
+            cors_origin_domains
+        ),
+    )
+    def test_invalid_cors_origins(self):
+        for invalid_origin in invalid_origins:
+            resp = self.client.options("/", HTTP_ORIGIN=invalid_origin)
+            assert ACCESS_CONTROL_ALLOW_ORIGIN not in resp


### PR DESCRIPTION
I have set the `CORS_ORIGIN_DOMAINS` environment variable to all our pipelines in Spinnaker. It is now `abakus.no,webkom.dev`. Tests have been added to test this.