### PR TITLE
Fix postgres search

### DIFF
--- a/lego/apps/articles/search_indexes.py
+++ b/lego/apps/articles/search_indexes.py
@@ -14,7 +14,7 @@ class ArticleModelIndex(SearchIndex):
     result_fields = ("title", "description", "cover")
     autocomplete_result_fields = ("title",)
 
-    search_fields = ("title", "text")
+    search_fields = ("title", "text", "description")
     autocomplete_fields = ("title",)
 
     def get_autocomplete(self, instance):

--- a/lego/apps/articles/search_indexes.py
+++ b/lego/apps/articles/search_indexes.py
@@ -14,27 +14,17 @@ class ArticleModelIndex(SearchIndex):
     result_fields = ("title", "description", "cover")
     autocomplete_result_fields = ("title",)
 
+    search_fields = ("title", "text")
+    autocomplete_fields = ("title",)
+
     def get_autocomplete(self, instance):
         return instance.title
 
     def search(self, query):
-        return (
-            self.queryset.annotate(search=SearchVector("title", "text"))
-            .filter(search=query)
-            .order_by("-created_at")
-        )
+        return super().search(query).order_by("-created_at")
 
     def autocomplete(self, query):
-        return (
-            self.queryset.annotate(search=SearchVector("title"))
-            .filter(
-                search=SearchQuery(
-                    ":* & ".join(query.split() + [""]).strip("& ").strip(),
-                    search_type="raw",
-                )
-            )
-            .order_by("-created_at")
-        )
+        return super().autocomplete(query).order_by("-created_at")
 
 
 register(ArticleModelIndex)

--- a/lego/apps/companies/search_indexes.py
+++ b/lego/apps/companies/search_indexes.py
@@ -12,6 +12,7 @@ class CompanyModelIndex(SearchIndex):
     result_fields = ("name", "description")
     autocomplete_result_fields = ("name",)
 
+    search_fields = ("name", "description")
     autocomplete_fields = ("name",)
 
     def get_autocomplete(self, instance):

--- a/lego/apps/companies/search_indexes.py
+++ b/lego/apps/companies/search_indexes.py
@@ -12,11 +12,10 @@ class CompanyModelIndex(SearchIndex):
     result_fields = ("name", "description")
     autocomplete_result_fields = ("name",)
 
+    autocomplete_fields = ("name",)
+
     def get_autocomplete(self, instance):
         return instance.name
-
-    def autocomplete(self, query):
-        return self.queryset.filter(name__istartswith=query)
 
 
 register(CompanyModelIndex)

--- a/lego/apps/events/search_indexes.py
+++ b/lego/apps/events/search_indexes.py
@@ -21,27 +21,17 @@ class EventModelIndex(SearchIndex):
     )
     autocomplete_result_fields = ("title", "start_time")
 
+    autocomplete_fields = ("title",)
+    search_fields = ("title", "description", "text")
+
     def get_autocomplete(self, instance):
         return instance.title
 
     def search(self, query):
-        return (
-            self.queryset.annotate(search=SearchVector("title", "description", "text"))
-            .filter(search=query)
-            .order_by("-start_time")
-        )
+        return super().search(query).order_by("-start_time")
 
     def autocomplete(self, query):
-        return (
-            self.queryset.annotate(search=SearchVector("title"))
-            .filter(
-                search=SearchQuery(
-                    ":* & ".join(query.split() + [""]).strip("& ").strip(),
-                    search_type="raw",
-                )
-            )
-            .order_by("-start_time")
-        )
+        return super().autocomplete(query).order_by("-start_time")
 
 
 register(EventModelIndex)

--- a/lego/apps/flatpages/search_indexes.py
+++ b/lego/apps/flatpages/search_indexes.py
@@ -1,3 +1,4 @@
+from django.contrib.postgres.search import SearchQuery, SearchVector
 from django.db.models import Q
 
 from lego.apps.search import register
@@ -14,12 +15,17 @@ class PageModelIndex(SearchIndex):
     result_fields = ("title", "content", "slug", "picture", "category")
     autocomplete_result_fields = ("title", "slug", "picture", "category")
 
+    def search(self, query):
+        return self.queryset.annotate(search=SearchVector("title", "content")).filter(
+            search=query
+        )
+
     def get_autocomplete(self, instance):
         return [instance.title, instance.slug_field]
 
     def autocomplete(self, query):
-        return self.queryset.filter(
-            Q(title__istartswith=query) | Q(slug__istartswith=query)
+        return self.queryset.annotate(search=SearchVector("title", "slug")).filter(
+            search=query
         )
 
 

--- a/lego/apps/flatpages/search_indexes.py
+++ b/lego/apps/flatpages/search_indexes.py
@@ -14,6 +14,7 @@ class PageModelIndex(SearchIndex):
     serializer_class = PageDetailSerializer
     result_fields = ("title", "content", "slug", "picture", "category")
     autocomplete_result_fields = ("title", "slug", "picture", "category")
+
     search_fields = ("title", "slug", "content")
     autocomplete_fields = ("title", "slug")
 

--- a/lego/apps/flatpages/search_indexes.py
+++ b/lego/apps/flatpages/search_indexes.py
@@ -14,19 +14,11 @@ class PageModelIndex(SearchIndex):
     serializer_class = PageDetailSerializer
     result_fields = ("title", "content", "slug", "picture", "category")
     autocomplete_result_fields = ("title", "slug", "picture", "category")
-
-    def search(self, query):
-        return self.queryset.annotate(search=SearchVector("title", "content")).filter(
-            search=query
-        )
+    search_fields = ("title", "slug", "content")
+    autocomplete_fields = ("title", "slug")
 
     def get_autocomplete(self, instance):
         return [instance.title, instance.slug_field]
-
-    def autocomplete(self, query):
-        return self.queryset.annotate(search=SearchVector("title", "slug")).filter(
-            search=query
-        )
 
 
 register(PageModelIndex)

--- a/lego/apps/gallery/search_indexes.py
+++ b/lego/apps/gallery/search_indexes.py
@@ -11,6 +11,8 @@ class GalleryIndex(SearchIndex):
     serializer_class = GallerySearchSerializer
     result_fields = ("title", "location", "description")
     autocomplete_result_fields = ("title",)
+
+    search_fields = ("title", "event__title")
     autocomplete_fields = ("title",)
 
     def get_autocomplete(self, instance):

--- a/lego/apps/gallery/search_indexes.py
+++ b/lego/apps/gallery/search_indexes.py
@@ -11,12 +11,13 @@ class GalleryIndex(SearchIndex):
     serializer_class = GallerySearchSerializer
     result_fields = ("title", "location", "description")
     autocomplete_result_fields = ("title",)
+    autocomplete_fields = ("title",)
 
     def get_autocomplete(self, instance):
         return [instance.title]
 
     def autocomplete(self, query):
-        return self.queryset.filter(title__istartswith=query)
+        return super().autocomplete(query).order_by("-created_at")
 
 
 register(GalleryIndex)

--- a/lego/apps/search/index.py
+++ b/lego/apps/search/index.py
@@ -33,7 +33,7 @@ class SearchIndex:
 
         if queryset is None:
             raise NotImplementedError(
-                f"You must provide a 'get_qyeryset' method or queryset attribute for the {self} "
+                f"You must provide a 'get_queryset' method or queryset attribute for the {self} "
                 f"index."
             )
         return queryset

--- a/lego/apps/search/index.py
+++ b/lego/apps/search/index.py
@@ -17,6 +17,7 @@ class SearchIndex:
 
     queryset = None
     serializer_class = None
+    fallback_to_autocomplete = False
 
     def get_backend(self):
         """
@@ -114,10 +115,10 @@ class SearchIndex:
         """
         search_fields = getattr(self, "search_fields", None)
         if search_fields is None:
-            search_fields = getattr(self, "autocomplete_fields", None)
-        if search_fields is None:
+            if self.fallback_to_autocomplete:
+                return self.autocomplete(query)
             raise NotImplementedError(
-                "You must provide a 'search_fields' or 'autocomplete_fields' attribute or override this method"
+                "You must provide a 'search_fields' attribute or override this method"
             )
 
         return self.queryset.annotate(lego_search=SearchVector(*search_fields)).filter(
@@ -131,10 +132,8 @@ class SearchIndex:
         """
         search_fields = getattr(self, "autocomplete_fields", None)
         if search_fields is None:
-            search_fields = getattr(self, "search_fields", None)
-        if search_fields is None:
             raise NotImplementedError(
-                "You must provide a 'search_fields' or 'autocomplete_fields' attribute or override this method"
+                "You must provide a autocomplete_fields' attribute or override this method"
             )
 
         return self.queryset.annotate(lego_search=SearchVector(*search_fields)).filter(

--- a/lego/apps/search/index.py
+++ b/lego/apps/search/index.py
@@ -30,7 +30,7 @@ class SearchIndex:
         Get the queryset that should be indexed. Override this method or set a queryset attribute
         on this class.
         """
-        queryset = getattr(self, "queryset")
+        queryset = getattr(self, "queryset", None)
 
         if queryset is None:
             raise NotImplementedError(
@@ -51,7 +51,7 @@ class SearchIndex:
         Override this method or set the serializer_class attribute on the class to define the
         serializer.
         """
-        serializer_class = getattr(self, "serializer_class")
+        serializer_class = getattr(self, "serializer_class", None)
         if serializer_class is None:
             raise NotImplementedError(
                 "You must provide a 'get_serializer_class' function or a "
@@ -71,7 +71,7 @@ class SearchIndex:
         """
         Returns a list of fields attached to the search result.
         """
-        result_fields = getattr(self, "result_fields")
+        result_fields = getattr(self, "result_fields", None)
         if result_fields is None:
             raise NotImplementedError(
                 "You must provide a 'get_result_fields' function or a "
@@ -112,7 +112,9 @@ class SearchIndex:
         Uses the model to do a full search. This will use the database for search
         Only works for PostgreSQL
         """
-        search_fields = getattr(self, "search_fields")
+        search_fields = getattr(self, "search_fields", None)
+        if search_fields is None:
+            search_fields = getattr(self, "autocomplete_fields", None)
         if search_fields is None:
             raise NotImplementedError(
                 "You must provide a 'search_fields' or 'autocomplete_fields' attribute or override this method"
@@ -127,9 +129,9 @@ class SearchIndex:
         Uses the model to search with autocomplete. This will use the database for search
         Only works for PostgreSQL
         """
-        search_fields = getattr(self, "autocomplete_fields")
+        search_fields = getattr(self, "autocomplete_fields", None)
         if search_fields is None:
-            search_fields = getattr(self, "search_fields")
+            search_fields = getattr(self, "search_fields", None)
         if search_fields is None:
             raise NotImplementedError(
                 "You must provide a 'search_fields' or 'autocomplete_fields' attribute or override this method"

--- a/lego/apps/tags/search_indexes.py
+++ b/lego/apps/tags/search_indexes.py
@@ -12,11 +12,11 @@ class TagIndex(SearchIndex):
     result_fields = ("tag",)
     autocomplete_result_fields = ("tag",)
 
+    autocomplete_fields = ("tag",)
+    fallback_to_autocomplete = True
+
     def get_autocomplete(self, instance):
         return [instance.tag]
-
-    def autocomplete(self, query):
-        return self.queryset.filter(tag__istartswith=query)
 
 
 register(TagIndex)

--- a/lego/apps/users/search_indexes.py
+++ b/lego/apps/users/search_indexes.py
@@ -22,6 +22,8 @@ class UserIndex(SearchIndex):
     )
     autocomplete_result_fields = ("username", "full_name", "profile_picture")
 
+    autocomplete_fields = ("first_name", "last_name", "username")
+
     def get_autocomplete(self, instance):
         return [
             instance.username,
@@ -29,16 +31,6 @@ class UserIndex(SearchIndex):
             instance.last_name,
             instance.first_name,
         ]
-
-    def autocomplete(self, query):
-        return self.queryset.annotate(
-            search=SearchVector("first_name", "last_name", "username")
-        ).filter(
-            search=SearchQuery(
-                ":* & ".join(query.split() + [""]).strip("& ").strip(),
-                search_type="raw",
-            )
-        )
 
 
 register(UserIndex)
@@ -51,16 +43,10 @@ class GroupIndex(SearchIndex):
     result_fields = ("name", "type", "logo")
     autocomplete_result_fields = ("name", "type", "logo")
 
+    autocomplete_fields = ("name",)
+
     def get_autocomplete(self, instance):
         return [instance.name] + instance.name.split(" ")
-
-    def autocomplete(self, query):
-        return self.queryset.annotate(search=SearchVector("name")).filter(
-            search=SearchQuery(
-                ":* & ".join(query.split() + [""]).strip("& ").strip(),
-                search_type="raw",
-            )
-        )
 
 
 register(GroupIndex)

--- a/lego/apps/users/search_indexes.py
+++ b/lego/apps/users/search_indexes.py
@@ -23,6 +23,7 @@ class UserIndex(SearchIndex):
     autocomplete_result_fields = ("username", "full_name", "profile_picture")
 
     autocomplete_fields = ("first_name", "last_name", "username")
+    fallback_to_autocomplete = True
 
     def get_autocomplete(self, instance):
         return [
@@ -44,6 +45,7 @@ class GroupIndex(SearchIndex):
     autocomplete_result_fields = ("name", "type", "logo")
 
     autocomplete_fields = ("name",)
+    fallback_to_autocomplete = True
 
     def get_autocomplete(self, instance):
         return [instance.name] + instance.name.split(" ")

--- a/lego/settings/base.py
+++ b/lego/settings/base.py
@@ -17,6 +17,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.contrib.postgres",
     "django_extensions",
     "oauth2_provider",
     "rest_framework",


### PR DESCRIPTION
Improve postgres search _alot_ by using PostgreSQL's full text search. Also implement the `search` method to allow more comprehensive searching. This is now used when pressing enter in the search bar in the webapp. IMO it's a _massive_ improvement since it searches in the content again.

Currently this adds a query for all search indices (some still missing). I have though about making this more general, since a lot of the autocomplete queries are very similar, especially the `SearchQuery` for autocompletion. It's not a big deal though, but let me know if anyone has any thoughts! :hand:.

**TODO:**
- [x] Edit the rest of the search indices
- [x] Consider generalizing the `search` and `autocomplete` methods with a general method for the base `SearchIndex` class. (see below)
- [ ] ~~Consider adding pagination (this will probably be another PR, not really in scope for this)~~

I ended up adding a method for `search` and `autocomplete` that uses a `search_fields` and `autocomplete_fields` to create a search vector and query. This makes the code a lot smaller, and allows us to add a new search index by just adding the fields that should be used for search/autocomplete as attributes.