### PR TITLE
Add permissions based on event type for event create update

### DIFF
--- a/lego/apps/events/permissions.py
+++ b/lego/apps/events/permissions.py
@@ -1,7 +1,12 @@
+from rest_framework.permissions import BasePermission
+
 from structlog import get_logger
 
+from lego.apps.permissions.actions import action_to_permission
 from lego.apps.permissions.constants import CREATE, DELETE, EDIT, VIEW
+from lego.apps.permissions.models import ObjectPermissionsModel
 from lego.apps.permissions.permissions import PermissionHandler
+from lego.apps.permissions.utils import get_permission_handler
 
 log = get_logger()
 
@@ -9,6 +14,23 @@ log = get_logger()
 class EventPermissionHandler(PermissionHandler):
 
     perms_without_object = [CREATE, "administrate"]
+
+    def event_type_keyword_permissions(self, event_type, perm):
+        from lego.apps.events.models import Event
+
+        return self.keyword_permission(Event, perm) + "{event_type}/".format(
+            event_type=event_type
+        )
+
+    def has_event_type_level_permission(self, user, request, perm):
+        if request is None:
+            return True
+        event_type = request.data.get("event_type")
+
+        required_keyword_permissions = self.event_type_keyword_permissions(
+            event_type, perm
+        )
+        return user.has_perm(required_keyword_permissions)
 
 
 class RegistrationPermissionHandler(PermissionHandler):
@@ -31,7 +53,7 @@ class RegistrationPermissionHandler(PermissionHandler):
         obj=None,
         queryset=None,
         check_keyword_permissions=True,
-        **kwargs
+        **kwargs,
     ):
 
         is_self = self.is_self(perm, user, obj)
@@ -41,3 +63,14 @@ class RegistrationPermissionHandler(PermissionHandler):
         return super().has_perm(
             user, perm, obj, queryset, check_keyword_permissions, **kwargs
         )
+
+
+class EventTypePermission(BasePermission):
+    def has_permission(self, request, view):
+        from lego.apps.events.models import Event
+
+        perm = action_to_permission(view.action)
+        if perm in [CREATE, EDIT]:
+            handler = get_permission_handler(Event)
+            return handler.has_event_type_level_permission(request.user, request, perm)
+        return super().has_permission(request, view)

--- a/lego/apps/events/views.py
+++ b/lego/apps/events/views.py
@@ -26,6 +26,7 @@ from lego.apps.events.exceptions import (
 )
 from lego.apps.events.filters import EventsFilterSet
 from lego.apps.events.models import Event, Pool, Registration
+from lego.apps.events.permissions import EventTypePermission
 from lego.apps.events.serializers.events import (
     EventAdministrateExportSerializer,
     EventAdministrateSerializer,
@@ -76,6 +77,8 @@ class EventViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
     )
     ordering_fields = ("start_time", "end_time", "title")
     ordering = "start_time"
+
+    permission_classes = (EventTypePermission,)
 
     def get_queryset(self):
         user = self.request.user


### PR DESCRIPTION
This allows the use of keyword permissions for create/update actions and
limiting to event type.

F.ex. /sudo/admin/events/create/social allows creating _only_ events
with the `social` type. (You need the same with `edit` to edit social
events).

### TODO
- [ ] Tests
- [ ] Modify serializers to limit fields you can set based on the event_type (might be another PR)
- [ ] Modify administrator view to limit what data the event admin can see. (^^^^)