### PR TITLE
Fix websocket connections

### DIFF
--- a/lego/apps/websockets/auth.py
+++ b/lego/apps/websockets/auth.py
@@ -1,5 +1,6 @@
 from urllib.parse import parse_qs
 
+from django.db import close_old_connections
 from rest_framework import exceptions
 
 from lego.apps.jwt.authentication import Authentication
@@ -24,6 +25,10 @@ class JWTAuthenticationMiddleware:
         self.authentication = JWTQSAuthentication()
 
     def __call__(self, scope):
+
+        # If there are old connecions in the database,
+        # authentication will fail. So we make sure to clean up.
+        close_old_connections()
         user, token = self.authentication.authenticate(scope)
         scope["user"] = user
         scope["token"] = token


### PR DESCRIPTION
Fixes an issue where websockets seemingly only work sometimes.

The issue I am seeing locally:
```
INFO 2020-07-22 20:48:01,560 [django.channels.server] WebSocket DISCONNECT / [127.0.0.1:58692]
ERROR 2020-07-22 20:48:11,723 [daphne.ws_protocol] [Failure instance: Traceback: <class 'django.db.utils.InterfaceError'>: connection already closed
/home/ludvig/code/lego/venv/lib/python3.7/site-packages/autobahn/websocket/protocol.py:2847:processHandshake
/home/ludvig/code/lego/venv/lib/python3.7/site-packages/txaio/tx.py:366:as_future
/home/ludvig/code/lego/venv/lib/python3.7/site-packages/twisted/internet/defer.py:151:maybeDeferred
/home/ludvig/code/lego/venv/lib/python3.7/site-packages/daphne/ws_protocol.py:83:onConnect
--- <exception caught here> ---
/home/ludvig/code/lego/venv/lib/python3.7/site-packages/twisted/internet/defer.py:151:maybeDeferred
/home/ludvig/code/lego/venv/lib/python3.7/site-packages/daphne/server.py:200:create_application
/home/ludvig/code/lego/venv/lib/python3.7/site-packages/channels/staticfiles.py:41:__call__
/home/ludvig/code/lego/venv/lib/python3.7/site-packages/channels/routing.py:54:__call__
/home/ludvig/code/lego/lego/apps/websockets/auth.py:29:__call__
/home/ludvig/code/lego/lego/apps/jwt/authentication.py:13:authenticate
/home/ludvig/code/lego/venv/lib/python3.7/site-packages/rest_framework_jwt/authentication.py:43:authenticate
/home/ludvig/code/lego/venv/lib/python3.7/site-packages/rest_framework_jwt/authentication.py:59:authenticate_credentials
/home/ludvig/code/lego/lego/apps/users/managers.py:37:get_by_natural_key
/home/ludvig/code/lego/venv/lib/python3.7/site-packages/django/db/models/manager.py:82:manager_method
/home/ludvig/code/lego/venv/lib/python3.7/site-packages/django/db/models/query.py:402:get
/home/ludvig/code/lego/venv/lib/python3.7/site-packages/django/db/models/query.py:256:__len__
/home/ludvig/code/lego/venv/lib/python3.7/site-packages/django/db/models/query.py:1242:_fetch_all
/home/ludvig/code/lego/venv/lib/python3.7/site-packages/django/db/models/query.py:55:__iter__
/home/ludvig/code/lego/venv/lib/python3.7/site-packages/django/db/models/sql/compiler.py:1138:execute_sql
/home/ludvig/code/lego/venv/lib/python3.7/site-packages/django/db/backends/base/base.py:256:cursor
/home/ludvig/code/lego/venv/lib/python3.7/site-packages/django/db/backends/base/base.py:235:_cursor
/home/ludvig/code/lego/venv/lib/python3.7/site-packages/django/db/utils.py:89:__exit__
/home/ludvig/code/lego/venv/lib/python3.7/site-packages/django/db/backends/base/base.py:235:_cursor
/home/ludvig/code/lego/venv/lib/python3.7/site-packages/django/db/backends/postgresql/base.py:223:create_cursor
]
```

This is due to old connections in the database, so it sees the old connections when trying to authenticate the new connection requests and will not create a new one.

Bad code: https://github.com/webkom/lego/blob/b2cdfea7712a198f2afed43a8c938ce68dba7349/lego/apps/websockets/auth.py#L21-L30

Docs reference: https://channels.readthedocs.io/en/latest/topics/authentication.html#custom-authentication