### PR TITLE
Only check open endpoints, and check their content

### DIFF
--- a/lego/apps/articles/fixtures/development_articles.yaml
+++ b/lego/apps/articles/fixtures/development_articles.yaml
@@ -128,7 +128,7 @@
 - model: articles.Article
   pk: 6
   fields:
-    title: Artikkel nr 6 sånn ca
+    title: Artikkel uten AUTH
     cover: test_article_cover.png
     description: "Eller hur hur hur hur."
     text:
@@ -141,8 +141,7 @@
       \ 1960-årene ved lanseringen av Letraset-ark med avsnitt fra Lorem Ipsum, og\
       \ senere med sideombrekkingsprogrammet Aldus PageMaker som tok i bruk nettopp\
       \ Lorem Ipsum for dummytekst. </p>"
-    can_view_groups:
-      - - Users
+    require_auth: false
     tags:
       - lorem
       - ipsum

--- a/lego/apps/healthchecks/apps.py
+++ b/lego/apps/healthchecks/apps.py
@@ -5,9 +5,9 @@ from health_check.plugins import plugin_dir
 from lego.apps.healthchecks.backends import (
     HealthCheckArticlesBackend,
     HealthCheckEventsBackend,
-    HealthCheckGroupsBackend,
+    HealthCheckJoblistingsBackend,
     HealthCheckPagesBackend,
-    HealthCheckUsersBackend,
+    HealthCheckSiteMetaBackend,
 )
 
 
@@ -17,6 +17,6 @@ class HealthChecksConfig(AppConfig):
     def ready(self):
         plugin_dir.register(HealthCheckArticlesBackend)
         plugin_dir.register(HealthCheckEventsBackend)
-        plugin_dir.register(HealthCheckGroupsBackend)
+        plugin_dir.register(HealthCheckJoblistingsBackend)
         plugin_dir.register(HealthCheckPagesBackend)
-        plugin_dir.register(HealthCheckUsersBackend)
+        plugin_dir.register(HealthCheckSiteMetaBackend)

--- a/lego/apps/healthchecks/backends.py
+++ b/lego/apps/healthchecks/backends.py
@@ -8,8 +8,14 @@ class HealthCheckArticlesBackend(BaseHealthCheckBackend):
 
     def check_status(self):
         response = requests.get("http://localhost:8000/api/v1/articles/")
+
+        # Check that the HTTP code was 200
         if response.status_code != 200:
             raise ServiceUnavailable("Articles did not return 200")
+
+        # Check that the endpoint returns some results
+        if len(response.json()["results"]) == 0:
+            raise ServiceUnavailable("Articles did not return any articles")
 
     def identifier(self):
         return self.__class__.__name__
@@ -20,20 +26,32 @@ class HealthCheckEventsBackend(BaseHealthCheckBackend):
 
     def check_status(self):
         response = requests.get("http://localhost:8000/api/v1/events/")
+
+        # Check that the HTTP code was 200
         if response.status_code != 200:
             raise ServiceUnavailable("Events did not return 200")
+
+        # Check that the endpoint returns some results
+        if len(response.json()["results"]) == 0:
+            raise ServiceUnavailable("Events did not return any events")
 
     def identifier(self):
         return self.__class__.__name__
 
 
-class HealthCheckGroupsBackend(BaseHealthCheckBackend):
+class HealthCheckJoblistingsBackend(BaseHealthCheckBackend):
     critical_service = True
 
     def check_status(self):
-        response = requests.get("http://localhost:8000/api/v1/groups/")
-        if response.status_code != 401:
-            raise ServiceUnavailable("Groups did not return 401")
+        response = requests.get("http://localhost:8000/api/v1/joblistings/")
+
+        # Check that the HTTP code was 200
+        if response.status_code != 200:
+            raise ServiceUnavailable("Joblistings did not return 200")
+
+        # Check that the endpoint returns some results
+        if len(response.json()["results"]) == 0:
+            raise ServiceUnavailable("Joblistings did not return any jobs")
 
     def identifier(self):
         return self.__class__.__name__
@@ -44,20 +62,34 @@ class HealthCheckPagesBackend(BaseHealthCheckBackend):
 
     def check_status(self):
         response = requests.get("http://localhost:8000/api/v1/pages/")
+
+        # Check that the HTTP code was 200
         if response.status_code != 200:
             raise ServiceUnavailable("Pages did not return 200")
+
+        # Check that the endpoint returns some results
+        if len(response.json()["results"]) == 0:
+            raise ServiceUnavailable("Pages did not return any pages")
 
     def identifier(self):
         return self.__class__.__name__
 
 
-class HealthCheckUsersBackend(BaseHealthCheckBackend):
+class HealthCheckSiteMetaBackend(BaseHealthCheckBackend):
     critical_service = True
 
     def check_status(self):
-        response = requests.get("http://localhost:8000/api/v1/users/")
-        if response.status_code != 401:
-            raise ServiceUnavailable("Users did not return 401")
+        response = requests.get("http://localhost:8000/api/v1/site-meta/")
+
+        # Check that the HTTP code was 200
+        if response.status_code != 200:
+            raise ServiceUnavailable("Site-Meta did not return 200")
+
+        if len(response.json()["site"]) == 0:
+            raise ServiceUnavailable("Site-Meta did not return any meta")
+
+        if len(response.json()["isAllowed"]) == 0:
+            raise ServiceUnavailable("Site-Meta did not return any permissions")
 
     def identifier(self):
         return self.__class__.__name__


### PR DESCRIPTION
So the last `/healthchecks/` endpoint checked that certain endpoints returned `401`, which in theory was a good way to check that the system was up and the permissions worked. But such `401` are logged by design the health checks then clogged up the logs with errors.

This change moves all health check backends to request our open endpoints and improved them by  checking the `content` of the endpoints and not just the `status-code`.