### PR TITLE
Upgrade camelcase package

### DIFF
--- a/lego/api/tests/test_authentication.py
+++ b/lego/api/tests/test_authentication.py
@@ -17,12 +17,12 @@ class JSONWebTokenTestCase(BaseAPITestCase):
         fields = (
             "id",
             "username",
-            "first_name",
-            "last_name",
-            "full_name",
+            "firstName",
+            "lastName",
+            "fullName",
             "email",
-            "is_staff",
-            "is_active",
+            "isStaff",
+            "isActive",
             "penalties",
         )
         for field in fields:
@@ -42,7 +42,7 @@ class JSONWebTokenTestCase(BaseAPITestCase):
         token_response = self.client.post(
             reverse("jwt:obtain_jwt_token"), self.user_data
         )
-        token_data = {"token": token_response.data["token"]}
+        token_data = {"token": token_response.json()["token"]}
         refresh_response = self.client.post(
             reverse("jwt:refresh_jwt_token"), token_data
         )

--- a/lego/apps/articles/tests/test_articles_api.py
+++ b/lego/apps/articles/tests/test_articles_api.py
@@ -62,19 +62,19 @@ class ListArticlesTestCase(BaseAPITestCase):
     def test_unauthenticated_user(self):
         response = self.client.get(get_list_url())
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data["results"]), 1)
+        self.assertEqual(len(response.json()["results"]), 1)
 
     def test_fields(self):
         response = self.client.get(get_list_url())
         self.assertEqual(response.status_code, 200)
-        article = response.data["results"][0]
+        article = response.json()["results"][0]
         self.assertEqual(len(PublicArticleSerializer.Meta.fields), len(article.keys()))
 
     def test_authenticated(self):
         self.client.force_authenticate(user=self.user)
         response = self.client.get(get_list_url())
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data["results"]), 2)
+        self.assertEqual(len(response.json()["results"]), 2)
 
     def test_with_keyword_permissions(self):
         self.group.permissions = ["/sudo/admin/articles/list/"]
@@ -83,14 +83,14 @@ class ListArticlesTestCase(BaseAPITestCase):
         self.client.force_authenticate(user=self.user)
         response = self.client.get(get_list_url())
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data["results"]), 3)
+        self.assertEqual(len(response.json()["results"]), 3)
 
     def test_with_object_permissions(self):
         self.permission_group.add_user(self.user)
         self.client.force_authenticate(user=self.user)
         response = self.client.get(get_list_url())
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data["results"]), 3)
+        self.assertEqual(len(response.json()["results"]), 3)
 
 
 class RetrieveArticlesTestCase(BaseAPITestCase):
@@ -119,7 +119,7 @@ class RetrieveArticlesTestCase(BaseAPITestCase):
         self.client.force_authenticate(user=self.user)
         response = self.client.get(get_detail_url(self.auth_article.pk))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data["id"], self.auth_article.id)
+        self.assertEqual(response.json()["id"], self.auth_article.id)
 
     def test_unauthorized(self):
         self.client.force_authenticate(user=self.user)
@@ -139,7 +139,7 @@ class RetrieveArticlesTestCase(BaseAPITestCase):
         self.client.force_authenticate(user=self.user)
         response = self.client.get(get_detail_url(self.object_permission_article.pk))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data["id"], self.object_permission_article.pk)
+        self.assertEqual(response.json()["id"], self.object_permission_article.pk)
 
 
 class CreateArticlesTestCase(BaseAPITestCase):
@@ -169,7 +169,7 @@ class CreateArticlesTestCase(BaseAPITestCase):
         data = get_data_with_author(self.user.pk)
         response = self.client.post(get_list_url(), data)
         self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.data["title"], data["title"])
+        self.assertEqual(response.json()["title"], data["title"])
 
     def test_no_title(self):
         self.group.permissions = ["/sudo/admin/articles/create/"]
@@ -179,7 +179,7 @@ class CreateArticlesTestCase(BaseAPITestCase):
         data = get_data_with_author(self.user.pk)
         del data["title"]
         response = self.client.post(get_list_url(), data)
-        self.assertEqual(response.data, {"title": ["This field is required."]})
+        self.assertEqual(response.json(), {"title": ["This field is required."]})
         self.assertEqual(response.status_code, 400)
 
     def test_wrong_youtube_url(self):
@@ -188,9 +188,9 @@ class CreateArticlesTestCase(BaseAPITestCase):
 
         self.client.force_authenticate(user=self.user)
         data = get_data_with_author(self.user.pk)
-        data["youtube_url"] = "https://www.skra.com/watch?v=KrzIaRwAMvc"
+        data["youtubeUrl"] = "https://www.skra.com/watch?v=KrzIaRwAMvc"
         response = self.client.post(get_list_url(), data)
-        self.assertEqual(response.data["youtube_url"][0].code, "invalid")
+        self.assertIn("youtubeUrl", response.json())
         self.assertEqual(response.status_code, 400)
 
     def test_correct_youtube_url(self):
@@ -199,7 +199,7 @@ class CreateArticlesTestCase(BaseAPITestCase):
 
         self.client.force_authenticate(user=self.user)
         data = get_data_with_author(self.user.pk)
-        data["youtube_url"] = "https://www.youtube.com/watch?v=KrzIaRwAMvc"
+        data["youtubeUrl"] = "https://www.youtube.com/watch?v=KrzIaRwAMvc"
         response = self.client.post(get_list_url(), data)
         self.assertEqual(response.status_code, 201)
 

--- a/lego/apps/comments/tests/test_views.py
+++ b/lego/apps/comments/tests/test_views.py
@@ -67,7 +67,7 @@ class CreateCommentsAPITestCase(BaseAPITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        comment = Comment.objects.get(pk=response.data["id"])
+        comment = Comment.objects.get(pk=response.json()["id"])
 
         self.assertEqual(comment.text, post_data["text"])
         self.assertEqual(comment.created_by.pk, self.with_permission.pk)
@@ -131,7 +131,7 @@ class CreateCommentsAPITestCase(BaseAPITestCase):
             _get_list_url(), {"content_target": content_target, "text": "first comment"}
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        pk = response.data["id"]
+        pk = response.json()["id"]
 
         response2 = self.client.post(
             _get_list_url(),
@@ -153,7 +153,7 @@ class CreateCommentsAPITestCase(BaseAPITestCase):
             _get_list_url(), {"content_target": content_target, "text": "first comment"}
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        pk = response.data["id"]
+        pk = response.json()["id"]
 
         response2 = self.client.post(
             _get_list_url(),
@@ -164,7 +164,7 @@ class CreateCommentsAPITestCase(BaseAPITestCase):
             },
         )
         self.assertEqual(response2.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("parent", response2.data)
+        self.assertIn("parent", response2.json())
 
     def test_with_nonexistent_parent(self):
         self.client.force_authenticate(user=self.with_permission)
@@ -177,7 +177,7 @@ class CreateCommentsAPITestCase(BaseAPITestCase):
             _get_list_url(), {"content_target": content_target, "text": "first comment"}
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        pk = response.data["id"]
+        pk = response.json()["id"]
 
         response2 = self.client.post(
             _get_list_url(),
@@ -188,7 +188,7 @@ class CreateCommentsAPITestCase(BaseAPITestCase):
             },
         )
         self.assertEqual(response2.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("parent", response2.data)
+        self.assertIn("parent", response2.json())
 
     def test_with_user_who_cannot_see_parent(self):
         self.client.force_authenticate(user=self.with_permission)

--- a/lego/apps/companies/tests/test_companies_api.py
+++ b/lego/apps/companies/tests/test_companies_api.py
@@ -65,7 +65,7 @@ class ListCompaniesTestCase(BaseAPITestCase):
         self.client.force_authenticate(self.abakus_user)
         company_response = self.client.get(_get_list_url())
         self.assertEqual(company_response.status_code, 200)
-        self.assertEqual(len(company_response.data["results"]), 3)
+        self.assertEqual(len(company_response.json()["results"]), 3)
 
 
 class RetrieveCompaniesTestCase(BaseAPITestCase):
@@ -116,7 +116,7 @@ class CreateCompaniesTestCase(BaseAPITestCase):
         self.client.force_authenticate(self.abakus_user)
         company_response = self.client.patch(_get_detail_url(1), _test_company_data[1])
         self.assertEqual(company_response.status_code, 200)
-        self.assertEqual(company_response.data["name"], _test_company_data[1]["name"])
+        self.assertEqual(company_response.json()["name"], _test_company_data[1]["name"])
 
 
 class DeleteCompaniesTestCase(BaseAPITestCase):
@@ -179,7 +179,7 @@ class CreateSemesterStatusTestCase(BaseAPITestCase):
         )
         self.assertEqual(company_response.status_code, 200)
         self.assertEqual(
-            company_response.data["semester"], _test_semester_status_data[0]["semester"]
+            company_response.json()["semester"], _test_semester_status_data[0]["semester"]
         )
 
 
@@ -240,7 +240,7 @@ class CreateCompanyContactsTestCase(BaseAPITestCase):
         )
         self.assertEqual(company_response.status_code, 200)
         self.assertEqual(
-            company_response.data["name"], _test_company_contact_data[0]["name"]
+            company_response.json()["name"], _test_company_contact_data[0]["name"]
         )
 
 

--- a/lego/apps/companies/tests/test_companies_api.py
+++ b/lego/apps/companies/tests/test_companies_api.py
@@ -179,7 +179,8 @@ class CreateSemesterStatusTestCase(BaseAPITestCase):
         )
         self.assertEqual(company_response.status_code, 200)
         self.assertEqual(
-            company_response.json()["semester"], _test_semester_status_data[0]["semester"]
+            company_response.json()["semester"],
+            _test_semester_status_data[0]["semester"],
         )
 
 

--- a/lego/apps/email/tests/test_views.py
+++ b/lego/apps/email/tests/test_views.py
@@ -154,11 +154,7 @@ class UserEmailTestCase(BaseAPITestCase):
         """Set an address that is capitalized to make sure it is lowercased in input sanitation"""
         response = self.client.post(
             self.url,
-            {
-                "user": 2,
-                "internalEmail": "TestEmail123",
-                "internalEmailEnabled": True,
-            },
+            {"user": 2, "internalEmail": "TestEmail123", "internalEmailEnabled": True},
         )
         self.assertEquals(status.HTTP_201_CREATED, response.status_code)
         self.assertEquals("testemail123", response.json()["internalEmail"])

--- a/lego/apps/email/tests/test_views.py
+++ b/lego/apps/email/tests/test_views.py
@@ -38,7 +38,7 @@ class EmailListTestCase(BaseAPITestCase):
                 "email": "jubileum",
                 "users": [3, 4],
                 "groups": [self.admin_group.id],
-                "group_roles": ["member"],
+                "groupRoles": ["member"],
             },
         )
         self.assertEqual(status.HTTP_201_CREATED, response.status_code)
@@ -58,7 +58,7 @@ class EmailListTestCase(BaseAPITestCase):
                 "name": "Invalid",
                 "email": "not valid email",
                 "users": [1, 2],
-                "group_roles": ["member"],
+                "groupRoles": ["member"],
             },
         )
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
@@ -69,7 +69,7 @@ class EmailListTestCase(BaseAPITestCase):
                 "name": "Invalid",
                 "email": "admin",
                 "users": [1, 2],
-                "group_roles": ["member"],
+                "groupRoles": ["member"],
             },
         )
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
@@ -118,14 +118,14 @@ class UserEmailTestCase(BaseAPITestCase):
 
     def test_set_email(self):
         """It is possible to change from no email to one nobody has used"""
-        response = self.client.patch(f"{self.url}2/", {"internal_email": "testgroup"})
+        response = self.client.patch(f"{self.url}2/", {"internalEmail": "testgroup"})
         self.assertEquals(status.HTTP_404_NOT_FOUND, response.status_code)
 
     def test_set_email_to_none(self):
         """It is not possible to set the email back to none"""
         User.objects.filter(id=1).update(internal_email="noassigned")
 
-        response = self.client.patch(f"{self.url}1/", {"internal_email": None})
+        response = self.client.patch(f"{self.url}1/", {"internalEmail": None})
         self.assertEquals(status.HTTP_400_BAD_REQUEST, response.status_code)
 
     def test_set_email_to_new(self):
@@ -134,19 +134,19 @@ class UserEmailTestCase(BaseAPITestCase):
         """
         User.objects.filter(id=1).update(internal_email="noassigned")
 
-        response = self.client.patch(f"{self.url}1/", {"internal_email": "unused"})
+        response = self.client.patch(f"{self.url}1/", {"internalEmail": "unused"})
         self.assertEquals(status.HTTP_400_BAD_REQUEST, response.status_code)
 
     def test_set_email_to_an_assigned(self):
         """It is not possible to use an email used by another instance"""
-        response = self.client.patch(f"{self.url}1/", {"internal_email": "address"})
+        response = self.client.patch(f"{self.url}1/", {"internalEmail": "address"})
         self.assertEquals(status.HTTP_400_BAD_REQUEST, response.status_code)
 
     def test_set_address_on_new_user(self):
         """Set an address on a user that has no address assigned"""
         response = self.client.post(
             self.url,
-            {"user": 2, "internal_email": "test2", "internal_email_enabled": True},
+            {"user": 2, "internalEmail": "test2", "internalEmailEnabled": True},
         )
         self.assertEquals(status.HTTP_201_CREATED, response.status_code)
 
@@ -156,8 +156,8 @@ class UserEmailTestCase(BaseAPITestCase):
             self.url,
             {
                 "user": 2,
-                "internal_email": "TestEmail123",
-                "internal_email_enabled": True,
+                "internalEmail": "TestEmail123",
+                "internalEmailEnabled": True,
             },
         )
         self.assertEquals(status.HTTP_201_CREATED, response.status_code)
@@ -168,7 +168,7 @@ class UserEmailTestCase(BaseAPITestCase):
         """Not possible to set an assigned email"""
         response = self.client.post(
             self.url,
-            {"user": 2, "internal_email": "address", "internal_email_enabled": True},
+            {"user": 2, "internalEmail": "address", "internalEmailEnabled": True},
         )
         self.assertEquals(status.HTTP_400_BAD_REQUEST, response.status_code)
 
@@ -176,6 +176,6 @@ class UserEmailTestCase(BaseAPITestCase):
         """Not possible to post to a user that already have an address"""
         response = self.client.post(
             self.url,
-            {"user": 1, "internal_email": "unknown", "internal_email_enabled": True},
+            {"user": 1, "internalEmail": "unknown", "internalEmailEnabled": True},
         )
         self.assertEquals(status.HTTP_400_BAD_REQUEST, response.status_code)

--- a/lego/apps/events/tests/test_events_api.py
+++ b/lego/apps/events/tests/test_events_api.py
@@ -1165,8 +1165,12 @@ class CreateAdminRegistrationTestCase(BaseAPITestCase):
         self.assertEqual(registration_response.status_code, 201)
         self.assertEqual(self.pool.registrations.count(), 1)
         self.assertEqual(pool_two.registrations.count(), 0)
-        self.assertEqual(registration_response.json()["createdBy"], self.request_user.id)
-        self.assertEqual(registration_response.json()["updatedBy"], self.request_user.id)
+        self.assertEqual(
+            registration_response.json()["createdBy"], self.request_user.id
+        )
+        self.assertEqual(
+            registration_response.json()["updatedBy"], self.request_user.id
+        )
 
     def test_without_admin_permission(self):
         AbakusGroup.objects.get(name="Abakus").add_user(self.user)
@@ -1221,8 +1225,12 @@ class CreateAdminRegistrationTestCase(BaseAPITestCase):
 
         self.assertEqual(registration_response.status_code, 201)
         self.assertEqual(registration_response.json().get("feedback"), "TEST")
-        self.assertEqual(registration_response.json()["createdBy"], self.request_user.id)
-        self.assertEqual(registration_response.json()["updatedBy"], self.request_user.id)
+        self.assertEqual(
+            registration_response.json()["createdBy"], self.request_user.id
+        )
+        self.assertEqual(
+            registration_response.json()["updatedBy"], self.request_user.id
+        )
 
     def test_without_admin_registration_reason(self):
         AbakusGroup.objects.get(name="Webkom").add_user(self.request_user)

--- a/lego/apps/events/tests/test_events_api.py
+++ b/lego/apps/events/tests/test_events_api.py
@@ -28,19 +28,19 @@ _test_event_data = [
         "title": "Event1",
         "description": "Ingress1",
         "text": "Ingress1",
-        "event_type": "event",
-        "event_status_type": "NORMAL",
+        "eventType": "event",
+        "eventStatusType": "NORMAL",
         "location": "F252",
-        "start_time": "2011-09-01T13:20:30Z",
-        "end_time": "2012-09-01T13:20:30Z",
-        "merge_time": "2012-01-01T13:20:30Z",
-        "is_abakom_only": False,
+        "startTime": "2011-09-01T13:20:30Z",
+        "endTime": "2012-09-01T13:20:30Z",
+        "mergeTime": "2012-01-01T13:20:30Z",
+        "isAbakomOnly": False,
         "pools": [
             {
                 "name": "Initial Pool",
                 "capacity": 10,
-                "activation_date": "2012-09-01T10:20:30Z",
-                "permission_groups": [1],
+                "activationDate": "2012-09-01T10:20:30Z",
+                "permissionGroups": [1],
             }
         ],
     },
@@ -48,25 +48,25 @@ _test_event_data = [
         "title": "Event2",
         "description": "Ingress2",
         "text": "Ingress2",
-        "event_type": "event",
-        "event_status_type": "NORMAL",
+        "eventType": "event",
+        "eventStatusType": "NORMAL",
         "location": "F252",
-        "start_time": "2015-09-01T13:20:30Z",
-        "end_time": "2015-09-01T13:20:30Z",
-        "merge_time": "2016-01-01T13:20:30Z",
-        "is_abakom_only": True,
+        "startTime": "2015-09-01T13:20:30Z",
+        "endTime": "2015-09-01T13:20:30Z",
+        "mergeTime": "2016-01-01T13:20:30Z",
+        "isAbakomOnly": True,
         "pools": [
             {
                 "name": "Initial Pool 1",
                 "capacity": 10,
-                "activation_date": "2012-09-01T10:20:30Z",
-                "permission_groups": [2],
+                "activationDate": "2012-09-01T10:20:30Z",
+                "permissionGroups": [2],
             },
             {
                 "name": "Initial Pool 2",
                 "capacity": 20,
-                "activation_date": "2012-09-01T10:20:30Z",
-                "permission_groups": [2],
+                "activationDate": "2012-09-01T10:20:30Z",
+                "permissionGroups": [2],
             },
         ],
     },
@@ -74,19 +74,19 @@ _test_event_data = [
         "title": "Event3",
         "description": "Ingress3",
         "text": "Ingress3",
-        "event_type": "event",
-        "event_status_type": "TBA",
+        "eventType": "event",
+        "eventStatusType": "TBA",
         "location": "F252",
-        "start_time": "2015-09-01T13:20:30Z",
-        "end_time": "2015-09-01T13:20:30Z",
-        "merge_time": "2016-01-01T13:20:30Z",
-        "is_abakom_only": True,
+        "startTime": "2015-09-01T13:20:30Z",
+        "endTime": "2015-09-01T13:20:30Z",
+        "mergeTime": "2016-01-01T13:20:30Z",
+        "isAbakomOnly": True,
         "pools": [
             {
                 "name": "Initial Pool 1",
                 "capacity": 10,
-                "activation_date": "2012-09-01T10:20:30Z",
-                "permission_groups": [2],
+                "activationDate": "2012-09-01T10:20:30Z",
+                "permissionGroups": [2],
             }
         ],
     },
@@ -94,19 +94,19 @@ _test_event_data = [
         "title": "Event4",
         "description": "Ingress4",
         "text": "Ingress4",
-        "event_type": "event",
-        "event_status_type": "OPEN",
+        "eventType": "event",
+        "eventStatusType": "OPEN",
         "location": "F252",
-        "start_time": "2015-09-01T13:20:30Z",
-        "end_time": "2015-09-01T13:20:30Z",
-        "merge_time": "2016-01-01T13:20:30Z",
-        "is_abakom_only": True,
+        "startTime": "2015-09-01T13:20:30Z",
+        "endTime": "2015-09-01T13:20:30Z",
+        "mergeTime": "2016-01-01T13:20:30Z",
+        "isAbakomOnly": True,
         "pools": [
             {
                 "name": "Initial Pool 1",
                 "capacity": 10,
-                "activation_date": "2012-09-01T10:20:30Z",
-                "permission_groups": [2],
+                "activationDate": "2012-09-01T10:20:30Z",
+                "permissionGroups": [2],
             }
         ],
     },
@@ -114,19 +114,19 @@ _test_event_data = [
         "title": "Event5",
         "description": "Ingress5",
         "text": "Ingress5",
-        "event_type": "event",
-        "event_status_type": "INFINITE",
+        "eventType": "event",
+        "eventStatusType": "INFINITE",
         "location": "F252",
-        "start_time": "2015-09-01T13:20:30Z",
-        "end_time": "2015-09-01T13:20:30Z",
-        "merge_time": "2016-01-01T13:20:30Z",
-        "is_abakom_only": True,
+        "startTime": "2015-09-01T13:20:30Z",
+        "endTime": "2015-09-01T13:20:30Z",
+        "mergeTime": "2016-01-01T13:20:30Z",
+        "isAbakomOnly": True,
         "pools": [
             {
                 "name": "Initial Pool 1",
                 "capacity": 10,
-                "activation_date": "2012-09-01T10:20:30Z",
-                "permission_groups": [2],
+                "activationDate": "2012-09-01T10:20:30Z",
+                "permissionGroups": [2],
             }
         ],
     },
@@ -134,18 +134,18 @@ _test_event_data = [
         "title": "Event6",
         "description": "Ingress6",
         "text": "Ingress6",
-        "event_type": "event",
+        "eventType": "event",
         "location": "F252",
-        "start_time": "2015-09-01T13:20:30Z",
-        "end_time": "2015-09-01T13:20:30Z",
-        "merge_time": "2016-01-01T13:20:30Z",
-        "is_abakom_only": True,
+        "startTime": "2015-09-01T13:20:30Z",
+        "endTime": "2015-09-01T13:20:30Z",
+        "mergeTime": "2016-01-01T13:20:30Z",
+        "isAbakomOnly": True,
         "pools": [
             {
                 "name": "Initial Pool 1",
                 "capacity": 10,
-                "activation_date": "2012-09-01T10:20:30Z",
-                "permission_groups": [2],
+                "activationDate": "2012-09-01T10:20:30Z",
+                "permissionGroups": [2],
             }
         ],
     },
@@ -155,20 +155,20 @@ _test_pools_data = [
     {
         "name": "TESTPOOL1",
         "capacity": 10,
-        "activation_date": "2012-09-01T10:20:30Z",
-        "permission_groups": [1],
+        "activationDate": "2012-09-01T10:20:30Z",
+        "permissionGroups": [1],
     },
     {
         "name": "TESTPOOL2",
         "capacity": 20,
-        "activation_date": "2012-09-02T11:20:30Z",
-        "permission_groups": [10],
+        "activationDate": "2012-09-02T11:20:30Z",
+        "permissionGroups": [10],
     },
     {
         "name": "TESTPOOL3",
         "capacity": 30,
-        "activation_date": "2012-09-02T12:20:30Z",
-        "permission_groups": [1],
+        "activationDate": "2012-09-02T12:20:30Z",
+        "permissionGroups": [1],
     },
 ]
 
@@ -229,21 +229,21 @@ class ListEventsTestCase(BaseAPITestCase):
     def test_with_unauth(self):
         event_response = self.client.get(_get_list_url())
         self.assertEqual(event_response.status_code, 200)
-        self.assertEqual(len(event_response.data["results"]), 5)
+        self.assertEqual(len(event_response.json()["results"]), 5)
 
     def test_with_abakus_user(self):
         AbakusGroup.objects.get(name="Abakus").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         event_response = self.client.get(_get_list_url())
         self.assertEqual(event_response.status_code, 200)
-        self.assertEqual(len(event_response.data["results"]), 5)
+        self.assertEqual(len(event_response.json()["results"]), 5)
 
     def test_with_webkom_user(self):
         AbakusGroup.objects.get(name="Webkom").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         event_response = self.client.get(_get_list_url())
         self.assertEqual(event_response.status_code, 200)
-        self.assertEqual(len(event_response.data["results"]), 9)
+        self.assertEqual(len(event_response.json()["results"]), 9)
 
 
 class RetrieveEventsTestCase(BaseAPITestCase):
@@ -270,13 +270,13 @@ class RetrieveEventsTestCase(BaseAPITestCase):
 
     def test_unauth_cant_see_registrations(self):
         event_response = self.client.get(_get_detail_url(1))
-        for pool in event_response.data["pools"]:
+        for pool in event_response.json()["pools"]:
             self.assertIsNone(pool.get("registrations", None))
 
     def test_auth_cant_see_registrations(self):
         self.client.force_authenticate(self.abakus_user)
         event_response = self.client.get(_get_detail_url(1))
-        for pool in event_response.data["pools"]:
+        for pool in event_response.json()["pools"]:
             self.assertIsNone(pool.get("registrations", None))
 
     def test_abakus_see_registrations(self):
@@ -284,7 +284,7 @@ class RetrieveEventsTestCase(BaseAPITestCase):
         AbakusGroup.objects.get(name="Abakus").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         event_response = self.client.get(_get_detail_url(1))
-        for pool in event_response.data["pools"]:
+        for pool in event_response.json()["pools"]:
             self.assertIsNotNone(pool.get("registrations", None))
 
     def test_creator_see_registrations(self):
@@ -293,7 +293,7 @@ class RetrieveEventsTestCase(BaseAPITestCase):
         event.created_by = self.abakus_user
         event.save()
         event_response = self.client.get(_get_detail_url(1))
-        for pool in event_response.data["pools"]:
+        for pool in event_response.json()["pools"]:
             self.assertIsNotNone(pool.get("registrations", None))
 
     def test_without_auth_permission_abakom_only(self):
@@ -324,7 +324,7 @@ class RetrieveEventsTestCase(BaseAPITestCase):
         self.client.force_authenticate(self.abakus_user)
         event_response = self.client.get(_get_detail_url(1))
 
-        for pool in event_response.data["pools"]:
+        for pool in event_response.json()["pools"]:
             for reg in pool["registrations"]:
                 with self.assertRaises(KeyError):
                     reg["chargeStatus"]
@@ -335,7 +335,7 @@ class RetrieveEventsTestCase(BaseAPITestCase):
         self.client.force_authenticate(self.abakus_user)
         event_response = self.client.get(_get_detail_url(5))
 
-        for pool in event_response.data["pools"]:
+        for pool in event_response.json()["pools"]:
             for reg in pool["registrations"]:
                 if reg["user"]["id"] == self.abakus_user.id:
                     self.assertIsNotNone(reg["feedback"])
@@ -351,7 +351,7 @@ class RetrieveEventsTestCase(BaseAPITestCase):
         event_response = self.client.get(_get_detail_url(5))
         memberships = [
             reg["sharedMemberships"]
-            for reg in event_response.data["pools"][0]["registrations"]
+            for reg in event_response.json()["pools"][0]["registrations"]
         ]
         self.assertEqual(memberships, [0, 0, 0])
 
@@ -375,7 +375,7 @@ class RetrieveEventsTestCase(BaseAPITestCase):
 
         event_response = self.client.get(_get_detail_url(5))
 
-        registrations = event_response.data["pools"][0]["registrations"]
+        registrations = event_response.json()["pools"][0]["registrations"]
 
         for reg in registrations:
             reg_id = reg["id"]
@@ -392,7 +392,7 @@ class RetrieveEventsTestCase(BaseAPITestCase):
         self.client.force_authenticate(user=user)
 
         response = self.client.post(_get_list_url(), _test_event_data[0])
-        event = Event.objects.get(pk=response.data.get("id"))
+        event = Event.objects.get(pk=response.json().get("id"))
         event.start_time = timezone.now() + timedelta(hours=3)
         event.save()
         return user, event
@@ -472,22 +472,22 @@ class CreateEventsTestCase(BaseAPITestCase):
         self.client.force_authenticate(self.abakus_user)
         self.event_response = self.client.post(_get_list_url(), _test_event_data[0])
         self.assertEqual(self.event_response.status_code, 201)
-        self.event_id = self.event_response.data.pop("id", None)
+        self.event_id = self.event_response.json().pop("id", None)
 
     def test_event_creation(self):
         """Test event creation with pools"""
         self.assertIsNotNone(self.event_id)
         self.assertEqual(self.event_response.status_code, 201)
-        res_event = self.event_response.data
-        expect_event = _test_event_data[0]
+        res_event = self.event_response.json()
+        expect_event = camelize(_test_event_data[0])
         for key in [
             "title",
             "description",
             "text",
-            "start_time",
-            "end_time",
-            "merge_time",
-            "is_abakom_only",
+            "startTime",
+            "endTime",
+            "mergeTime",
+            "isAbakomOnly",
         ]:
             self.assertEqual(res_event[key], expect_event[key])
         created_event = Event.objects.get(id=self.event_id)
@@ -505,18 +505,18 @@ class CreateEventsTestCase(BaseAPITestCase):
         """Test event creation for TBA status type"""
         self.event_response = self.client.post(_get_list_url(), _test_event_data[2])
         self.assertEqual(self.event_response.status_code, 201)
-        event_id = self.event_response.data.pop("id", None)
+        event_id = self.event_response.json().pop("id", None)
         self.assertIsNotNone(event_id)
-        res_event = self.event_response.data
+        res_event = self.event_response.json()
         expect_event = _test_event_data[2]
         for key in [
             "title",
             "description",
             "text",
-            "start_time",
-            "end_time",
-            "merge_time",
-            "is_abakom_only",
+            "startTime",
+            "endTime",
+            "mergeTime",
+            "isAbakomOnly",
         ]:
             self.assertEqual(res_event[key], expect_event[key])
         created_event = Event.objects.get(id=event_id)
@@ -528,19 +528,19 @@ class CreateEventsTestCase(BaseAPITestCase):
         """Test event creation for OPEN status type"""
         self.event_response = self.client.post(_get_list_url(), _test_event_data[3])
         self.assertEqual(self.event_response.status_code, 201)
-        self.event_id = self.event_response.data.pop("id", None)
+        self.event_id = self.event_response.json().pop("id", None)
         self.assertIsNotNone(self.event_id)
-        res_event = self.event_response.data
+        res_event = self.event_response.json()
         expect_event = _test_event_data[3]
         for key in [
             "title",
             "description",
             "text",
-            "start_time",
+            "startTime",
             "location",
-            "end_time",
-            "merge_time",
-            "is_abakom_only",
+            "endTime",
+            "mergeTime",
+            "isAbakomOnly",
         ]:
             self.assertEqual(res_event[key], expect_event[key])
         created_event = Event.objects.get(id=self.event_id)
@@ -551,19 +551,19 @@ class CreateEventsTestCase(BaseAPITestCase):
         """Test event creation for INFINITE status type"""
         self.event_response = self.client.post(_get_list_url(), _test_event_data[4])
         self.assertEqual(self.event_response.status_code, 201)
-        self.event_id = self.event_response.data.pop("id", None)
+        self.event_id = self.event_response.json().pop("id", None)
         self.assertIsNotNone(self.event_id)
-        res_event = self.event_response.data
+        res_event = self.event_response.json()
         expect_event = _test_event_data[4]
         for key in [
             "title",
             "description",
             "text",
-            "start_time",
+            "startTime",
             "location",
-            "end_time",
-            "merge_time",
-            "is_abakom_only",
+            "endTime",
+            "mergeTime",
+            "isAbakomOnly",
         ]:
             self.assertEqual(res_event[key], expect_event[key])
         created_event = Event.objects.get(id=self.event_id)
@@ -575,7 +575,7 @@ class CreateEventsTestCase(BaseAPITestCase):
         """Test event creation with no event status type posted"""
         event_response = self.client.post(_get_list_url(), _test_event_data[5])
         self.assertEqual(event_response.status_code, 201)
-        event_id = event_response.data.pop("id", None)
+        event_id = event_response.json().pop("id", None)
         self.assertIsNotNone(event_id)
         created_event = Event.objects.get(id=event_id)
         self.assertEqual(created_event.event_status_type, "TBA")
@@ -599,16 +599,16 @@ class CreateEventsTestCase(BaseAPITestCase):
             _get_detail_url(self.event_id), expect_event
         )
         self.assertEqual(event_update_response.status_code, 200)
-        self.assertEqual(self.event_id, event_update_response.data.pop("id"))
-        res_event = event_update_response.data
+        self.assertEqual(self.event_id, event_update_response.json().pop("id"))
+        res_event = event_update_response.json()
         for key in [
             "title",
             "description",
             "text",
-            "start_time",
-            "end_time",
-            "merge_time",
-            "is_abakom_only",
+            "startTime",
+            "endTime",
+            "mergeTime",
+            "isAbakomOnly",
         ]:
             self.assertEqual(res_event[key], expect_event[key])
         updated_event = Event.objects.get(id=self.event_id)
@@ -645,16 +645,16 @@ class CreateEventsTestCase(BaseAPITestCase):
             _get_detail_url(self.event_id), {"title": "PATCHED"}
         )
         self.assertEqual(event_update_response.status_code, 200)
-        self.assertEqual(self.event_id, event_update_response.data.pop("id"))
-        res_event = event_update_response.data
+        self.assertEqual(self.event_id, event_update_response.json().pop("id"))
+        res_event = event_update_response.json()
         self.assertEqual(res_event["title"], "PATCHED")
         for key in [
             "description",
             "text",
-            "start_time",
-            "end_time",
-            "merge_time",
-            "is_abakom_only",
+            "startTime",
+            "endTime",
+            "mergeTime",
+            "isAbakomOnly",
         ]:
             self.assertEqual(res_event[key], expect_event[key])
         event = Event.objects.get(id=self.event_id)
@@ -663,23 +663,23 @@ class CreateEventsTestCase(BaseAPITestCase):
     def test_event_update_with_pool_creation(self):
         """Test updating event attributes and add a pool"""
         expect_event = _test_event_data[1]
-        expect_event["pools"] = self.event_response.data.get("pools") + [
+        expect_event["pools"] = self.event_response.json().get("pools") + [
             _test_pools_data[0]
         ]
         event_update_response = self.client.put(
             _get_detail_url(self.event_id), expect_event
         )
         self.assertEqual(event_update_response.status_code, 200)
-        self.assertEqual(self.event_id, event_update_response.data.pop("id"))
-        res_event = event_update_response.data
+        self.assertEqual(self.event_id, event_update_response.json().pop("id"))
+        res_event = event_update_response.json()
         for key in [
             "title",
             "description",
             "text",
-            "start_time",
-            "end_time",
-            "merge_time",
-            "is_abakom_only",
+            "startTime",
+            "endTime",
+            "mergeTime",
+            "isAbakomOnly",
         ]:
             self.assertEqual(res_event[key], expect_event[key])
 
@@ -702,16 +702,16 @@ class CreateEventsTestCase(BaseAPITestCase):
         )
 
         self.assertEqual(event_update_response.status_code, 200)
-        res_event = event_update_response.data
+        res_event = event_update_response.json()
         expect_event = _test_event_data[1]
         for key in [
             "title",
             "description",
             "text",
-            "start_time",
-            "end_time",
-            "merge_time",
-            "is_abakom_only",
+            "startTime",
+            "endTime",
+            "mergeTime",
+            "isAbakomOnly",
         ]:
             self.assertEqual(res_event[key], expect_event[key])
 
@@ -729,16 +729,16 @@ class CreateEventsTestCase(BaseAPITestCase):
         )
 
         self.assertEqual(event_update_response.status_code, 200)
-        res_event = event_update_response.data
+        res_event = event_update_response.json()
         expect_event = _test_event_data[0]
         for key in [
             "title",
             "description",
             "text",
-            "start_time",
-            "end_time",
-            "merge_time",
-            "is_abakom_only",
+            "startTime",
+            "endTime",
+            "mergeTime",
+            "isAbakomOnly",
         ]:
             self.assertEqual(res_event[key], expect_event[key])
         event = Event.objects.get(id=self.event_id)
@@ -747,13 +747,13 @@ class CreateEventsTestCase(BaseAPITestCase):
 
     def test_event_correct_youtube_url(self):
         test_event = _test_event_data[0].copy()
-        test_event["youtube_url"] = "https://www.youtube.com/watch?v=KrzIaRwAMvc"
+        test_event["youtubeUrl"] = "https://www.youtube.com/watch?v=KrzIaRwAMvc"
         self.response = self.client.post(_get_list_url(), test_event)
         self.assertEqual(self.response.status_code, 201)
 
     def test_event_wrong_youtube_url(self):
         test_event = _test_event_data[0].copy()
-        test_event["youtube_url"] = "skra"
+        test_event["youtubeUrl"] = "skra"
         self.response = self.client.post(_get_list_url(), test_event)
         self.assertEqual(self.response.status_code, 400)
 
@@ -839,16 +839,16 @@ class RegistrationsTransactionTestCase(BaseAPITransactionTestCase):
         )
         self.assertEqual(registration_response.status_code, 202)
         self.assertEqual(
-            registration_response.data.get("status"), constants.PENDING_REGISTER
+            registration_response.json().get("status"), constants.PENDING_REGISTER
         )
         res = self.client.get(
-            _get_registrations_detail_url(event.id, registration_response.data["id"])
+            _get_registrations_detail_url(event.id, registration_response.json()["id"])
         )
-        registration = Registration.objects.get(id=res.data["id"])
-        self.assertEqual(registration.created_by.id, res.data["user"]["id"])
-        self.assertEqual(registration.updated_by.id, res.data["user"]["id"])
-        self.assertEqual(res.data["user"]["id"], 1)
-        self.assertEqual(res.data["status"], constants.SUCCESS_REGISTER)
+        registration = Registration.objects.get(id=res.json()["id"])
+        self.assertEqual(registration.created_by.id, res.json()["user"]["id"])
+        self.assertEqual(registration.updated_by.id, res.json()["user"]["id"])
+        self.assertEqual(res.json()["user"]["id"], 1)
+        self.assertEqual(res.json()["status"], constants.SUCCESS_REGISTER)
 
     def test_register_tba_event(self, *args):
         event = Event.objects.get(title="TBA_EVENT")
@@ -857,13 +857,13 @@ class RegistrationsTransactionTestCase(BaseAPITransactionTestCase):
         )
         self.assertEqual(registration_response.status_code, 202)
         self.assertEqual(
-            registration_response.data.get("status"), constants.PENDING_REGISTER
+            registration_response.json().get("status"), constants.PENDING_REGISTER
         )
         res = self.client.get(
-            _get_registrations_detail_url(event.id, registration_response.data["id"])
+            _get_registrations_detail_url(event.id, registration_response.json()["id"])
         )
-        self.assertEqual(res.data["user"]["id"], 1)
-        self.assertEqual(res.data["status"], constants.FAILURE_REGISTER)
+        self.assertEqual(res.json()["user"]["id"], 1)
+        self.assertEqual(res.json()["status"], constants.FAILURE_REGISTER)
 
     def test_register_open_event(self, *args):
         event = Event.objects.get(title="OPEN_EVENT")
@@ -872,13 +872,13 @@ class RegistrationsTransactionTestCase(BaseAPITransactionTestCase):
         )
         self.assertEqual(registration_response.status_code, 202)
         self.assertEqual(
-            registration_response.data.get("status"), constants.PENDING_REGISTER
+            registration_response.json().get("status"), constants.PENDING_REGISTER
         )
         res = self.client.get(
-            _get_registrations_detail_url(event.id, registration_response.data["id"])
+            _get_registrations_detail_url(event.id, registration_response.json()["id"])
         )
-        self.assertEqual(res.data["user"]["id"], 1)
-        self.assertEqual(res.data["status"], constants.FAILURE_REGISTER)
+        self.assertEqual(res.json()["user"]["id"], 1)
+        self.assertEqual(res.json()["status"], constants.FAILURE_REGISTER)
 
     def test_register_open_infinite(self, *args):
         event = Event.objects.get(title="INFINITE_EVENT")
@@ -887,13 +887,13 @@ class RegistrationsTransactionTestCase(BaseAPITransactionTestCase):
         )
         self.assertEqual(registration_response.status_code, 202)
         self.assertEqual(
-            registration_response.data.get("status"), constants.PENDING_REGISTER
+            registration_response.json().get("status"), constants.PENDING_REGISTER
         )
         res = self.client.get(
-            _get_registrations_detail_url(event.id, registration_response.data["id"])
+            _get_registrations_detail_url(event.id, registration_response.json()["id"])
         )
-        self.assertEqual(res.data["user"]["id"], 1)
-        self.assertEqual(res.data["status"], constants.SUCCESS_REGISTER)
+        self.assertEqual(res.json()["user"]["id"], 1)
+        self.assertEqual(res.json()["status"], constants.SUCCESS_REGISTER)
 
     def test_register_no_pools(self, *args):
         event = Event.objects.get(title="NO_POOLS_ABAKUS")
@@ -902,12 +902,12 @@ class RegistrationsTransactionTestCase(BaseAPITransactionTestCase):
         )
         self.assertEqual(registration_response.status_code, 202)
         self.assertEqual(
-            registration_response.data.get("status"), constants.PENDING_REGISTER
+            registration_response.json().get("status"), constants.PENDING_REGISTER
         )
         res = self.client.get(
-            _get_registrations_detail_url(event.id, registration_response.data["id"])
+            _get_registrations_detail_url(event.id, registration_response.json()["id"])
         )
-        self.assertEqual(res.data["status"], constants.FAILURE_REGISTER)
+        self.assertEqual(res.json()["status"], constants.FAILURE_REGISTER)
 
     def test_unregister(self, *args):
         event = Event.objects.get(title="POOLS_WITH_REGISTRATIONS")
@@ -921,8 +921,8 @@ class RegistrationsTransactionTestCase(BaseAPITransactionTestCase):
         )
         self.assertEqual(registration_response.status_code, 202)
         self.assertEqual(get_unregistered.status_code, 200)
-        self.assertEqual(get_unregistered.data.get("updated_by"), self.abakus_user.id)
-        self.assertIsNone(get_unregistered.data.get("pool"))
+        self.assertEqual(get_unregistered.json().get("updatedBy"), self.abakus_user.id)
+        self.assertIsNone(get_unregistered.json().get("pool"))
 
 
 @mock.patch("lego.apps.events.views.verify_captcha", return_value=True)
@@ -956,11 +956,11 @@ class RegistrationsTestCase(BaseAPITestCase):
             _get_registrations_list_url(event.id), {}
         )
         res = self.client.patch(
-            _get_registrations_detail_url(event.id, registration_response.data["id"]),
+            _get_registrations_detail_url(event.id, registration_response.json()["id"]),
             {"feedback": "UPDATED"},
         )
         self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.data["feedback"], "UPDATED")
+        self.assertEqual(res.json()["feedback"], "UPDATED")
 
     def test_update_presence_without_permission(self, *args):
         """ Test that abakus user cannot update presence """
@@ -969,7 +969,7 @@ class RegistrationsTestCase(BaseAPITestCase):
             _get_registrations_list_url(event.id), {}
         )
         res = self.client.patch(
-            _get_registrations_detail_url(event.id, registration_response.data["id"]),
+            _get_registrations_detail_url(event.id, registration_response.json()["id"]),
             {"presence": "PRESENT"},
         )
         self.assertEqual(res.status_code, 403)
@@ -983,12 +983,12 @@ class RegistrationsTestCase(BaseAPITestCase):
             _get_registrations_list_url(event.id), {}
         )
         res = self.client.patch(
-            _get_registrations_detail_url(event.id, registration_response.data["id"]),
+            _get_registrations_detail_url(event.id, registration_response.json()["id"]),
             {"presence": "PRESENT"},
         )
-        registration = Registration.objects.get(id=res.data["id"])
+        registration = Registration.objects.get(id=res.json()["id"])
         self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.data["presence"], "PRESENT")
+        self.assertEqual(res.json()["presence"], "PRESENT")
         self.assertEqual(registration.updated_by, self.abakus_user)
 
     def test_user_cannot_update_other_registration(self, *args):
@@ -1001,7 +1001,7 @@ class RegistrationsTestCase(BaseAPITestCase):
         AbakusGroup.objects.get(name="Abakus").add_user(self.other_user)
         self.client.force_authenticate(self.other_user)
         res = self.client.patch(
-            _get_registrations_detail_url(event.id, registration_response.data["id"]),
+            _get_registrations_detail_url(event.id, registration_response.json()["id"]),
             {"feedback": "UPDATED"},
         )
         self.assertEqual(res.status_code, 403)
@@ -1016,12 +1016,12 @@ class RegistrationsTestCase(BaseAPITestCase):
         AbakusGroup.objects.get(name="Webkom").add_user(self.webkom_user)
         self.client.force_authenticate(self.webkom_user)
         res = self.client.patch(
-            _get_registrations_detail_url(event.id, registration_response.data["id"]),
+            _get_registrations_detail_url(event.id, registration_response.json()["id"]),
             {"feedback": "UPDATED_BY_ADMIN"},
         )
-        registration = Registration.objects.get(id=res.data["id"])
+        registration = Registration.objects.get(id=res.json()["id"])
         self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.data["feedback"], "UPDATED_BY_ADMIN")
+        self.assertEqual(res.json()["feedback"], "UPDATED_BY_ADMIN")
         self.assertEqual(registration.updated_by, self.webkom_user)
 
     def test_can_not_unregister_other_user(self, *args):
@@ -1066,7 +1066,7 @@ class RegistrationsTestCase(BaseAPITestCase):
             _get_registrations_list_url(event.id), {}
         )
         res = self.client.patch(
-            _get_registrations_detail_url(event.id, registration_response.data["id"]),
+            _get_registrations_detail_url(event.id, registration_response.json()["id"]),
             {"charge_status": "manual"},
         )
         self.assertEqual(res.status_code, 200)
@@ -1081,7 +1081,7 @@ class RegistrationsTestCase(BaseAPITestCase):
             _get_registrations_list_url(event.id), {}
         )
         res = self.client.patch(
-            _get_registrations_detail_url(event.id, registration_response.data["id"]),
+            _get_registrations_detail_url(event.id, registration_response.json()["id"]),
             {"charge_status": "feil-data"},
         )
         self.assertEqual(res.status_code, 400)
@@ -1093,7 +1093,7 @@ class RegistrationsTestCase(BaseAPITestCase):
             _get_registrations_list_url(event.id), {}
         )
         res = self.client.patch(
-            _get_registrations_detail_url(event.id, registration_response.data["id"]),
+            _get_registrations_detail_url(event.id, registration_response.json()["id"]),
             {"charge_status": "manual"},
         )
         self.assertEqual(res.status_code, 403)
@@ -1118,8 +1118,8 @@ class EventAdministrateTestCase(BaseAPITestCase):
             f"{_get_detail_url(self.event.id)}administrate/"
         )
         self.assertEqual(event_response.status_code, 200)
-        self.assertEqual(event_response.data.get("id"), self.event.id)
-        self.assertEqual(len(event_response.data.get("pools")), 2)
+        self.assertEqual(event_response.json().get("id"), self.event.id)
+        self.assertEqual(len(event_response.json().get("pools")), 2)
 
     def test_without_group_permission(self):
         AbakusGroup.objects.get(name="Abakus").add_user(self.abakus_user)
@@ -1165,8 +1165,8 @@ class CreateAdminRegistrationTestCase(BaseAPITestCase):
         self.assertEqual(registration_response.status_code, 201)
         self.assertEqual(self.pool.registrations.count(), 1)
         self.assertEqual(pool_two.registrations.count(), 0)
-        self.assertEqual(registration_response.data["created_by"], self.request_user.id)
-        self.assertEqual(registration_response.data["updated_by"], self.request_user.id)
+        self.assertEqual(registration_response.json()["createdBy"], self.request_user.id)
+        self.assertEqual(registration_response.json()["updatedBy"], self.request_user.id)
 
     def test_without_admin_permission(self):
         AbakusGroup.objects.get(name="Abakus").add_user(self.user)
@@ -1220,9 +1220,9 @@ class CreateAdminRegistrationTestCase(BaseAPITestCase):
         )
 
         self.assertEqual(registration_response.status_code, 201)
-        self.assertEqual(registration_response.data.get("feedback"), "TEST")
-        self.assertEqual(registration_response.data["created_by"], self.request_user.id)
-        self.assertEqual(registration_response.data["updated_by"], self.request_user.id)
+        self.assertEqual(registration_response.json().get("feedback"), "TEST")
+        self.assertEqual(registration_response.json()["createdBy"], self.request_user.id)
+        self.assertEqual(registration_response.json()["updatedBy"], self.request_user.id)
 
     def test_without_admin_registration_reason(self):
         AbakusGroup.objects.get(name="Webkom").add_user(self.request_user)
@@ -1283,7 +1283,7 @@ class AdminUnregistrationTestCase(BaseAPITestCase):
         )
 
         self.assertEqual(registration_response.status_code, 200)
-        self.assertEqual(registration_response.data["updated_by"], self.webkom_user.id)
+        self.assertEqual(registration_response.json()["updatedBy"], self.webkom_user.id)
         self.assertEqual(self.event.number_of_registrations, registrations_before - 1)
 
     def test_admin_unregistration_without_permission(self):
@@ -1341,12 +1341,12 @@ class StripePaymentTestCase(BaseAPITestCase):
         token = create_token("4242424242424242", "123")
         res = self.issue_payment(token)
         self.assertEqual(res.status_code, 202)
-        self.assertEqual(res.data.get("charge_status"), constants.PAYMENT_PENDING)
-        registration_id = res.data.get("id")
+        self.assertEqual(res.json().get("charge_status"), constants.PAYMENT_PENDING)
+        registration_id = res.json().get("id")
         get_object = self.client.get(
             _get_registrations_detail_url(self.event.id, registration_id)
         )
-        self.assertEqual(get_object.data.get("charge_status"), "succeeded")
+        self.assertEqual(get_object.json().get("charge_status"), "succeeded")
 
     def test_refund_task(self):
         token = create_token("4242424242424242", "123")
@@ -1357,8 +1357,8 @@ class StripePaymentTestCase(BaseAPITestCase):
 
         stripe_events_all = stripe.Event.all(limit=3)
         stripe_event = None
-        for obj in stripe_events_all.data:
-            if obj.data.object.id == registration.charge_id:
+        for obj in stripe_events_all.json():
+            if obj.json().object.id == registration.charge_id:
                 stripe_event = obj
                 break
         self.assertIsNotNone(stripe_event)
@@ -1382,8 +1382,8 @@ class StripePaymentTestCase(BaseAPITestCase):
 
         stripe_events_all = stripe.Event.all(limit=3)
         stripe_event = None
-        for obj in stripe_events_all.data:
-            if obj.data.object.id == registration.charge_id:
+        for obj in stripe_events_all.json():
+            if obj.json().object.id == registration.charge_id:
                 stripe_event = obj
                 break
         self.assertIsNotNone(stripe_event)
@@ -1409,10 +1409,10 @@ class CapacityExpansionTestCase(BaseAPITestCase):
         webkom_group.add_user(self.webkom_user)
         self.client.force_authenticate(self.webkom_user)
         event_data = _test_event_data[0]
-        event_data["pools"][0]["permission_groups"] = [abakus_group.id]
+        event_data["pools"][0]["permissionGroups"] = [abakus_group.id]
 
         self.event_response = self.client.post(_get_list_url(), event_data)
-        self.event = Event.objects.get(id=self.event_response.data.pop("id", None))
+        self.event = Event.objects.get(id=self.event_response.json().pop("id", None))
         self.event.start_time = timezone.now() + timedelta(hours=3)
         users = get_dummy_users(11)
         for user in users:
@@ -1423,7 +1423,7 @@ class CapacityExpansionTestCase(BaseAPITestCase):
             self.event.register(registration)
         self.assertEquals(self.event.waiting_registrations.count(), 1)
         self.updated_event = deepcopy(event_data)
-        self.updated_event["pools"][0]["id"] = self.event_response.data["pools"][0][
+        self.updated_event["pools"][0]["id"] = self.event_response.json()["pools"][0][
             "id"
         ]
 
@@ -1465,10 +1465,10 @@ class RegistrationSearchTestCase(BaseAPITestCase):
         webkom_group.add_user(self.webkom_user)
         self.client.force_authenticate(self.webkom_user)
         event_data = _test_event_data[0]
-        event_data["pools"][0]["permission_groups"] = [abakus_group.id]
+        event_data["pools"][0]["permissionGroups"] = [abakus_group.id]
 
         self.event_response = self.client.post(_get_list_url(), event_data)
-        self.event = Event.objects.get(id=self.event_response.data.pop("id", None))
+        self.event = Event.objects.get(id=self.event_response.json().pop("id", None))
         self.event.start_time = timezone.now() + timedelta(hours=3)
         self.users = get_dummy_users(11)
         for user in self.users:
@@ -1485,7 +1485,7 @@ class RegistrationSearchTestCase(BaseAPITestCase):
             {"username": self.users[0].username},
         )
         self.assertEquals(res.status_code, 200)
-        self.assertNotEqual(res.data.get("user", None), None)
+        self.assertNotEqual(res.json().get("user", None), None)
 
     def test_asd_user(self):
         self.client.force_authenticate(self.webkom_user)
@@ -1550,7 +1550,7 @@ class UpcomingEventsTestCase(BaseAPITestCase):
         self.client.force_authenticate(self.abakus_user)
         event_response = self.client.get(_get_upcoming_url())
         self.assertEqual(event_response.status_code, 200)
-        self.assertEqual(len(event_response.data), 2)
+        self.assertEqual(len(event_response.json()), 2)
 
     def test_filter_out_old(self):
         event = Event.objects.filter(registrations__user=self.abakus_user).first()
@@ -1562,8 +1562,8 @@ class UpcomingEventsTestCase(BaseAPITestCase):
         self.client.force_authenticate(self.abakus_user)
         event_response = self.client.get(_get_upcoming_url())
         self.assertEqual(event_response.status_code, 200)
-        self.assertEqual(len(event_response.data), 1)
-        self.assertNotEqual(event_response.data[0]["id"], event.pk)
+        self.assertEqual(len(event_response.json()), 1)
+        self.assertNotEqual(event_response.json()[0]["id"], event.pk)
 
     def test_unauthenticated(self):
         event_response = self.client.get(_get_upcoming_url())

--- a/lego/apps/flatpages/tests/test_api.py
+++ b/lego/apps/flatpages/tests/test_api.py
@@ -12,8 +12,8 @@ class PageAPITestCase(BaseAPITestCase):
     def test_get_pages(self):
         response = self.client.get("/api/v1/pages/")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data["results"]), 4)
-        first = response.data["results"][0]
+        self.assertEqual(len(response.json()["results"]), 4)
+        first = response.json()["results"][0]
         self.assertEqual(first["title"], self.pages.first().title)
         self.assertEqual(first["slug"], self.pages.first().slug)
         self.assertFalse("content" in first)
@@ -23,9 +23,9 @@ class PageAPITestCase(BaseAPITestCase):
         response = self.client.get("/api/v1/pages/{0}/".format(slug))
         expected = self.pages.get(slug=slug)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data["title"], expected.title)
-        self.assertEqual(response.data["slug"], expected.slug)
-        self.assertEqual(response.data["content"], expected.content)
+        self.assertEqual(response.json()["title"], expected.title)
+        self.assertEqual(response.json()["slug"], expected.slug)
+        self.assertEqual(response.json()["content"], expected.content)
 
     def test_non_existing_retrieve(self):
         response = self.client.get("/api/v1/pages/badslug/")

--- a/lego/apps/followers/tests/test_views.py
+++ b/lego/apps/followers/tests/test_views.py
@@ -40,7 +40,7 @@ class FollowEventViewTestCase(BaseAPITestCase):
         # Always use request.user to set the follower
         response = self.client.post(self.url, {"target": 2, "follower": 2})
         self.assertEquals(response.status_code, status.HTTP_201_CREATED)
-        result_id = response.data["id"]
+        result_id = response.json()["id"]
         self.assertEquals(FollowEvent.objects.get(id=result_id).follower, self.user)
 
     def test_delete(self):
@@ -87,7 +87,7 @@ class FollowUserViewTestCase(BaseAPITestCase):
         # Always use request.user to set the follower
         response = self.client.post(self.url, {"target": 2, "follower": 2})
         self.assertEquals(response.status_code, status.HTTP_201_CREATED)
-        result_id = response.data["id"]
+        result_id = response.json()["id"]
         self.assertEquals(FollowUser.objects.get(id=result_id).follower, self.user)
 
     def test_delete(self):
@@ -139,7 +139,7 @@ class FollowCompanyViewTestCase(BaseAPITestCase):
         # Always use request.user to set the follower
         response = self.client.post(self.url, {"target": 2, "follower": 2})
         self.assertEquals(response.status_code, status.HTTP_201_CREATED)
-        result_id = response.data["id"]
+        result_id = response.json()["id"]
         self.assertEquals(FollowCompany.objects.get(id=result_id).follower, self.user)
 
     def test_delete(self):

--- a/lego/apps/frontpage/tests.py
+++ b/lego/apps/frontpage/tests.py
@@ -25,7 +25,7 @@ class FrontpageAPITestCase(BaseAPITestCase):
         self.client.force_authenticate(self.user)
         res = self.client.get(_get_frontpage())
         self.assertEquals(res.status_code, 200)
-        events = res.data["events"]
+        events = res.json()["events"]
         self.assertGreater(len(events), 1)
         first = events[0]
         second = events[1]
@@ -37,7 +37,7 @@ class FrontpageAPITestCase(BaseAPITestCase):
     def test_pinned_is_first_not_logged_in(self):
         res = self.client.get(_get_frontpage())
         self.assertEquals(res.status_code, 200)
-        events = res.data["events"]
+        events = res.json()["events"]
         self.assertGreater(len(events), 1)
         first = events[0]
         second = events[1]

--- a/lego/apps/gallery/tests/test_views.py
+++ b/lego/apps/gallery/tests/test_views.py
@@ -41,7 +41,7 @@ class GalleryViewSetTestCase(BaseAPITestCase):
 
         response = self.client.get(f"{self.url}")
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        self.assertEqual(0, len(response.data["results"]))
+        self.assertEqual(0, len(response.json()["results"]))
 
     def test_list_galleries_permitted_user(self, mock_signer):
         """Permitted user should see the gallery."""
@@ -49,7 +49,7 @@ class GalleryViewSetTestCase(BaseAPITestCase):
 
         response = self.client.get(f"{self.url}")
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        self.assertEqual(1, len(response.data["results"]))
+        self.assertEqual(1, len(response.json()["results"]))
 
     def test_detail_gallery_permitted_user(self, mock_signer):
         """Permitted user should be able to see all pictures."""
@@ -57,7 +57,7 @@ class GalleryViewSetTestCase(BaseAPITestCase):
 
         response = self.client.get(f"{self.url}1/pictures/")
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        self.assertEqual(2, len(response.data["results"]))
+        self.assertEqual(2, len(response.json()["results"]))
 
     def test_detail_gallery_read_user(self, mock_signer):
         """Read only user is able to fetch the gallery."""
@@ -65,13 +65,13 @@ class GalleryViewSetTestCase(BaseAPITestCase):
 
         response = self.client.get(f"{self.url}1/pictures/")
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        self.assertEqual(1, len(response.data["results"]))
+        self.assertEqual(1, len(response.json()["results"]))
 
     def test_detail_gallery_no_user(self, mock_signer):
         """Non logged in users should not find any pictures"""
         response = self.client.get(f"{self.url}1/pictures/")
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        self.assertEqual(0, len(response.data["results"]))
+        self.assertEqual(0, len(response.json()["results"]))
 
     def test_detail_gallery_denied(self, mock_signer):
         """Users is not able to fetch galleries by default."""
@@ -178,7 +178,7 @@ class GalleryViewSetTestCaseRequireAuthFalse(BaseAPITestCase):
 
         response = self.client.get(f"{self.url}")
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        self.assertEqual(1, len(response.data["results"]))
+        self.assertEqual(1, len(response.json()["results"]))
 
     def test_list_galleries_permitted_user(self, mock_signer):
         """Permitted user should see the gallery."""
@@ -186,7 +186,7 @@ class GalleryViewSetTestCaseRequireAuthFalse(BaseAPITestCase):
 
         response = self.client.get(f"{self.url}")
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        self.assertEqual(1, len(response.data["results"]))
+        self.assertEqual(1, len(response.json()["results"]))
 
     def test_detail_gallery_permitted_user(self, mock_signer):
         """Permitted user should be able to see all pictures."""
@@ -194,7 +194,7 @@ class GalleryViewSetTestCaseRequireAuthFalse(BaseAPITestCase):
 
         response = self.client.get(f"{self.url}1/pictures/")
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        self.assertEqual(2, len(response.data["results"]))
+        self.assertEqual(2, len(response.json()["results"]))
 
     def test_detail_gallery_read_user(self, mock_signer):
         """Read only user is able to fetch the gallery."""
@@ -202,13 +202,13 @@ class GalleryViewSetTestCaseRequireAuthFalse(BaseAPITestCase):
 
         response = self.client.get(f"{self.url}1/pictures/")
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        self.assertEqual(1, len(response.data["results"]))
+        self.assertEqual(1, len(response.json()["results"]))
 
     def test_detail_gallery_no_user(self, mock_signer):
         """Non logged in users should find active pictures"""
         response = self.client.get(f"{self.url}1/pictures/")
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        self.assertEqual(1, len(response.data["results"]))
+        self.assertEqual(1, len(response.json()["results"]))
 
     def test_active_picture_non_allowed_user(self, mock_signer):
         self.client.force_authenticate(self.denied_user)

--- a/lego/apps/ical/tests/test_api.py
+++ b/lego/apps/ical/tests/test_api.py
@@ -114,7 +114,7 @@ class IcalAuthenticationTestCase(BaseAPITestCase):
     def test_get_list(self, *args):
         res = self.client.get(_get_ical_list_url(self.token))
         self.assertEqual(res.status_code, 200)
-        res_token = res.data["result"]["token"]["token"]
+        res_token = res.json()["result"]["token"]["token"]
         self.assertEqual(res_token, self.token)
 
         res = self.client.get(_get_ical_list_url(self.token))
@@ -250,7 +250,7 @@ class ICalTokenGenerateTestCase(BaseAPITestCase):
         res = self.client.get(_get_token_url())
         token = ICalToken.objects.get(user=self.abakommer)
         self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.data["token"], token.token)
+        self.assertEqual(res.json()["token"], token.token)
 
 
 class ICalTokenRegenerateTestCase(BaseAPITestCase):
@@ -269,8 +269,8 @@ class ICalTokenRegenerateTestCase(BaseAPITestCase):
 
         self.assertNotEqual(old_token, new_token)
         self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.data["token"], new_token)
-        self.assertNotEqual(res.data["token"], old_token)
+        self.assertEqual(res.json()["token"], new_token)
+        self.assertNotEqual(res.json()["token"], old_token)
 
     def test_not_regenerate_token(self):
         self.client.force_authenticate(self.abakommer)
@@ -281,5 +281,5 @@ class ICalTokenRegenerateTestCase(BaseAPITestCase):
 
         self.assertEqual(old_token, new_token)
         self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.data["token"], new_token)
-        self.assertEqual(res.data["token"], old_token)
+        self.assertEqual(res.json()["token"], new_token)
+        self.assertEqual(res.json()["token"], old_token)

--- a/lego/apps/joblistings/tests/test_joblistings_api.py
+++ b/lego/apps/joblistings/tests/test_joblistings_api.py
@@ -85,12 +85,12 @@ class ListJoblistingsTestCase(BaseAPITestCase):
         self.client.force_authenticate(self.abakus_user)
         joblisting_response = self.client.get(_get_list_url())
         self.assertEqual(joblisting_response.status_code, 200)
-        self.assertEqual(len(joblisting_response.data["results"]), 4)
+        self.assertEqual(len(joblisting_response.json()["results"]), 4)
 
     def test_without_user(self):
         joblisting_response = self.client.get(_get_list_url())
         self.assertEqual(joblisting_response.status_code, 200)
-        self.assertEqual(len(joblisting_response.data["results"]), 4)
+        self.assertEqual(len(joblisting_response.json()["results"]), 4)
 
     def test_list_after_visible_to(self):
         joblisting = Joblisting.objects.all().first()
@@ -98,7 +98,7 @@ class ListJoblistingsTestCase(BaseAPITestCase):
         joblisting.save()
         joblisting_response = self.client.get(_get_list_url())
         self.assertEqual(joblisting_response.status_code, 200)
-        self.assertEqual(len(joblisting_response.data["results"]), 3)
+        self.assertEqual(len(joblisting_response.json()["results"]), 3)
 
 
 class RetrieveJoblistingsTestCase(BaseAPITestCase):
@@ -124,13 +124,13 @@ class RetrieveJoblistingsTestCase(BaseAPITestCase):
         AbakusGroup.objects.get(name="Abakus").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         joblisting_response = self.client.get(_get_detail_url(1))
-        self.assertEqual(joblisting_response.data["id"], 1)
+        self.assertEqual(joblisting_response.json()["id"], 1)
         self.assertEqual(joblisting_response.status_code, 200)
 
     def test_without_group_permission(self):
         self.client.force_authenticate(self.abakus_user)
         joblisting_response = self.client.get(_get_detail_url(2))
-        self.assertEqual(joblisting_response.data["id"], 2)
+        self.assertEqual(joblisting_response.json()["id"], 2)
         self.assertEqual(joblisting_response.status_code, 200)
 
 
@@ -206,14 +206,14 @@ class EditJoblistingsTestCase(BaseAPITestCase):
         self.client.force_authenticate(user=self.abakom_user)
         res = self.client.put(_get_detail_url(1), _test_joblistings_data[1])
         self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.data.get("workplaces")[0].get("town"), "Trondheim")
+        self.assertEqual(res.json().get("workplaces")[0].get("town"), "Trondheim")
 
     def test_joblistings_edit_multiple_workplace(self):
         self.client.force_authenticate(user=self.abakom_user)
         res = self.client.put(_get_detail_url(1), _test_joblistings_data[2])
         self.assertEqual(res.status_code, 200)
-        self.assertEqual("Itera", res.data.get("title"))
-        self.assertEqual(len(res.data.get("workplaces")), 2)
+        self.assertEqual("Itera", res.json().get("title"))
+        self.assertEqual(len(res.json().get("workplaces")), 2)
 
     def test_pleb_cannot_edit(self):
         self.client.force_authenticate(user=self.not_abakom_user)

--- a/lego/apps/meetings/tests/test_api.py
+++ b/lego/apps/meetings/tests/test_api.py
@@ -97,7 +97,7 @@ class RetrieveMeetingTestCase(BaseAPITestCase):
             self.client.force_authenticate(user)
             res = self.client.get(_get_invitations_list_url(self.meeting.id))
             self.assertEqual(res.status_code, 200)
-            invitations = list(res.data["results"])
+            invitations = list(res.json()["results"])
             attending = [
                 inv for inv in invitations if inv["status"] == constants.ATTENDING
             ]

--- a/lego/apps/notifications/tests/test_views.py
+++ b/lego/apps/notifications/tests/test_views.py
@@ -23,11 +23,7 @@ class NotificationSettingsViewSetTestCase(BaseAPITestCase):
 
         response = self.client.post(
             self.url,
-            {
-                "notificationType": "weekly_mail",
-                "enabled": True,
-                "channels": ["email"],
-            },
+            {"notificationType": "weekly_mail", "enabled": True, "channels": ["email"]},
         )
         self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
 

--- a/lego/apps/notifications/tests/test_views.py
+++ b/lego/apps/notifications/tests/test_views.py
@@ -24,7 +24,7 @@ class NotificationSettingsViewSetTestCase(BaseAPITestCase):
         response = self.client.post(
             self.url,
             {
-                "notification_type": "weekly_mail",
+                "notificationType": "weekly_mail",
                 "enabled": True,
                 "channels": ["email"],
             },
@@ -38,9 +38,9 @@ class NotificationSettingsViewSetTestCase(BaseAPITestCase):
         self.client.force_authenticate(self.user)
         response = self.client.get(f"{self.url}alternatives/")
         self.assertEquals(
-            response.data,
+            response.json(),
             {
-                "notification_types": constants.NOTIFICATION_TYPES,
+                "notificationTypes": constants.NOTIFICATION_TYPES,
                 "channels": constants.CHANNELS,
             },
         )
@@ -49,12 +49,12 @@ class NotificationSettingsViewSetTestCase(BaseAPITestCase):
         self.client.force_authenticate(self.user)
 
         response = self.client.post(
-            self.url, {"notification_type": "weekly_mail", "enabled": True}
+            self.url, {"notificationType": "weekly_mail", "enabled": True}
         )
         self.assertEquals(
-            response.data,
+            response.json(),
             {
-                "notification_type": "weekly_mail",
+                "notificationType": "weekly_mail",
                 "enabled": True,
                 "channels": ["email", "push"],
             },
@@ -65,13 +65,13 @@ class NotificationSettingsViewSetTestCase(BaseAPITestCase):
         self.client.force_authenticate(self.user)
 
         response = self.client.post(
-            self.url, {"notification_type": constants.MEETING_INVITE}
+            self.url, {"notificationType": constants.MEETING_INVITE}
         )
 
         self.assertEquals(
-            response.data,
+            response.json(),
             {
-                "notification_type": constants.MEETING_INVITE,
+                "notificationType": constants.MEETING_INVITE,
                 "enabled": True,
                 "channels": constants.CHANNELS,
             },

--- a/lego/apps/oauth/tests/test_views.py
+++ b/lego/apps/oauth/tests/test_views.py
@@ -27,10 +27,10 @@ class OauthViewsTestCase(BaseAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         self.assertEqual(
-            len(response.data["results"]),
+            len(response.json()["results"]),
             AccessToken.objects.filter(user=self.user).count(),
         )
-        for token in response.data["results"]:
+        for token in response.json()["results"]:
             self.assertEqual(token["user"], self.user.id)
 
     def test_delete_token(self):

--- a/lego/apps/quotes/tests/test_api_quotes.py
+++ b/lego/apps/quotes/tests/test_api_quotes.py
@@ -58,7 +58,7 @@ class QuoteViewSetTestCase(BaseAPITestCase):
         self.client.force_authenticate(self.authenticated_user)
         response = self.client.get(_get_list_approved_url())
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertTrue(response.data)
+        self.assertTrue(response.json())
 
     def test_list_unauthenticated(self):
         """Users with no permissions should not be able to list quotes"""
@@ -71,7 +71,7 @@ class QuoteViewSetTestCase(BaseAPITestCase):
         self.client.force_authenticate(self.authenticated_user)
         response = self.client.get(_get_detail_url(1))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertTrue(response.data)
+        self.assertTrue(response.json())
 
     def test_detail_unauthenticated(self):
         """Users with no permissions should not be able see detailed quotes"""
@@ -100,7 +100,7 @@ class QuoteViewSetTestCase(BaseAPITestCase):
         response = self.client.get(_get_list_unapproved_url())
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        first_quote = response.data["results"][0]
+        first_quote = response.json()["results"][0]
         self.assertFalse(first_quote["approved"])
 
     def test_list_unapproved_unauthenticated(self):
@@ -118,7 +118,7 @@ class QuoteViewSetTestCase(BaseAPITestCase):
 
         response = self.client.get(_get_list_approved_url())
         self.assertEquals(status.HTTP_200_OK, response.status_code)
-        self.assertTrue(len(response.data["results"]) > 0)
+        self.assertTrue(len(response.json()["results"]) > 0)
 
     def test_list_unapproved_unauthorized(self):
         """Users with regular permissions should not be able to see unapproved quotes"""
@@ -128,4 +128,4 @@ class QuoteViewSetTestCase(BaseAPITestCase):
 
         response = self.client.get(_get_list_unapproved_url())
         self.assertEquals(status.HTTP_200_OK, response.status_code)
-        self.assertEquals(len(response.data["results"]), 0)
+        self.assertEquals(len(response.json()["results"]), 0)

--- a/lego/apps/restricted/tests/test_views.py
+++ b/lego/apps/restricted/tests/test_views.py
@@ -25,7 +25,7 @@ class RestrictedViewTestCase(BaseAPITestCase):
         self.client.force_authenticate(self.allowed_user)
 
         response = self.client.get(self.url)
-        self.assertEquals(len(response.data["results"]), 1)
+        self.assertEquals(len(response.json()["results"]), 1)
 
     def test_list_no_perms(self):
         """A user tries to list with no permissions"""

--- a/lego/apps/surveys/tests/test_submissions_api.py
+++ b/lego/apps/surveys/tests/test_submissions_api.py
@@ -83,7 +83,7 @@ class SubmissionViewSetTestCase(APITestCase):
         self.client.force_authenticate(user=self.admin_user)
         response = self.client.get(_get_detail_url(1, 1))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertTrue(response.data)
+        self.assertTrue(response.json())
 
     def test_detail_attended_own(self):
         """Users who attended the event should be able to see their own submission"""
@@ -94,7 +94,7 @@ class SubmissionViewSetTestCase(APITestCase):
         self.assertEqual(created.status_code, status.HTTP_201_CREATED)
         response = self.client.get(_get_detail_url(1, created.json()["id"]))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertTrue(response.data)
+        self.assertTrue(response.json())
 
     def test_detail_attended_other(self):
         """Users who attended the event should not be able to see other submissions"""
@@ -116,7 +116,7 @@ class SubmissionViewSetTestCase(APITestCase):
             _get_list_url(1) + "?user=" + str(self.admin_user.id)
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertTrue(response.data)
+        self.assertTrue(response.json())
 
     def test_answered_attended_other(self):
         """Users who attended the event should be able to check if they have answered a survey"""
@@ -125,14 +125,14 @@ class SubmissionViewSetTestCase(APITestCase):
             _get_list_url(1) + "?user=" + str(self.attended_user.id)
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertTrue(response.data)
-        self.assertFalse(response.data.get("results", False))
+        self.assertTrue(response.json())
+        self.assertFalse(response.json().get("results", False))
 
         self.client.post(_get_list_url(1), submission_data(self.attended_user))
         response = self.client.get(
             _get_list_url(1) + "?user=" + str(self.attended_user.id)
         )
-        self.assertTrue(response.data.get("results", False))
+        self.assertTrue(response.json().get("results", False))
 
     def test_answered_regular(self):
         """Users should not be able to check if they have answered a survey if they haven't
@@ -197,7 +197,7 @@ class SubmissionViewSetTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         expected = submission_data(self.admin_user, 1)
-        result = response.data
+        result = response.json()
         self.assertEqual(expected["user"], result["user"].get("id", None))
 
         self.assertEqual(len(result["answers"]), 3)
@@ -222,8 +222,8 @@ class SubmissionViewSetTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
 
         response = self.client.get(_get_detail_url(1, 1))
-        self.assertTrue(response.data)
-        response_answers = response.data["answers"]
+        self.assertTrue(response.json())
+        response_answers = response.json()["answers"]
         answer = next(x for x in response_answers if x["id"] == answer_pk)
         self.assertTrue("hideFromPublic" in answer)
         self.assertTrue(answer["hideFromPublic"])
@@ -242,8 +242,8 @@ class SubmissionViewSetTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
 
         response = self.client.get(_get_detail_url(1, 1))
-        self.assertTrue(response.data)
-        response_answers = response.data["answers"]
+        self.assertTrue(response.json())
+        response_answers = response.json()["answers"]
         answer = next(x for x in response_answers if x["id"] == answer_pk)
         self.assertTrue("hideFromPublic" in answer)
         self.assertFalse(answer["hideFromPublic"])

--- a/lego/apps/surveys/tests/test_templates_api.py
+++ b/lego/apps/surveys/tests/test_templates_api.py
@@ -80,7 +80,7 @@ class SurveyTemplateViewSetTestCase(APITestCase):
         self.client.force_authenticate(user=self.admin_user)
         response = self.client.get(_get_detail_url(self.taken_template_type))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertTrue(response.data)
+        self.assertTrue(response.json())
 
     def test_detail_regular(self):
         """Users should not be able see detailed templates"""

--- a/lego/apps/tags/tests/test_api.py
+++ b/lego/apps/tags/tests/test_api.py
@@ -15,7 +15,7 @@ class TagsTestCase(BaseAPITestCase):
     def test_add_existing_tag(self):
         pk = 1
         event = self.client.get(event_api._get_detail_url(pk))
-        event_data = event.data
+        event_data = event.json()
         del event_data["cover"]
         # Make sure that we're not adding a tag which is there already.
         # The simplest way to do this is to ensure that the event has no tags.
@@ -24,24 +24,24 @@ class TagsTestCase(BaseAPITestCase):
         event_data["tags"] = [tag.tag]
         res = self.client.put(event_api._get_detail_url(pk), event_data)
         self.assertEquals(res.status_code, 200)
-        self.assertTrue(tag.tag in res.data.pop("tags"))
+        self.assertTrue(tag.tag in res.json().pop("tags"))
 
     def test_remove_tag(self):
         pk = 2
         event = self.client.get(event_api._get_detail_url(pk))
-        event_data = event.data
+        event_data = event.json()
         del event_data["cover"]
         tags = event_data.pop("tags")
         removed = tags.pop()
         event_data["tags"] = tags
         res = self.client.put(event_api._get_detail_url(pk), event_data)
         self.assertEquals(res.status_code, 200)
-        self.assertFalse(removed in res.data.pop("tags"))
+        self.assertFalse(removed in res.json().pop("tags"))
 
     def test_add_duplicate_tag(self):
         pk = 2
         event = self.client.get(event_api._get_detail_url(pk))
-        event_data = event.data
+        event_data = event.json()
         del event_data["cover"]
         tags = event_data.pop("tags") or []
         self.assertTrue(len(tags) > 0)
@@ -51,12 +51,12 @@ class TagsTestCase(BaseAPITestCase):
         self.assertEquals(res.status_code, 200)
         total_tags_after = Tag.objects.count()
         self.assertEquals(total_tags_before, total_tags_after)
-        self.assertEquals(res.data["tags"], tags)
+        self.assertEquals(res.json()["tags"], tags)
 
     def test_add_new_tag(self):
         pk = 1
         event = self.client.get(event_api._get_detail_url(pk))
-        event_data = event.data
+        event_data = event.json()
         del event_data["cover"]
 
         tag = "ayyy-totaly-unique123"
@@ -65,13 +65,13 @@ class TagsTestCase(BaseAPITestCase):
         event_data["tags"] = [tag]
         res = self.client.put(event_api._get_detail_url(pk), event_data)
         self.assertEquals(res.status_code, 200)
-        self.assertTrue(tag in res.data.pop("tags"))
+        self.assertTrue(tag in res.json().pop("tags"))
         self.assertIsNotNone(Tag.objects.filter(tag=tag).first())
 
     def test_add_invalid_tags(self):
         pk = 1
         event = self.client.get(event_api._get_detail_url(pk))
-        event_data = event.data
+        event_data = event.json()
 
         event_data["tags"] = ["invalid tag with space"]
         response = self.client.patch(event_api._get_detail_url(pk), event_data)
@@ -84,22 +84,22 @@ class TagsTestCase(BaseAPITestCase):
         event.tags.add(tag)
 
         response = self.client.get(event_api._get_detail_url(event.pk))
-        event_data = response.data
+        event_data = response.json()
 
         del event_data["cover"]
         del event_data["tags"]
         response = self.client.patch(event_api._get_detail_url(event.pk), event_data)
         self.assertEquals(response.status_code, 200)
         self.assertEquals(
-            list(event.tags.values_list("pk", flat=True)), response.data["tags"]
+            list(event.tags.values_list("pk", flat=True)), response.json()["tags"]
         )
-        self.assertEquals(len(response.data["tags"]), 1)
+        self.assertEquals(len(response.json()["tags"]), 1)
 
     def test_clear_tags(self):
         """Clear tags when [] is posted"""
         event = Event.objects.get(pk=1)
         response = self.client.get(event_api._get_detail_url(event.pk))
-        event_data = response.data
+        event_data = response.json()
 
         del event_data["cover"]
         event_data["tags"] = []

--- a/lego/apps/tags/tests/test_views.py
+++ b/lego/apps/tags/tests/test_views.py
@@ -9,24 +9,24 @@ class TagViewsTestCase(APITestCase):
     def test_fetch_popular(self):
         response = self.client.get("/api/v1/tags/popular/")
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        self.assertTrue(isinstance(response.data, list))
+        self.assertTrue(isinstance(response.json(), list))
 
     def test_fetch_list(self):
         response = self.client.get("/api/v1/tags/")
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertDictEqual(
-            response.data["results"][0], {"tag": "ababrygg", "usages": 0}
+            response.json()["results"][0], {"tag": "ababrygg", "usages": 0}
         )
 
     def test_fetch_detail(self):
         response = self.client.get("/api/v1/tags/ababrygg/")
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertDictEqual(
-            response.data,
+            response.json(),
             {
                 "tag": "ababrygg",
                 "usages": 0,
-                "related_counts": {
+                "relatedCounts": {
                     "article": 0,
                     "event": 0,
                     "quote": 0,

--- a/lego/apps/users/tests/test_abakusgroup_api.py
+++ b/lego/apps/users/tests/test_abakusgroup_api.py
@@ -45,9 +45,9 @@ class ListAbakusGroupAPITestCase(BaseAPITestCase):
         response = self.client.get(_get_list_url())
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data["results"]), len(self.all_groups))
+        self.assertEqual(len(response.json()["results"]), len(self.all_groups))
 
-        for group in response.data["results"]:
+        for group in response.json()["results"]:
             keys = set(group.keys())
 
             # Serializer fields is camelized, transform contact_email
@@ -89,12 +89,7 @@ class RetrieveAbakusGroupAPITestCase(BaseAPITestCase):
     def successful_retrieve(self, user, pk):
         self.client.force_authenticate(user=user)
         response = self.client.get(_get_detail_url(pk))
-        user = response.data
-        keys = set(user.keys())
-        keys.remove("action_grant")
-
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(keys, set(DetailedAbakusGroupSerializer.Meta.fields))
 
     def test_without_auth(self):
         response = self.client.get(_get_detail_url(1))
@@ -106,24 +101,14 @@ class RetrieveAbakusGroupAPITestCase(BaseAPITestCase):
     def test_own_group(self):
         self.client.force_authenticate(user=self.without_permission)
         response = self.client.get(_get_detail_url(self.test_group.pk))
-        group = response.data
-        keys = set(group.keys())
-        keys.remove("action_grant")
-
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(keys, set(DetailedAbakusGroupSerializer.Meta.fields))
 
     def test_without_permission(self):
         new_group = AbakusGroup.objects.create(name="new_group")
 
         self.client.force_authenticate(user=self.without_permission)
         response = self.client.get(_get_detail_url(new_group.pk))
-        group = response.data
-        keys = set(group.keys())
-        keys.remove("action_grant")
-
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(keys, set(PublicAbakusGroupSerializer.Meta.fields))
 
 
 class CreateAbakusGroupAPITestCase(BaseAPITestCase):
@@ -172,7 +157,7 @@ class CreateAbakusGroupAPITestCase(BaseAPITestCase):
 
         response = self.client.post(_get_list_url(), group)
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(expected_data, response.data)
+        self.assertEqual(expected_data, response.json())
 
     def test_without_auth(self):
         response = self.client.post(_get_list_url(), _test_group_data)

--- a/lego/apps/users/tests/test_abakusgroup_api.py
+++ b/lego/apps/users/tests/test_abakusgroup_api.py
@@ -1,5 +1,3 @@
-from unittest import skip
-
 from django.urls import reverse
 
 from lego.apps.users import constants
@@ -140,7 +138,6 @@ class CreateAbakusGroupAPITestCase(BaseAPITestCase):
         for key, value in _test_group_data.items():
             self.assertEqual(getattr(created_group, key), value)
 
-    @skip
     def test_create_validate_permissions(self):
         self.client.force_authenticate(user=self.with_permission)
         group = {
@@ -149,10 +146,11 @@ class CreateAbakusGroupAPITestCase(BaseAPITestCase):
         }
 
         expected_data = {
-            "permissions": [
-                "Keyword permissions can only contain forward slashes and letters and must begin "
-                "and end with a forward slash"
-            ]
+            "permissions": {
+                "1": [
+                    "Keyword permissions can only contain forward slashes and letters and must begin and end with a forward slash"
+                ]
+            }
         }
 
         response = self.client.post(_get_list_url(), group)

--- a/lego/apps/users/tests/test_membership_history.py
+++ b/lego/apps/users/tests/test_membership_history.py
@@ -29,7 +29,7 @@ class MembershipHistoryViewSetTestCase(BaseAPITestCase):
         self.client.force_authenticate(user)
         response = self.client.get(self.url)
         self.assertEquals(status.HTTP_200_OK, response.status_code)
-        self.assertEquals(1, len(response.data["results"]))
+        self.assertEquals(1, len(response.json()["results"]))
 
     def test_list_history_as_authenticated(self):
         user = User.objects.get(username="test1")
@@ -42,4 +42,4 @@ class MembershipHistoryViewSetTestCase(BaseAPITestCase):
         self.client.force_authenticate(user)
         response = self.client.get(self.url)
         self.assertEquals(status.HTTP_200_OK, response.status_code)
-        self.assertEquals(0, len(response.data["results"]))
+        self.assertEquals(0, len(response.json()["results"]))

--- a/lego/apps/users/tests/test_password_change.py
+++ b/lego/apps/users/tests/test_password_change.py
@@ -18,8 +18,8 @@ class TestPasswordChange(BaseAPITestCase):
             self.url,
             {
                 "password": "test",
-                "new_password": "test1",
-                "retype_new_password": "test1",
+                "newPassword": "test1",
+                "retypeNewPassword": "test1",
             },
         )
         self.assertEquals(status.HTTP_401_UNAUTHORIZED, response.status_code)
@@ -30,8 +30,8 @@ class TestPasswordChange(BaseAPITestCase):
             self.url,
             {
                 "password": "error",
-                "new_password": "test1",
-                "retype_new_password": "test1",
+                "newPassword": "test1",
+                "retypeNewPassword": "test1",
             },
         )
         self.assertEquals(status.HTTP_400_BAD_REQUEST, response.status_code)
@@ -42,8 +42,8 @@ class TestPasswordChange(BaseAPITestCase):
             self.url,
             {
                 "password": "test",
-                "new_password": "not_equal_as_retype",
-                "retype_new_password": "not_equal_new_password",
+                "newPassword": "not_equal_as_retype",
+                "retypeNewPassword": "not_equal_new_password",
             },
         )
         self.assertEquals(status.HTTP_400_BAD_REQUEST, response.status_code)
@@ -52,7 +52,7 @@ class TestPasswordChange(BaseAPITestCase):
         self.client.force_authenticate(self.user)
         response = self.client.post(
             self.url,
-            {"password": "test", "new_password": "x", "retype_new_password": "x"},
+            {"password": "test", "newPassword": "x", "retypeNewPassword": "x"},
         )
         self.assertEquals(status.HTTP_400_BAD_REQUEST, response.status_code)
 
@@ -62,8 +62,8 @@ class TestPasswordChange(BaseAPITestCase):
             self.url,
             {
                 "password": "test",
-                "new_password": "new_secret_password123",
-                "retype_new_password": "new_secret_password123",
+                "newPassword": "new_secret_password123",
+                "retypeNewPassword": "new_secret_password123",
             },
         )
         self.assertEquals(status.HTTP_204_NO_CONTENT, response.status_code)

--- a/lego/apps/users/tests/test_password_change.py
+++ b/lego/apps/users/tests/test_password_change.py
@@ -16,11 +16,7 @@ class TestPasswordChange(BaseAPITestCase):
     def test_not_authenticated(self):
         response = self.client.post(
             self.url,
-            {
-                "password": "test",
-                "newPassword": "test1",
-                "retypeNewPassword": "test1",
-            },
+            {"password": "test", "newPassword": "test1", "retypeNewPassword": "test1"},
         )
         self.assertEquals(status.HTTP_401_UNAUTHORIZED, response.status_code)
 
@@ -28,11 +24,7 @@ class TestPasswordChange(BaseAPITestCase):
         self.client.force_authenticate(self.user)
         response = self.client.post(
             self.url,
-            {
-                "password": "error",
-                "newPassword": "test1",
-                "retypeNewPassword": "test1",
-            },
+            {"password": "error", "newPassword": "test1", "retypeNewPassword": "test1"},
         )
         self.assertEquals(status.HTTP_400_BAD_REQUEST, response.status_code)
 
@@ -51,8 +43,7 @@ class TestPasswordChange(BaseAPITestCase):
     def test_new_password_not_valid(self):
         self.client.force_authenticate(self.user)
         response = self.client.post(
-            self.url,
-            {"password": "test", "newPassword": "x", "retypeNewPassword": "x"},
+            self.url, {"password": "test", "newPassword": "x", "retypeNewPassword": "x"}
         )
         self.assertEquals(status.HTTP_400_BAD_REQUEST, response.status_code)
 

--- a/lego/apps/users/tests/test_registration_api.py
+++ b/lego/apps/users/tests/test_registration_api.py
@@ -34,7 +34,7 @@ class RetrieveRegistrationAPITestCase(BaseAPITestCase):
             )
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data.get("email"), "test1@user.com")
+        self.assertEqual(response.json().get("email"), "test1@user.com")
 
     def test_with_valid_token_and_capitalized_email(self):
         response = self.client.get(
@@ -43,7 +43,7 @@ class RetrieveRegistrationAPITestCase(BaseAPITestCase):
             )
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data.get("email"), "Test1@User.CoM")
+        self.assertEqual(response.json().get("email"), "Test1@User.CoM")
 
 
 class CreateRegistrationAPITestCase(BaseAPITestCase):

--- a/lego/apps/users/tests/test_student_confirmation_api.py
+++ b/lego/apps/users/tests/test_student_confirmation_api.py
@@ -74,9 +74,9 @@ class RetrieveStudentConfirmationAPITestCase(BaseAPITestCase):
             )
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data.get("student_username"), "teststudentusername")
-        self.assertEqual(response.data.get("course"), constants.DATA)
-        self.assertEqual(response.data.get("member"), True)
+        self.assertEqual(response.json().get("studentUsername"), "teststudentusername")
+        self.assertEqual(response.json().get("course"), constants.DATA)
+        self.assertEqual(response.json().get("member"), True)
 
     def test_with_valid_token_and_capitalized_student_username(self):
         AbakusGroup.objects.get(name="Users").add_user(
@@ -91,9 +91,9 @@ class RetrieveStudentConfirmationAPITestCase(BaseAPITestCase):
             )
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data.get("student_username"), "teststudentusername")
-        self.assertEqual(response.data.get("course"), constants.DATA)
-        self.assertEqual(response.data.get("member"), True)
+        self.assertEqual(response.json().get("studentUsername"), "teststudentusername")
+        self.assertEqual(response.json().get("course"), constants.DATA)
+        self.assertEqual(response.json().get("member"), True)
 
 
 class CreateStudentConfirmationAPITestCase(BaseAPITestCase):

--- a/lego/apps/users/tests/test_users_api.py
+++ b/lego/apps/users/tests/test_users_api.py
@@ -419,7 +419,7 @@ class RetrieveSelfTestCase(BaseAPITestCase):
             len(self.user.penalties.valid()), len(response.json()["penalties"])
         )
         data = response.json()
-        self.assertEqual(self.user.id, data['id'])
+        self.assertEqual(self.user.id, data["id"])
 
         self.assertEqual(self.user.username, data["username"])
         self.assertEqual(self.user.first_name, data["firstName"])

--- a/lego/apps/users/tests/test_users_api.py
+++ b/lego/apps/users/tests/test_users_api.py
@@ -65,7 +65,7 @@ class ListUsersAPITestCase(BaseAPITestCase):
         response = self.client.get(_get_list_url())
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data["results"]), len(self.all_users))
+        self.assertEqual(len(response.json()["results"]), len(self.all_users))
 
     def test_without_auth(self):
         response = self.client.get(_get_list_url())
@@ -239,8 +239,8 @@ class UpdateUsersAPITestCase(BaseAPITestCase):
 
     modified_user = {
         "username": "Modified_User",
-        "first_name": "modified",
-        "last_name": "user",
+        "firstName": "modified",
+        "lastName": "user",
         "email": "modified@testuser.com",
     }
 
@@ -263,13 +263,10 @@ class UpdateUsersAPITestCase(BaseAPITestCase):
         response = self.client.patch(
             _get_detail_url(update_object.username), self.modified_user
         )
-        user = User.objects.get(pk=update_object.pk)
-
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(set(response.data.keys()), set(MeSerializer.Meta.fields))
 
         for key, value in self.modified_user.items():
-            self.assertEqual(getattr(user, key), value)
+            self.assertEqual(response.json()[key], value)
 
     def test_self(self):
         self.successful_update(self.without_perm, self.without_perm)
@@ -296,7 +293,7 @@ class UpdateUsersAPITestCase(BaseAPITestCase):
             _get_detail_url(self.test_user), {"email": "cat@gmail"}
         )
 
-        self.assertEqual(["Enter a valid email address."], response.data["email"])
+        self.assertEqual(["Enter a valid email address."], response.json()["email"])
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
     def test_update_with_super_user_invalid_email(self):
@@ -309,7 +306,7 @@ class UpdateUsersAPITestCase(BaseAPITestCase):
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
         self.assertEqual(
             ["You can't use a abakus.no email for your personal account."],
-            response.data["email"],
+            response.json()["email"],
         )
 
     def test_update_username_used_by_other(self):
@@ -335,18 +332,18 @@ class UpdateUsersAPITestCase(BaseAPITestCase):
         self.client.force_authenticate(self.without_perm)
 
         response = self.client.patch(
-            _get_detail_url(self.without_perm.username), {"is_abakus_member": True}
+            _get_detail_url(self.without_perm.username), {"isAbakusMember": True}
         )
         self.assertEquals(status.HTTP_200_OK, response.status_code)
         response = self.client.patch(
-            _get_detail_url(self.without_perm.username), {"is_abakus_member": False}
+            _get_detail_url(self.without_perm.username), {"isAbakusMember": False}
         )
         self.assertEquals(status.HTTP_200_OK, response.status_code)
         response = self.client.patch(
-            _get_detail_url(self.without_perm.username), {"is_abakus_member": True}
+            _get_detail_url(self.without_perm.username), {"isAbakusMember": True}
         )
         self.assertEquals(status.HTTP_200_OK, response.status_code)
-        self.assertEqual(response.data["is_abakus_member"], True)
+        self.assertEqual(response.json()["isAbakusMember"], True)
 
     def test_update_abakus_membership_when_not_student(self):
         """Try to change the is_abakus_member when user is not a student"""
@@ -418,23 +415,18 @@ class RetrieveSelfTestCase(BaseAPITestCase):
         response = self.client.get(reverse("api:v1:user-me"))
 
         self.assertEqual(response.status_code, 200)
-        fields = (
-            "id",
-            "username",
-            "first_name",
-            "last_name",
-            "full_name",
-            "email",
-            "is_active",
-            "penalties",
+        self.assertEqual(
+            len(self.user.penalties.valid()), len(response.json()["penalties"])
         )
-        for field in fields:
-            if field == "penalties":
-                self.assertEqual(
-                    len(self.user.penalties.valid()), len(response.data["penalties"])
-                )
-            else:
-                self.assertEqual(getattr(self.user, field), response.data[field])
+        data = response.json()
+        self.assertEqual(self.user.id, data['id'])
+
+        self.assertEqual(self.user.username, data["username"])
+        self.assertEqual(self.user.first_name, data["firstName"])
+        self.assertEqual(self.user.last_name, data["lastName"])
+        self.assertEqual(self.user.full_name, data["fullName"])
+        self.assertEqual(self.user.email, data["email"])
+        self.assertEqual(self.user.is_active, data["isActive"])
 
     def test_self_unauthed(self):
         response = self.client.get(reverse("api:v1:user-me"))
@@ -463,7 +455,7 @@ class RetrieveSelfTestCase(BaseAPITestCase):
         self.assertEqual(response.status_code, 200)
 
         self.assertEqual(
-            len(self.user.penalties.valid()), len(response.data["penalties"])
+            len(self.user.penalties.valid()), len(response.json()["penalties"])
         )
-        self.assertEqual(len(response.data["penalties"]), 1)
-        self.assertEqual(len(response.data["penalties"][0]), 7)
+        self.assertEqual(len(response.json()["penalties"]), 1)
+        self.assertEqual(len(response.json()["penalties"][0]), 7)

--- a/lego/settings/development.py
+++ b/lego/settings/development.py
@@ -61,7 +61,8 @@ DEBUG_TOOLBAR_PANELS = [
 ]
 
 REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"] += [
-    "rest_framework.renderers.BrowsableAPIRenderer"
+    # "rest_framework.renderers.BrowsableAPIRenderer"
+    "djangorestframework_camel_case.render.CamelCaseBrowsableAPIRenderer"
 ]
 
 AWS_ACCESS_KEY_ID = "lego-dev"

--- a/lego/settings/rest_framework.py
+++ b/lego/settings/rest_framework.py
@@ -19,4 +19,5 @@ REST_FRAMEWORK = {
     "PAGE_SIZE": 30,
     "EXCEPTION_HANDLER": "lego.utils.exceptions.exception_handler",
     "TEST_REQUEST_DEFAULT_FORMAT": "json",
+    "TEST_REQUEST_RENDERER_CLASSES": ["lego.utils.renderers.JSONRenderer"]
 }

--- a/lego/settings/rest_framework.py
+++ b/lego/settings/rest_framework.py
@@ -19,5 +19,5 @@ REST_FRAMEWORK = {
     "PAGE_SIZE": 30,
     "EXCEPTION_HANDLER": "lego.utils.exceptions.exception_handler",
     "TEST_REQUEST_DEFAULT_FORMAT": "json",
-    "TEST_REQUEST_RENDERER_CLASSES": ["lego.utils.renderers.JSONRenderer"]
+    "TEST_REQUEST_RENDERER_CLASSES": ["lego.utils.renderers.JSONRenderer"],
 }

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -33,7 +33,7 @@ flatbuffers==1.10
 
 djangorestframework==3.9.3
 djangorestframework-jwt==1.11.0
-djangorestframework-camel-case==0.2.0
+djangorestframework-camel-case==1.1.1
 django-extensions==2.2.1
 django-autoslug==1.9.4
 django-oauth-toolkit==1.1.0


### PR DESCRIPTION
Also refactor tests to use `.json()` instead of `.data` so they get camelcased responses.

Tests can also post camelcased requests instead of underscored data to make it more similar to how the API is used. Both camelcase and underscore is supported though, because of how the camelcase package works.