### PR TITLE
Increase JWT refresh expiry to 180 days 🚀

### DIFF
--- a/lego/settings/base.py
+++ b/lego/settings/base.py
@@ -109,9 +109,12 @@ TEMPLATES = [
 ]
 
 JWT_AUTH = {
-    "JWT_ALLOW_REFRESH": True,
-    "JWT_EXPIRATION_DELTA": datetime.timedelta(days=31),
+    # Tokens will expire after 14 days
+    "JWT_EXPIRATION_DELTA": datetime.timedelta(days=14),
     "JWT_RESPONSE_PAYLOAD_HANDLER": "lego.apps.jwt.handlers.response_handler",
+    # Allow refresh. Tokens can be refreshed for 180 days after initial login, so users must login ~twice a year
+    "JWT_ALLOW_REFRESH": True,
+    "JWT_REFRESH_EXPIRATION_DELTA": datetime.timedelta(days=180),
 }
 
 OAUTH2_PROVIDER_APPLICATION_MODEL = "oauth.APIApplication"


### PR DESCRIPTION
I keep getting tired of logging in once a week. :man_shrugging:  Default refresh length
is 7 days, so even tho. token is valid longer (was 31), the user was
logged out since refresh failed.

The refresh expiry is now 180 days after initial login, but token is
only valid for 14 days.

180 (and 14) is just a random number, so feel free to discuss the length.