### PR TITLE
Don't try to cancel a non-existing payment on registration update

### DIFF
--- a/lego/apps/events/views.py
+++ b/lego/apps/events/views.py
@@ -344,7 +344,8 @@ class RegistrationViewSet(
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         if (
-            serializer.validated_data.get("payment_status", None)
+            registration.payment_intent_id
+            and serializer.validated_data.get("payment_status", None)
             == constants.PAYMENT_MANUAL
         ):
             async_cancel_payment.delay(registration.id)


### PR DESCRIPTION
Found another issue :upside_down_face:. This gives an error when there is no payment intent created
for a registration and someone updates the registration.
