### PR TITLE
Add support for fetching descendant memberships

### DIFF
--- a/lego/apps/users/views/memberships.py
+++ b/lego/apps/users/views/memberships.py
@@ -2,7 +2,7 @@ from rest_framework import viewsets
 
 from lego.apps.permissions.api.views import AllowedPermissionsMixin
 from lego.apps.users.filters import MembershipFilterSet
-from lego.apps.users.models import Membership
+from lego.apps.users.models import AbakusGroup, Membership
 from lego.apps.users.serializers.memberships import MembershipSerializer
 
 
@@ -13,6 +13,10 @@ class MembershipViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
 
     def get_queryset(self):
         group = self.kwargs["group_pk"]
+        descendants = self.request.query_params.get("descendants", None)
+        if descendants == "true":
+            return AbakusGroup.objects.get(pk=group).memberships
+
         return Membership.objects.filter(abakus_group_id=group)
 
     def create(self, request, *args, **kwargs):


### PR DESCRIPTION
~impossible to do this using django-filter, so this was the simplest way
to do it.

When fetching with descendants=true, it will return all memberships for
the group and for all the child groups.