### PR TITLE
Add unsubscribe link in mails

### DIFF
--- a/lego/apps/restricted/message_processor.py
+++ b/lego/apps/restricted/message_processor.py
@@ -149,6 +149,10 @@ class MessageProcessor:
             )
         else:
             footer.append("Opprinnelig avsender har valgt å skjule sin adresse.")
+        
+        footer.append(
+            f"Meld deg av her: {settings.FRONTEND_URL}/users/me/settings/notifications"
+        )
 
         footer = "\n".join(footer)
         charset = message.get_content_charset() or "us-ascii"

--- a/lego/templates/email/base.html
+++ b/lego/templates/email/base.html
@@ -216,11 +216,6 @@
         <table cellspacing="0" cellpadding="0" width="100%" bgcolor="#ffffff" background="http://s3.amazonaws.com/swu-filepicker/4E687TRe69Ld95IDWyEg_bg_top_02.jpg" style="background-color:transparent">
           <tr>
             <td width="100%" height="80" valign="top" style="text-align: center; vertical-align:middle;">
-            <!--[if gte mso 9]>
-            <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="mso-width-percent:1000;height:80px; v-text-anchor:middle;">
-              <v:fill type="tile" src="http://s3.amazonaws.com/swu-filepicker/4E687TRe69Ld95IDWyEg_bg_top_02.jpg" color="#ffffff" />
-              <v:textbox inset="0,0,0,0">
-            <![endif]-->
               <center>
                 <table cellpadding="0" cellspacing="0" width="600" class="w320">
                   <tr>
@@ -228,15 +223,10 @@
                       <a href=""><img width="150" height="30" src="https://abakus.no/185f9aa436cf7f5da598fd7e07700efd.png"></a>
                     </td>
                     <td class="pull-right mobile-header-padding-right" style="color: #4d4d4d;">
-                      <a href="https://www.facebook.com/AbakusNTNU"><img width="38" height="47" src="http://s3.amazonaws.com/swu-filepicker/LMPMj7JSRoCWypAvzaN3_social_09.gif"/></a>
                     </td>
                   </tr>
                 </table>
               </center>
-              <!--[if gte mso 9]>
-              </v:textbox>
-            </v:rect>
-            <![endif]-->
             </td>
           </tr>
         </table>
@@ -263,9 +253,21 @@
         <table cellpadding="0" cellspacing="0" width="600" class="w320">
           <tr>
             <td style="padding: 25px 0 25px">
-              <strong>Abakus Linjeforening</strong><br />
+              <b>Abakus Linjeforening</b><br />
                 <a mailto="abakus@abakus.no">abakus@abakus.no</a> <br />
                 <a href="{{ frontend_url }}">abakus.no</a> <br /><br />
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <p style="text-decoration: none !important; font-size: x-small;">
+                Ønsker du ikke å motta slike e-post fra Abakus, 
+                <br/>
+                kan du
+                <a href="{{ frontend_url }}/users/me/settings/notifications">
+                  melde deg av her.
+                </a>
+              </p>
             </td>
           </tr>
         </table>


### PR DESCRIPTION
Fix #2084

Add a link to notification settings in bottom of mail where user can unsubscribe mails.
![image](https://user-images.githubusercontent.com/31897129/110530246-7fe85f00-811a-11eb-9ea9-8cedbcb328aa.png)

I also removed the facebook-link as it can increase the chances of the mail being reported as spam.
I changed the `<strong>`-tag with a `<b>`-tag because older clients support it.
I also deleted some comments that didn't seem necessary, but I dont really know... 

And for restricted mail.