### PR TITLE
Revert " Add support for Gsuit as email backend"

### DIFF
--- a/lego/settings/production.py
+++ b/lego/settings/production.py
@@ -36,13 +36,9 @@ DATABASES = {"default": env.db()}
 # Cache
 CACHES = {"default": env.cache()}
 
-# Gsuite mail
-EMAIL_BACKEND = env("EMAIL_BACKEND")
-EMAIL_HOST = env("EMAIL_HOST")
-EMAIL_HOST_USER = env("EMAIL_HOST_USER")
-EMAIL_HOST_PASSWORD = env("EMAIL_HOST_PASSWORD")
-EMAIL_PORT = env("EMAIL_PORT")
-EMAIL_USE_TLS = env("EMAIL_USE_TLS")
+# Email / We may enable the celery email backend.
+EMAIL_CONFIG = env.email()
+vars().update(EMAIL_CONFIG)
 
 # File Storage
 AWS_ACCESS_KEY_ID = env("AWS_ACCESS_KEY_ID")

--- a/lego/settings/production.py
+++ b/lego/settings/production.py
@@ -37,6 +37,7 @@ DATABASES = {"default": env.db()}
 CACHES = {"default": env.cache()}
 
 # Email / We may enable the celery email backend.
+# See https://github.com/joke2k/django-environ#email-settings for how to configure
 EMAIL_CONFIG = env.email()
 vars().update(EMAIL_CONFIG)
 


### PR DESCRIPTION
Reverts webkom/lego#1850

I realized that this actually didn't do anything, and configuring for using Gsuit was always supperted. It was just a bit cryptic that the `env.email()` actually uses an email url for configuration. So I added a comment about configuration.

We could keep it, but it (was) a breaking change, so its better to keep it the way it was and edit our own conf.