### PR TITLE
Update sentry sdk

### DIFF
--- a/lego/apps/restricted/lmtp/service.py
+++ b/lego/apps/restricted/lmtp/service.py
@@ -89,9 +89,7 @@ class LMTPService(BaseCommand, smtpd.SMTPServer):
                 return status.append(channel.OK_250)
 
             except Exception:
-                from raven.contrib.django.raven_compat.models import client
 
-                client.captureException()
                 log.exception("lmtp_lookup_failure")
                 status.append(channel.ERR_550)
 

--- a/lego/settings/celery.py
+++ b/lego/settings/celery.py
@@ -29,21 +29,6 @@ def celery_init(*args, **kwargs):
     analytics_client.setup_analytics()
 
 
-@app.on_configure.connect()
-def on_configure(*args, **kwargs):
-
-    import raven
-    from raven.contrib.celery import register_signal, register_logger_signal
-
-    client = raven.Client()
-
-    # register a custom filter to filter out duplicate logs
-    register_logger_signal(client)
-
-    # hook into the Celery error handler
-    register_signal(client)
-
-
 @setup_logging.connect()
 def on_setup_logging(**kwargs):
     """

--- a/lego/settings/logging.py
+++ b/lego/settings/logging.py
@@ -44,7 +44,6 @@ LOGGING = {
     },
     "loggers": {
         "celery": {"level": "DEBUG", "propagate": True},
-        "raven": {"level": "DEBUG", "handlers": ["console"], "propagate": False},
         "sentry.errors": {
             "level": "DEBUG",
             "handlers": ["console"],

--- a/lego/settings/production.py
+++ b/lego/settings/production.py
@@ -3,7 +3,10 @@ import re
 from urllib.parse import urlparse
 
 import environ
+import sentry_sdk
 import stripe
+from sentry_sdk.integrations.celery import CeleryIntegration
+from sentry_sdk.integrations.django import DjangoIntegration
 
 from lego.settings import (
     BASE_DIR,
@@ -47,17 +50,15 @@ THUMBOR_SERVER = env("THUMBOR_SERVER")
 THUMBOR_SECURITY_KEY = env("THUMBOR_SECURITY_KEY")
 
 # Sentry
-SENTRY_CLIENT = "raven.contrib.django.raven_compat.DjangoClient"
 SENTRY_DSN = env("SENTRY")
-RAVEN_CONFIG = {
-    "dsn": SENTRY_DSN,
-    "release": env("RELEASE", default="latest"),
-    "environment": ENVIRONMENT_NAME,
-}
-INSTALLED_APPS += ["raven.contrib.django.raven_compat"]
-MIDDLEWARE = [
-    "raven.contrib.django.raven_compat.middleware.SentryResponseErrorIdMiddleware"
-] + MIDDLEWARE
+SENTRY_RELEASE = env("RELEASE", default="latest")
+sentry_sdk.init(
+    dsn=SENTRY_DSN,
+    integrations=[DjangoIntegration(), CeleryIntegration()],
+    release=SENTRY_RELEASE,
+    environment=ENVIRONMENT_NAME,
+    send_default_pii=True,
+)
 
 # Celery
 CELERY_BROKER_URL = env("CELERY_BROKER_URL")

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@ ipython==7.13.0
 psycopg2-binary==2.8.5
 unicode-slugify==0.1.3
 pyyaml==5.3.1
-raven==6.10.0
+sentry-sdk==0.14.3
 redis==3.4.1
 hiredis==1.0.1
 certifi==2019.11.28


### PR DESCRIPTION
Updates from `raven` to the new `sentry-sdk`. Have tested some, but have not confirmed that the celery integration works as intended.