### PR TITLE
Use boto==1.9 (aka. boto3>=1.9<=1.10)

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,7 @@ elasticsearch==6.2.0
 celery==4.2.1
 stripe==2.24.1
 structlog==19.1.0
-boto3==1.9.151
+boto3>=1.9<=1.10
 bs4==0.0.1
 bleach==3.1.0
 requests==2.21.0


### PR DESCRIPTION
Getting crazy by all the boto-PRs. We don't need to pin it to any special version, as long as it keeps using `1.9.XYZ`... No more doppins mail&slack&gituhub-notification every day ™️ 

Pls merge me. NOW. 👼 

Closes https://github.com/webkom/lego/pull/1620