### PR TITLE
Fix the order of the commands in READE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ $ python3 -m venv venv
 $ echo "from .development import *" > lego/settings/local.py
 $ source venv/bin/activate
 $ pip install -r requirements/dev.txt
+$ docker-compose up -d
 $ python manage.py initialize_development
 
 # Activate and run (do every time)


### PR DESCRIPTION
The order of the commands presented in the "initial setup" step in README.md is wrong. One has to run docker-compose up -d before running python manage.py initialize_development