### PR TITLE
Remove day limit on previous personal events in ICal

### DIFF
--- a/lego/apps/ical/viewsets.py
+++ b/lego/apps/ical/viewsets.py
@@ -93,7 +93,7 @@ class ICalViewset(viewsets.ViewSet):
         )
 
         permission_handler = get_permission_handler(Meeting)
-        meetings = permission_handler.filter_queryset(request.user)
+        meetings = permission_handler.filter_queryset(request.user, Meeting.objects.all())
 
         utils.add_events_to_ical_feed(feed, following_events)
         utils.add_meetings_to_ical_feed(feed, meetings)

--- a/lego/apps/ical/viewsets.py
+++ b/lego/apps/ical/viewsets.py
@@ -93,7 +93,7 @@ class ICalViewset(viewsets.ViewSet):
         )
 
         permission_handler = get_permission_handler(Meeting)
-        meetings = permission_handler.filter_queryset(request.user, Meeting.objects.all())
+        meetings = permission_handler.filter_queryset(request.user, Meeting.objects
 
         utils.add_events_to_ical_feed(feed, following_events)
         utils.add_meetings_to_ical_feed(feed, meetings)
@@ -103,25 +103,25 @@ class ICalViewset(viewsets.ViewSet):
     @decorators.action(detail=False, methods=["GET"])
     def registrations(self, request):
         """Registration ical route."""
-        calendar_type = constants.TYPE_REGISTRATIONS
-        feed = utils.generate_ical_feed(request, calendar_type)
+        calendar_type=constants.TYPE_REGISTRATIONS
+        feed=utils.generate_ical_feed(request, calendar_type)
 
-        permission_handler = get_permission_handler(Event)
-        events = permission_handler.filter_queryset(
+        permission_handler=get_permission_handler(Event)
+        events=permission_handler.filter_queryset(
             request.user, Event.objects.all().filter(end_time__gt=timezone.now())
         )
 
         for event in events:
-            reg_time = event.get_earliest_registration_time(request.user)
+            reg_time=event.get_earliest_registration_time(request.user)
             if not reg_time:  # User cannot register
                 continue
 
-            ical_starttime = reg_time
-            ical_endtime = ical_starttime + timedelta(
+            ical_starttime=reg_time
+            ical_endtime=ical_starttime + timedelta(
                 minutes=constants.REGISTRATION_EVENT_LENGTH_IN_MINUTES
             )
-            price = event.get_price(request.user) if event.is_priced else None
-            title = f"Reg: {event.title}"
+            price=event.get_price(request.user) if event.is_priced else None
+            title=f"Reg: {event.title}"
 
             utils.add_event_to_ical_feed(
                 feed,
@@ -136,11 +136,11 @@ class ICalViewset(viewsets.ViewSet):
     @decorators.action(detail=False, methods=["GET"])
     def events(self, request):
         """Event ical route."""
-        calendar_type = constants.TYPE_EVENTS
-        feed = utils.generate_ical_feed(request, calendar_type)
+        calendar_type=constants.TYPE_EVENTS
+        feed=utils.generate_ical_feed(request, calendar_type)
 
-        permission_handler = get_permission_handler(Event)
-        events = permission_handler.filter_queryset(
+        permission_handler=get_permission_handler(Event)
+        events=permission_handler.filter_queryset(
             request.user,
             Event.objects.all().filter(
                 end_time__gt=timezone.now()

--- a/lego/apps/ical/viewsets.py
+++ b/lego/apps/ical/viewsets.py
@@ -89,21 +89,11 @@ class ICalViewset(viewsets.ViewSet):
         permission_handler = get_permission_handler(Event)
         following_events = permission_handler.filter_queryset(
             request.user,
-            Event.objects.filter(
-                followers__follower_id=request.user.id,
-                end_time__gt=timezone.now()
-                - timedelta(days=constants.HISTORY_BACKWARDS_IN_DAYS),
-            ).all(),
+            Event.objects.filter(followers__follower_id=request.user.id).all(),
         )
 
         permission_handler = get_permission_handler(Meeting)
-        meetings = permission_handler.filter_queryset(
-            request.user,
-            Meeting.objects.filter(
-                end_time__gt=timezone.now()
-                - timedelta(days=constants.HISTORY_BACKWARDS_IN_DAYS)
-            ),
-        )
+        meetings = permission_handler.filter_queryset(request.user)
 
         utils.add_events_to_ical_feed(feed, following_events)
         utils.add_meetings_to_ical_feed(feed, meetings)

--- a/lego/apps/ical/viewsets.py
+++ b/lego/apps/ical/viewsets.py
@@ -93,7 +93,8 @@ class ICalViewset(viewsets.ViewSet):
         )
 
         permission_handler = get_permission_handler(Meeting)
-        meetings = permission_handler.filter_queryset(request.user, Meeting.objects
+        meetings = permission_handler.filter_queryset(
+            request.user, Meeting.objects)
 
         utils.add_events_to_ical_feed(feed, following_events)
         utils.add_meetings_to_ical_feed(feed, meetings)
@@ -103,25 +104,25 @@ class ICalViewset(viewsets.ViewSet):
     @decorators.action(detail=False, methods=["GET"])
     def registrations(self, request):
         """Registration ical route."""
-        calendar_type=constants.TYPE_REGISTRATIONS
-        feed=utils.generate_ical_feed(request, calendar_type)
+        calendar_type = constants.TYPE_REGISTRATIONS
+        feed = utils.generate_ical_feed(request, calendar_type)
 
-        permission_handler=get_permission_handler(Event)
-        events=permission_handler.filter_queryset(
+        permission_handler = get_permission_handler(Event)
+        events = permission_handler.filter_queryset(
             request.user, Event.objects.all().filter(end_time__gt=timezone.now())
         )
 
         for event in events:
-            reg_time=event.get_earliest_registration_time(request.user)
+            reg_time = event.get_earliest_registration_time(request.user)
             if not reg_time:  # User cannot register
                 continue
 
-            ical_starttime=reg_time
-            ical_endtime=ical_starttime + timedelta(
+            ical_starttime = reg_time
+            ical_endtime = ical_starttime + timedelta(
                 minutes=constants.REGISTRATION_EVENT_LENGTH_IN_MINUTES
             )
-            price=event.get_price(request.user) if event.is_priced else None
-            title=f"Reg: {event.title}"
+            price = event.get_price(request.user) if event.is_priced else None
+            title = f"Reg: {event.title}"
 
             utils.add_event_to_ical_feed(
                 feed,
@@ -136,15 +137,15 @@ class ICalViewset(viewsets.ViewSet):
     @decorators.action(detail=False, methods=["GET"])
     def events(self, request):
         """Event ical route."""
-        calendar_type=constants.TYPE_EVENTS
-        feed=utils.generate_ical_feed(request, calendar_type)
+        calendar_type = constants.TYPE_EVENTS
+        feed = utils.generate_ical_feed(request, calendar_type)
 
-        permission_handler=get_permission_handler(Event)
-        events=permission_handler.filter_queryset(
+        permission_handler = get_permission_handler(Event)
+        events = permission_handler.filter_queryset(
             request.user,
             Event.objects.all().filter(
-                end_time__gt=timezone.now()
-                - timedelta(days=constants.HISTORY_BACKWARDS_IN_DAYS)
+                end_time__gt=timezone.now() -
+                timedelta(days=constants.HISTORY_BACKWARDS_IN_DAYS)
             ),
         )
 

--- a/lego/apps/ical/viewsets.py
+++ b/lego/apps/ical/viewsets.py
@@ -89,7 +89,7 @@ class ICalViewset(viewsets.ViewSet):
         permission_handler = get_permission_handler(Event)
         following_events = permission_handler.filter_queryset(
             request.user,
-            Event.objects.filter(followers__follower_id=request.user.id).all(),
+            Event.objects.filter(followers__follower_id=request.user.id),
         )
 
         permission_handler = get_permission_handler(Meeting)

--- a/lego/apps/ical/viewsets.py
+++ b/lego/apps/ical/viewsets.py
@@ -88,13 +88,11 @@ class ICalViewset(viewsets.ViewSet):
 
         permission_handler = get_permission_handler(Event)
         following_events = permission_handler.filter_queryset(
-            request.user,
-            Event.objects.filter(followers__follower_id=request.user.id),
+            request.user, Event.objects.filter(followers__follower_id=request.user.id)
         )
 
         permission_handler = get_permission_handler(Meeting)
-        meetings = permission_handler.filter_queryset(
-            request.user, Meeting.objects)
+        meetings = permission_handler.filter_queryset(request.user, Meeting.objects)
 
         utils.add_events_to_ical_feed(feed, following_events)
         utils.add_meetings_to_ical_feed(feed, meetings)
@@ -144,8 +142,8 @@ class ICalViewset(viewsets.ViewSet):
         events = permission_handler.filter_queryset(
             request.user,
             Event.objects.all().filter(
-                end_time__gt=timezone.now() -
-                timedelta(days=constants.HISTORY_BACKWARDS_IN_DAYS)
+                end_time__gt=timezone.now()
+                - timedelta(days=constants.HISTORY_BACKWARDS_IN_DAYS)
             ),
         )
 


### PR DESCRIPTION
With this change, personal events will remain in the user's personal calendar (eg. iCal, Google Calendar) [Previously, personal events disappreard from the user's personal calendar after 10 days]