### PR TITLE
[WIP] Export event enpoint

### DIFF
--- a/lego/apps/events/views.py
+++ b/lego/apps/events/views.py
@@ -278,6 +278,9 @@ class EventViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
         detail=True, methods=["GET"], serializer_class=EventAdministrateSerializer
     )
     def export(self, *args, **kwargs):
+        if not self.request.user.is_authenticated:
+            return Response(status=status.HTTP_401_UNAUTHORIZED)
+
         has_permission = self.request.user.has_perm("administrate", obj=Event)
         if not has_permission:
             return Response(status=status.HTTP_403_FORBIDDEN)
@@ -304,7 +307,6 @@ class EventViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
         writer = csv.writer(response)
         writer.writerow(["username", "fullName", "emailAddress", "pool"])
         for pool in event["pools"]:
-            print("\n\n\n", pool)
             for registration in pool["registrations"]:
                 writer.writerow(
                     [

--- a/lego/apps/users/serializers/users.py
+++ b/lego/apps/users/serializers/users.py
@@ -85,7 +85,11 @@ class AdministrateUserSerializer(PublicUserSerializer):
     """
 
     class Meta(PublicUserSerializer.Meta):
-        fields = PublicUserSerializer.Meta.fields + ("abakus_groups", "allergies")
+        fields = PublicUserSerializer.Meta.fields + (
+            "abakus_groups",
+            "allergies",
+            "email_address",
+        )
 
 
 class SearchUserSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
This PR adds an endpoint `/eventes/{id}/export` to export all registrations on an event to a csv file.

Currently it only includes `username`, `fullName`, `emailAdress` and `pool.name`.


Open for discussion on adding support for customization of included fields via query paremeters.