### PR TITLE
Fix bug in penalty offset and make freeze dates inclusive

### DIFF
--- a/lego/apps/users/models.py
+++ b/lego/apps/users/models.py
@@ -410,14 +410,16 @@ class Penalty(BasisModel):
         offset_days = 0
         multiplier = 1 if forwards else -1
 
-        while remaining_days > 0:
-
-            date_to_check = start_date + (multiplier * timedelta(days=offset_days))
-
-            if not Penalty.ignore_date(date_to_check):
+        date_to_check = start_date + (multiplier * timedelta(days=offset_days))
+        ignore_date = Penalty.ignore_date(date_to_check)
+        while remaining_days > 0 or ignore_date:
+            if not ignore_date:
                 remaining_days -= 1
 
             offset_days += 1
+
+            date_to_check = start_date + (multiplier * timedelta(days=offset_days))
+            ignore_date = Penalty.ignore_date(date_to_check)
 
         return timedelta(days=offset_days)
 
@@ -425,8 +427,8 @@ class Penalty(BasisModel):
     def ignore_date(date):
         summer_from, summer_to = settings.PENALTY_IGNORE_SUMMER
         winter_from, winter_to = settings.PENALTY_IGNORE_WINTER
-        if summer_from < (date.month, date.day) < summer_to:
+        if summer_from <= (date.month, date.day) <= summer_to:
             return True
-        elif winter_to < (date.month, date.day) <= winter_from:
+        elif winter_to < (date.month, date.day) < winter_from:
             return False
         return True


### PR DESCRIPTION
Ref mail about weird penalty behaviour where the penalty said that it would expire 01/12, but was still counted as active.
This is recreated in `test_penalty_offset_is_calculated_correctly` and fixed in `penalty_offset`.
If you run the test without the changes, it will fail saying that the expire date is 22/12, but somehow it is still counted as active.
I also changed it so that the freeze/ignore dates were inclusive, as I found it easier to work with.

The bug was (in my mind) caused by the fact that when we count `penalty_offset` forwards vs backwards we get different results when crossing "freeze-points"