### PR TITLE
Add some fixtures for paid events

### DIFF
--- a/lego/apps/events/fixtures/development_events.yaml
+++ b/lego/apps/events/fixtures/development_events.yaml
@@ -1434,3 +1434,22 @@
     require_auth: True
   model: events.Event
   pk: 53
+- fields:
+    description: Abakus inviterer til julebord!
+    end_time: '2016-04-10T08:00:00+00:00'
+    event_type: event
+    event_status_type: NORMAL
+    location: Scandic nidelva
+    start_time: '2016-04-09T15:00:00+00:00'
+    text:
+      "<p>Da er det tid for julebord!</br>\
+      \ <b>Pris: 270</b></p>"
+    title: Julebord
+    is_priced: True
+    price_member: 27000
+    price_guest: 35000
+    cover: test_event_cover.png
+    created_by: 3
+    require_auth: False
+  model: events.Event
+  pk: 54

--- a/lego/apps/events/fixtures/development_pools.yaml
+++ b/lego/apps/events/fixtures/development_pools.yaml
@@ -727,3 +727,12 @@
       - - Abakus
   model: events.Pool
   pk: 81
+- fields:
+    activation_date: '2016-01-01T17:00:00+00:00'
+    capacity: 0
+    event: 54
+    name: Abakus
+    permission_groups:
+      - - Abakus
+  model: events.Pool
+  pk: 82

--- a/lego/utils/management/commands/load_fixtures.py
+++ b/lego/utils/management/commands/load_fixtures.py
@@ -118,9 +118,19 @@ class Command(BaseCommand):
             event.end_time = date + timedelta(days=i - 10, hours=4)
             event.save()
             for j, pool in enumerate(event.pools.all()):
-                pool.activation_date = date.replace(hour=12, minute=0) + timedelta(
-                    days=i - j - 16
-                )
+                # If you set this date in the fixture, the activation_date will be earlier than now
+                # so that the pool is open
+                if (
+                    pool.activation_date.date()
+                    == timezone.datetime(year=2016, month=1, day=1).date()
+                ):
+                    pool.activation_date = date.replace(hour=12, minute=0) - timedelta(
+                        days=1
+                    )
+                else:
+                    pool.activation_date = date.replace(hour=12, minute=0) + timedelta(
+                        days=i - j - 16
+                    )
                 pool.save()
 
     def generate_groups(self):


### PR DESCRIPTION
Adds a _pretty_ hidden feature where any pools set with `activation_date="2016-01-01"` will be set such that the registration is open. This is useful mostly for E2E tests. Also it is nice with some fixtures predefined for testing registrations and paid events.