### PR TITLE
Fix bad equality check in survey permission handler

### DIFF
--- a/lego/apps/surveys/permissions.py
+++ b/lego/apps/surveys/permissions.py
@@ -59,4 +59,4 @@ class SurveyTokenPermissions(permissions.BasePermission):
         if view.action not in ["retrieve"]:
             return False
         survey = Survey.objects.get(id=view.kwargs["pk"])
-        return request.auth and survey.id is request.auth.id
+        return request.auth and survey.id == request.auth.id


### PR DESCRIPTION
Ints <= 256 are preallocated on the heap, so any int under 257 points to
the same object in memory. Since the is operator compares object
references, two vars with the same value > 256 are allocated as
different memory objects meaning is will evaluate to False.

Changing to == fixes this issue by comparing the value instead.

see https://medium.com/peloton-engineering/the-dangers-of-using-is-in-python-f42941124027