### PR TITLE
Add sentry processor to structlog

### DIFF
--- a/lego/settings/logging.py
+++ b/lego/settings/logging.py
@@ -1,9 +1,10 @@
 import socket
-from logging import getLogger
+from logging import ERROR, getLogger
 
 import cssutils
 import structlog
 from structlog.threadlocal import wrap_dict
+from structlog_sentry import SentryJsonProcessor
 
 from lego.settings import TESTING
 
@@ -83,6 +84,7 @@ structlog.configure(
         structlog.processors.TimeStamper(fmt="iso"),
         structlog.processors.StackInfoRenderer(),
         structlog.processors.format_exc_info,
+        SentryJsonProcessor(level=ERROR),
         structlog.processors.JSONRenderer(),
     ],
     context_class=WrappedDictClass,

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,14 +5,12 @@ ipython==7.15.0
 psycopg2-binary==2.8.5
 unicode-slugify==0.1.3
 pyyaml==5.3.1
-sentry-sdk==0.15.1
 redis==3.4.1
 hiredis==1.0.1
 certifi==2020.4.5.1
 elasticsearch==6.2.0
 celery==4.4.2
 stripe==2.24.1
-structlog==20.1.0
 boto3>=1.9<=1.10
 bs4==0.0.1
 bleach==3.1.4
@@ -21,9 +19,14 @@ ldap3==2.7
 google-api-python-client==1.9.3
 oauth2client
 premailer==3.6.1
-analytics-python==1.2.9
 libthumbor==2.0.1
 django-health-check==3.12.1
+
+# Logging/errors
+structlog==20.1.0
+structlog-sentry==1.2.2
+sentry-sdk==0.15.1
+analytics-python==1.2.9
 
 # channels
 channels==2.4.0


### PR DESCRIPTION
Adds `sentry-structlog` processor, configured to capture all `log.error()`.

A lot of places in LEGO, we have a try catch, where the catch will log the error, but this makes it
hard to notice without custom alerting rules in our log aggregater (currently loki-grafana).
The processor will send all log.error's to sentry in addition, so that we get an error if f.ex. an
email fails sending :upside_down_face:.

[Example sentry issue](https://sentry.io/organizations/abakus/issues/1821995742/?referrer=slack)
