### PR TITLE
Random quote freshness

### DIFF
--- a/lego/apps/quotes/fixtures/development_quotes.yaml
+++ b/lego/apps/quotes/fixtures/development_quotes.yaml
@@ -17,6 +17,30 @@
 - model: quotes.Quote
   pk: 3
   fields:
+    title: Test tittel
+    text: Sist gang jeg løftet noe tungt var 1L melk
+    source: Peder når han må ta håndbak
+    approved: 1
+
+- model: quotes.Quote
+  pk: 4
+  fields:
+    title: Test tittel
+    text: Jeg må skaffe meg en jobb der jeg kan sparke folk
+    source: Odin
+    approved: 1
+
+- model: quotes.Quote
+  pk: 5
+  fields:
+    title: Test tittel
+    text: Du snakker med charterkongen her
+    source: Peder
+    approved: 1
+
+- model: quotes.Quote
+  pk: 6
+  fields:
     title: Webkommer forsøker å avvise en invitasjon til en strippeklubb
     text: I like the big dick from the man
     source: Webkommedlem

--- a/lego/apps/quotes/views.py
+++ b/lego/apps/quotes/views.py
@@ -1,3 +1,4 @@
+import ast
 from random import choice
 
 from rest_framework import status, viewsets
@@ -43,8 +44,8 @@ class QuoteViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
 
     @action(detail=False, methods=["GET"])
     def random(self, request, *args, **kwargs):
-        seen_query_param = request.query_params.get("seen", [])
-        seen = eval(seen_query_param)
+        seen_query_param = request.query_params.get("seen", "[]")
+        seen = ast.literal_eval(seen_query_param)
         queryset = self.get_queryset().filter(approved=True)
         # Check if there are more "fresh", ie unseen, quotes. Otherwise, we have no choice but to show a stale one.
         if len(seen) < len(queryset):

--- a/lego/apps/quotes/views.py
+++ b/lego/apps/quotes/views.py
@@ -43,7 +43,7 @@ class QuoteViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
         return Response(status=status.HTTP_200_OK)
 
     @action(detail=False, methods=["GET"])
-    def random(self, request, *args, **kwargs):
+    def random(self, request):
         seen_query_param = request.query_params.get("seen", "[]")
         seen = ast.literal_eval(seen_query_param)
         queryset = self.get_queryset().filter(approved=True)

--- a/lego/apps/quotes/views.py
+++ b/lego/apps/quotes/views.py
@@ -43,7 +43,10 @@ class QuoteViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
 
     @action(detail=False, methods=["GET"])
     def random(self, request):
+        seen = [3, 12]
         queryset = self.get_queryset().filter(approved=True)
+        if len(seen) != len(queryset):
+            queryset = queryset.exclude(pk__in=seen)
         values = queryset.values_list("pk", flat=True)
         if not values:
             return Response(status=status.HTTP_204_NO_CONTENT)

--- a/lego/apps/quotes/views.py
+++ b/lego/apps/quotes/views.py
@@ -42,10 +42,12 @@ class QuoteViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
         return Response(status=status.HTTP_200_OK)
 
     @action(detail=False, methods=["GET"])
-    def random(self, request):
-        seen = [3, 12]
+    def random(self, request, *args, **kwargs):
+        seen_query_param = request.query_params.get("seen", [])
+        seen = eval(seen_query_param)
         queryset = self.get_queryset().filter(approved=True)
-        if len(seen) != len(queryset):
+        # Check if there are more "fresh", ie unseen, quotes. Otherwise, we have no choice but to show a stale one.
+        if len(seen) < len(queryset):
             queryset = queryset.exclude(pk__in=seen)
         values = queryset.values_list("pk", flat=True)
         if not values:


### PR DESCRIPTION
Allows sending a query param `seen` (Array of QuoteIds) when fetching random quote. If provided, attempts to avoid sending a quote that has "already been seen", ie one whose id is in the provided `seen` list. Thus, the frontend client is able to avoid displaying duplicate quotes until all available quotes have been shown.

Related to https://github.com/webkom/lego-webapp/pull/1692, but can be merged alone