### PR TITLE
Add basic scope support to oauth

### DIFF
--- a/lego/apps/oauth/authentication.py
+++ b/lego/apps/oauth/authentication.py
@@ -14,9 +14,19 @@ class Authentication(OAuth2Authentication):
     def authenticate(self, request):
         authentication = super().authenticate(request)
 
-        if authentication:
-            user = authentication[0]
-            log.bind(current_user=user.id)
-            track(user, "authenticate")
+        if not authentication:
+            return None
+        user, token = authentication
+        log.bind(current_user=user.id)
+        track(user, "authenticate")
 
-        return authentication
+        if token.allow_scopes(["all"]):
+            return authentication
+
+        # Temporary only allow requests to the oauth2_userdata endpoint
+        if (
+            token.allow_scopes(["user"])
+            and request.path == "/api/v1/users/oauth2_userdata/"
+        ):
+            return authentication
+        return None

--- a/lego/apps/users/serializers/users.py
+++ b/lego/apps/users/serializers/users.py
@@ -112,6 +112,40 @@ class SearchGroupSerializer(serializers.ModelSerializer):
         fields = ("id", "name", "type", "logo")
 
 
+class Oauth2UserDataSerializer(serializers.ModelSerializer):
+    """
+    Basic serailizer
+    """
+
+    abakus_groups = PublicAbakusGroupSerializer(many=True)
+    memberships = MembershipSerializer(many=True)
+    profile_picture = ImageField(required=False, options={"height": 200, "width": 200})
+    is_student = serializers.SerializerMethodField()
+    is_abakus_member = serializers.BooleanField()
+
+    class Meta:
+        model = User
+        fields = (
+            "id",
+            "username",
+            "first_name",
+            "last_name",
+            "full_name",
+            "email_address",
+            "profile_picture",
+            "gender",
+            "is_active",
+            "is_student",
+            "abakus_groups",
+            "is_abakus_member",
+            "is_abakom_member",
+            "memberships",
+        )
+
+    def get_is_student(self, user):
+        return user.is_verified_student()
+
+
 class MeSerializer(serializers.ModelSerializer):
     """
     Serializer for the /me, retrieve and update endpoint with EDIT permissions.

--- a/lego/apps/users/views/users.py
+++ b/lego/apps/users/views/users.py
@@ -17,6 +17,7 @@ from lego.apps.users.serializers.registration import RegistrationConfirmationSer
 from lego.apps.users.serializers.users import (
     ChangeGradeSerializer,
     MeSerializer,
+    Oauth2UserDataSerializer,
     PublicUserSerializer,
     PublicUserWithGroupsSerializer,
 )
@@ -70,6 +71,20 @@ class UsersViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
             return [AllowAny()]
 
         return super().get_permissions()
+
+    @action(
+        detail=False,
+        methods=["GET"],
+        # The oauth lib will give permission if it has scope user
+        permission_classes=[IsAuthenticated],
+        serializer_class=Oauth2UserDataSerializer,
+    )
+    def oauth2_userdata(self, request):
+        """
+        Read-only endpoint used to retrieve information about the authenticated user.
+        """
+        serializer = self.get_serializer(request.user)
+        return Response(serializer.data)
 
     @action(
         detail=False,

--- a/lego/settings/base.py
+++ b/lego/settings/base.py
@@ -117,7 +117,10 @@ OAUTH2_PROVIDER_APPLICATION_MODEL = "oauth.APIApplication"
 # Tokens is valid for 7 days.
 OAUTH2_PROVIDER = {
     "ACCESS_TOKEN_EXPIRE_SECONDS": 86400 * 7,
-    "SCOPES": {"user": "Gir tilgang til brukerprofilen."},
+    "SCOPES": {
+        "user": "Enkel brukerinfo. Dette gir lesetilgang til navn, profilbilde, epost og dine medlemskap",
+        "all": "Gir tilgang til all brukerinfo. Kan også gjøre ting som deg",
+    },
 }
 
 ROOT_URLCONF = "lego.urls"

--- a/lego/settings/development.py
+++ b/lego/settings/development.py
@@ -20,6 +20,7 @@ CAPTCHA_KEY = (
     os.environ.get("CAPTCHA_KEY") or "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe"
 )
 
+SESSION_COOKIE_SECURE = False
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql_psycopg2",


### PR DESCRIPTION
If the an oauth app use scope "user", it will only be granted access to
"/users/oauth2_userdata", a simple endpoint with name, profile picture,
memberships.

Scope "all" gives full access.