### PR TITLE
Replace hard-coded http status code integers with constants from rest_framework

### DIFF
--- a/lego/api/test_urls.py
+++ b/lego/api/test_urls.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from rest_framework import status
 
 from lego.utils.test_utils import BaseTestCase
 
@@ -6,14 +7,14 @@ from lego.utils.test_utils import BaseTestCase
 class VersionRedirectTestCase(BaseTestCase):
     def test_redirect(self):
         response = self.client.get("/api/users/")
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
         self.assertTrue(settings.API_VERSION in response.url)
 
     def test_404(self):
         response = self.client.get("/api/bad-url/")
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_default_router_redirect(self):
         response = self.client.get("/api/")
-        self.assertEquals(response.status_code, 302)
+        self.assertEquals(response.status_code, status.HTTP_302_FOUND)
         self.assertIn(settings.API_VERSION, response.url)

--- a/lego/apps/companies/tests/test_companies_api.py
+++ b/lego/apps/companies/tests/test_companies_api.py
@@ -1,4 +1,5 @@
 from django.urls import reverse
+from rest_framework import status
 
 from lego.apps.users.models import AbakusGroup, User
 from lego.utils.test_utils import BaseAPITestCase
@@ -58,13 +59,13 @@ class ListCompaniesTestCase(BaseAPITestCase):
         AbakusGroup.objects.get(name="Abakus").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         company_response = self.client.get(_get_list_url())
-        self.assertEqual(company_response.status_code, 403)
+        self.assertEqual(company_response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_with_bedkom_user(self):
         AbakusGroup.objects.get(name="Bedkom").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         company_response = self.client.get(_get_list_url())
-        self.assertEqual(company_response.status_code, 200)
+        self.assertEqual(company_response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(company_response.json()["results"]), 3)
 
 
@@ -78,13 +79,13 @@ class RetrieveCompaniesTestCase(BaseAPITestCase):
         AbakusGroup.objects.get(name="Abakus").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         company_response = self.client.get(_get_detail_url(1))
-        self.assertEqual(company_response.status_code, 403)
+        self.assertEqual(company_response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_with_bedkom_user(self):
         AbakusGroup.objects.get(name="Bedkom").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         company_response = self.client.get(_get_detail_url(1))
-        self.assertEqual(company_response.status_code, 200)
+        self.assertEqual(company_response.status_code, status.HTTP_200_OK)
 
 
 class CreateCompaniesTestCase(BaseAPITestCase):
@@ -97,25 +98,25 @@ class CreateCompaniesTestCase(BaseAPITestCase):
         AbakusGroup.objects.get(name="Abakus").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         company_response = self.client.post(_get_list_url(), _test_company_data[0])
-        self.assertEqual(company_response.status_code, 403)
+        self.assertEqual(company_response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_company_creation_with_bedkom_user(self):
         AbakusGroup.objects.get(name="Bedkom").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         company_response = self.client.post(_get_list_url(), _test_company_data[0])
-        self.assertEqual(company_response.status_code, 201)
+        self.assertEqual(company_response.status_code, status.HTTP_201_CREATED)
 
     def test_company_update_with_abakus_user(self):
         AbakusGroup.objects.get(name="Abakus").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         company_response = self.client.patch(_get_detail_url(1), _test_company_data[1])
-        self.assertEqual(company_response.status_code, 403)
+        self.assertEqual(company_response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_company_update_with_bedkom_user(self):
         AbakusGroup.objects.get(name="Bedkom").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         company_response = self.client.patch(_get_detail_url(1), _test_company_data[1])
-        self.assertEqual(company_response.status_code, 200)
+        self.assertEqual(company_response.status_code, status.HTTP_200_OK)
         self.assertEqual(company_response.json()["name"], _test_company_data[1]["name"])
 
 
@@ -129,16 +130,16 @@ class DeleteCompaniesTestCase(BaseAPITestCase):
         AbakusGroup.objects.get(name="Abakus").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         delete_response = self.client.delete(_get_detail_url(1))
-        self.assertEqual(delete_response.status_code, 403)
+        self.assertEqual(delete_response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_company_delete_with_bedkom_user(self):
         AbakusGroup.objects.get(name="Bedkom").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         delete_response = self.client.delete(_get_detail_url(1))
-        self.assertEqual(delete_response.status_code, 204)
+        self.assertEqual(delete_response.status_code, status.HTTP_204_NO_CONTENT)
 
         company_response = self.client.get(_get_detail_url(1))
-        self.assertEqual(company_response.status_code, 404)
+        self.assertEqual(company_response.status_code, status.HTTP_404_NOT_FOUND)
 
 
 class CreateSemesterStatusTestCase(BaseAPITestCase):
@@ -153,7 +154,7 @@ class CreateSemesterStatusTestCase(BaseAPITestCase):
         company_response = self.client.post(
             _get_semester_status_list_url(1), _test_semester_status_data[0]
         )
-        self.assertEqual(company_response.status_code, 403)
+        self.assertEqual(company_response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_semester_status_creation_with_bedkom_user(self):
         AbakusGroup.objects.get(name="Bedkom").add_user(self.abakus_user)
@@ -161,7 +162,7 @@ class CreateSemesterStatusTestCase(BaseAPITestCase):
         response = self.client.post(
             _get_semester_status_list_url(1), _test_semester_status_data[0]
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_semester_status_update_with_abakus_user(self):
         AbakusGroup.objects.get(name="Abakus").add_user(self.abakus_user)
@@ -169,7 +170,7 @@ class CreateSemesterStatusTestCase(BaseAPITestCase):
         response = self.client.patch(
             _get_semester_status_detail_url(1, 1), _test_semester_status_data[0]
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_semester_status_update_with_bedkom_user(self):
         AbakusGroup.objects.get(name="Bedkom").add_user(self.abakus_user)
@@ -177,7 +178,7 @@ class CreateSemesterStatusTestCase(BaseAPITestCase):
         company_response = self.client.patch(
             _get_semester_status_detail_url(1, 1), _test_semester_status_data[0]
         )
-        self.assertEqual(company_response.status_code, 200)
+        self.assertEqual(company_response.status_code, status.HTTP_200_OK)
         self.assertEqual(
             company_response.json()["semester"],
             _test_semester_status_data[0]["semester"],
@@ -194,13 +195,13 @@ class DeleteSemesterStatusTestCase(BaseAPITestCase):
         AbakusGroup.objects.get(name="Abakus").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         response = self.client.delete(_get_semester_status_detail_url(1, 1))
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_semester_status_deletion_with_bedkom_user(self):
         AbakusGroup.objects.get(name="Bedkom").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         response = self.client.delete(_get_semester_status_detail_url(1, 1))
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
 
 class CreateCompanyContactsTestCase(BaseAPITestCase):
@@ -215,7 +216,7 @@ class CreateCompanyContactsTestCase(BaseAPITestCase):
         response = self.client.post(
             _get_company_contacts_list_url(1), _test_company_contact_data[0]
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_company_contact_creation_with_bedkom_user(self):
         AbakusGroup.objects.get(name="Bedkom").add_user(self.abakus_user)
@@ -223,7 +224,7 @@ class CreateCompanyContactsTestCase(BaseAPITestCase):
         response = self.client.post(
             _get_company_contacts_list_url(1), _test_company_contact_data[0]
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_company_contact_update_with_abakus_user(self):
         AbakusGroup.objects.get(name="Abakus").add_user(self.abakus_user)
@@ -231,7 +232,7 @@ class CreateCompanyContactsTestCase(BaseAPITestCase):
         response = self.client.patch(
             _get_company_contacts_detail_url(1, 1), _test_company_contact_data[0]
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_company_contact_update_with_bedkom_user(self):
         AbakusGroup.objects.get(name="Bedkom").add_user(self.abakus_user)
@@ -239,7 +240,7 @@ class CreateCompanyContactsTestCase(BaseAPITestCase):
         company_response = self.client.patch(
             _get_company_contacts_detail_url(1, 1), _test_company_contact_data[0]
         )
-        self.assertEqual(company_response.status_code, 200)
+        self.assertEqual(company_response.status_code, status.HTTP_200_OK)
         self.assertEqual(
             company_response.json()["name"], _test_company_contact_data[0]["name"]
         )
@@ -255,12 +256,12 @@ class DeleteCompanyContacsTestCase(BaseAPITestCase):
         AbakusGroup.objects.get(name="Abakus").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         response = self.client.delete(_get_company_contacts_detail_url(1, 1))
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_company_contact_deletion_with_bedkom_user(self):
         AbakusGroup.objects.get(name="Bedkom").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         response = self.client.delete(_get_company_contacts_detail_url(1, 1))
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         get_response = self.client.get(_get_company_contacts_detail_url(1, 1))
-        self.assertEqual(get_response.status_code, 404)
+        self.assertEqual(get_response.status_code, status.HTTP_404_NOT_FOUND)

--- a/lego/apps/companies/tests/test_company_interest.py
+++ b/lego/apps/companies/tests/test_company_interest.py
@@ -1,4 +1,5 @@
 from django.urls import reverse
+from rest_framework import status
 
 from lego.apps.users.models import AbakusGroup, User
 from lego.utils.test_utils import BaseAPITestCase
@@ -53,13 +54,15 @@ class ListCompanyInterestTestCase(BaseAPITestCase):
         AbakusGroup.objects.get(name="Abakus").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         company_interest_list_response = self.client.get(_get_company_interests())
-        self.assertEqual(company_interest_list_response.status_code, 403)
+        self.assertEqual(
+            company_interest_list_response.status_code, status.HTTP_403_FORBIDDEN
+        )
 
     def test_list_with_bedkom_user(self):
         AbakusGroup.objects.get(name="Bedkom").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         company_interest_list_response = self.client.get(_get_company_interests())
-        self.assertEqual(company_interest_list_response.status_code, 200)
+        self.assertEqual(company_interest_list_response.status_code, status.HTTP_200_OK)
         self.assertTrue(len(company_interest_list_response.json()["results"]))
 
 
@@ -74,7 +77,7 @@ class CreateCompanyInterestTestCase(BaseAPITestCase):
         response = self.client.post(
             _get_company_interests(), _test_company_interest_data[0]
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
 
 class RetrieveSemestersInInterestFormTestCase(BaseAPITestCase):
@@ -86,7 +89,7 @@ class RetrieveSemestersInInterestFormTestCase(BaseAPITestCase):
 
     def test_retrieve_with_any_user(self):
         response = self.client.get(_get_company_semesters())
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
 
 class DeleteCompanyInterestFromList(BaseAPITestCase):
@@ -103,15 +106,15 @@ class DeleteCompanyInterestFromList(BaseAPITestCase):
         AbakusGroup.objects.get(name="Abakus").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         response = self.client.delete(_get_detail_company_interest(1))
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_delete_with_bedkom_user(self):
         AbakusGroup.objects.get(name="Bedkom").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         response = self.client.delete(_get_detail_company_interest(1))
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         get_response = self.client.get(_get_detail_company_interest(1))
-        self.assertEqual(get_response.status_code, 404)
+        self.assertEqual(get_response.status_code, status.HTTP_404_NOT_FOUND)
 
 
 class EditCompanyInterest(BaseAPITestCase):
@@ -130,9 +133,9 @@ class EditCompanyInterest(BaseAPITestCase):
         response = self.client.patch(
             _get_detail_company_interest(1), _test_company_interest_data[1]
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         get_response = self.client.get(_get_detail_company_interest(1))
-        self.assertEqual(get_response.status_code, 403)
+        self.assertEqual(get_response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_edit_with_bedkom_user(self):
         AbakusGroup.objects.get(name="Bedkom").add_user(self.abakus_user)
@@ -140,6 +143,6 @@ class EditCompanyInterest(BaseAPITestCase):
         response = self.client.patch(
             _get_detail_company_interest(1), _test_company_interest_data[1]
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         get_response = self.client.get(_get_detail_company_interest(1))
-        self.assertEqual(get_response.status_code, 200)
+        self.assertEqual(get_response.status_code, status.HTTP_200_OK)

--- a/lego/apps/events/tests/test_events_api.py
+++ b/lego/apps/events/tests/test_events_api.py
@@ -5,6 +5,7 @@ from unittest import mock, skipIf
 from django.conf import settings
 from django.urls import reverse
 from django.utils import timezone
+from rest_framework import status
 
 import stripe
 from djangorestframework_camel_case.render import camelize
@@ -234,21 +235,21 @@ class ListEventsTestCase(BaseAPITestCase):
 
     def test_with_unauth(self):
         event_response = self.client.get(_get_list_url())
-        self.assertEqual(event_response.status_code, 200)
+        self.assertEqual(event_response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(event_response.json()["results"]), 6)
 
     def test_with_abakus_user(self):
         AbakusGroup.objects.get(name="Abakus").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         event_response = self.client.get(_get_list_url())
-        self.assertEqual(event_response.status_code, 200)
+        self.assertEqual(event_response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(event_response.json()["results"]), 6)
 
     def test_with_webkom_user(self):
         AbakusGroup.objects.get(name="Webkom").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         event_response = self.client.get(_get_list_url())
-        self.assertEqual(event_response.status_code, 200)
+        self.assertEqual(event_response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(event_response.json()["results"]), 10)
 
 
@@ -266,13 +267,13 @@ class RetrieveEventsTestCase(BaseAPITestCase):
     def test_without_authentication(self):
         """Test that unauth user can retrieve event"""
         event_response = self.client.get(_get_detail_url(2))
-        self.assertEqual(event_response.status_code, 200)
+        self.assertEqual(event_response.status_code, status.HTTP_200_OK)
 
     def test_with_authentication(self):
         """Test that auth user can retrieve event"""
         self.client.force_authenticate(self.abakus_user)
         event_response = self.client.get(_get_detail_url(2))
-        self.assertEqual(event_response.status_code, 200)
+        self.assertEqual(event_response.status_code, status.HTTP_200_OK)
 
     def test_unauth_cant_see_registrations(self):
         event_response = self.client.get(_get_detail_url(1))
@@ -307,14 +308,14 @@ class RetrieveEventsTestCase(BaseAPITestCase):
         event = Event.objects.get(title="ABAKOM_ONLY")
         self.client.force_authenticate(self.abakus_user)
         event_response = self.client.get(_get_detail_url(event.id))
-        self.assertEqual(event_response.status_code, 404)
+        self.assertEqual(event_response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_without_group_permission_abakom_only(self):
         """Test that auth user cannot retrieve abakom only event"""
         event = Event.objects.get(title="ABAKOM_ONLY")
         self.client.force_authenticate(self.abakus_user)
         event_response = self.client.get(_get_detail_url(event.id))
-        self.assertEqual(event_response.status_code, 404)
+        self.assertEqual(event_response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_with_group_permission_abakom_only(self):
         """Test that abakom user can retrieve abakom only event"""
@@ -322,7 +323,7 @@ class RetrieveEventsTestCase(BaseAPITestCase):
         event = Event.objects.get(title="ABAKOM_ONLY")
         self.client.force_authenticate(self.abakus_user)
         event_response = self.client.get(_get_detail_url(event.id))
-        self.assertEqual(event_response.status_code, 200)
+        self.assertEqual(event_response.status_code, status.HTTP_200_OK)
 
     def test_payment_status_hidden_when_not_priced(self):
         """Test that paymentStatus is hidden when getting nonpriced event"""
@@ -477,13 +478,13 @@ class CreateEventsTestCase(BaseAPITestCase):
         AbakusGroup.objects.get(name="Webkom").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         self.event_response = self.client.post(_get_list_url(), _test_event_data[0])
-        self.assertEqual(self.event_response.status_code, 201)
+        self.assertEqual(self.event_response.status_code, status.HTTP_201_CREATED)
         self.event_id = self.event_response.json().pop("id", None)
 
     def test_event_creation(self):
         """Test event creation with pools"""
         self.assertIsNotNone(self.event_id)
-        self.assertEqual(self.event_response.status_code, 201)
+        self.assertEqual(self.event_response.status_code, status.HTTP_201_CREATED)
         res_event = self.event_response.json()
         expect_event = camelize(_test_event_data[0])
         for key in [
@@ -510,7 +511,7 @@ class CreateEventsTestCase(BaseAPITestCase):
     def test_event_creation_tba(self):
         """Test event creation for TBA status type"""
         self.event_response = self.client.post(_get_list_url(), _test_event_data[2])
-        self.assertEqual(self.event_response.status_code, 201)
+        self.assertEqual(self.event_response.status_code, status.HTTP_201_CREATED)
         event_id = self.event_response.json().pop("id", None)
         self.assertIsNotNone(event_id)
         res_event = self.event_response.json()
@@ -533,7 +534,7 @@ class CreateEventsTestCase(BaseAPITestCase):
     def test_event_creation_open(self):
         """Test event creation for OPEN status type"""
         self.event_response = self.client.post(_get_list_url(), _test_event_data[3])
-        self.assertEqual(self.event_response.status_code, 201)
+        self.assertEqual(self.event_response.status_code, status.HTTP_201_CREATED)
         self.event_id = self.event_response.json().pop("id", None)
         self.assertIsNotNone(self.event_id)
         res_event = self.event_response.json()
@@ -556,7 +557,7 @@ class CreateEventsTestCase(BaseAPITestCase):
     def test_event_creation_infinite(self):
         """Test event creation for INFINITE status type"""
         self.event_response = self.client.post(_get_list_url(), _test_event_data[4])
-        self.assertEqual(self.event_response.status_code, 201)
+        self.assertEqual(self.event_response.status_code, status.HTTP_201_CREATED)
         self.event_id = self.event_response.json().pop("id", None)
         self.assertIsNotNone(self.event_id)
         res_event = self.event_response.json()
@@ -580,7 +581,7 @@ class CreateEventsTestCase(BaseAPITestCase):
     def test_event_create_no_event_status_type(self):
         """Test event creation with no event status type posted"""
         event_response = self.client.post(_get_list_url(), _test_event_data[5])
-        self.assertEqual(event_response.status_code, 201)
+        self.assertEqual(event_response.status_code, status.HTTP_201_CREATED)
         event_id = event_response.json().pop("id", None)
         self.assertIsNotNone(event_id)
         created_event = Event.objects.get(id=event_id)
@@ -589,13 +590,13 @@ class CreateEventsTestCase(BaseAPITestCase):
     def test_event_creation_without_auth(self):
         self.client.logout()
         response = self.client.post(_get_list_url(), _test_event_data[1])
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_event_creation_without_perm(self):
         user = User.objects.get(username="abakule")
         self.client.force_authenticate(user)
         response = self.client.post(_get_list_url(), _test_event_data[1])
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_event_update(self):
         """Test updating event attributes"""
@@ -604,7 +605,7 @@ class CreateEventsTestCase(BaseAPITestCase):
         event_update_response = self.client.put(
             _get_detail_url(self.event_id), expect_event
         )
-        self.assertEqual(event_update_response.status_code, 200)
+        self.assertEqual(event_update_response.status_code, status.HTTP_200_OK)
         self.assertEqual(self.event_id, event_update_response.json().pop("id"))
         res_event = event_update_response.json()
         for key in [
@@ -632,7 +633,7 @@ class CreateEventsTestCase(BaseAPITestCase):
         event_update_response = self.client.put(
             _get_detail_url(self.event_id), try_event
         )
-        self.assertEqual(event_update_response.status_code, 403)
+        self.assertEqual(event_update_response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_event_update_without_auth(self):
         """Test updating event attributes without auth is not allowed"""
@@ -642,7 +643,9 @@ class CreateEventsTestCase(BaseAPITestCase):
         event_update_response = self.client.put(
             _get_detail_url(self.event_id), try_event
         )
-        self.assertEqual(event_update_response.status_code, 401)
+        self.assertEqual(
+            event_update_response.status_code, status.HTTP_401_UNAUTHORIZED
+        )
 
     def test_event_partial_update(self):
         """Test patching event attributes"""
@@ -650,7 +653,7 @@ class CreateEventsTestCase(BaseAPITestCase):
         event_update_response = self.client.patch(
             _get_detail_url(self.event_id), {"title": "PATCHED"}
         )
-        self.assertEqual(event_update_response.status_code, 200)
+        self.assertEqual(event_update_response.status_code, status.HTTP_200_OK)
         self.assertEqual(self.event_id, event_update_response.json().pop("id"))
         res_event = event_update_response.json()
         self.assertEqual(res_event["title"], "PATCHED")
@@ -675,7 +678,7 @@ class CreateEventsTestCase(BaseAPITestCase):
         event_update_response = self.client.put(
             _get_detail_url(self.event_id), expect_event
         )
-        self.assertEqual(event_update_response.status_code, 200)
+        self.assertEqual(event_update_response.status_code, status.HTTP_200_OK)
         self.assertEqual(self.event_id, event_update_response.json().pop("id"))
         res_event = event_update_response.json()
         for key in [
@@ -707,7 +710,7 @@ class CreateEventsTestCase(BaseAPITestCase):
             _get_detail_url(self.event_id), _test_event_data[1]
         )
 
-        self.assertEqual(event_update_response.status_code, 200)
+        self.assertEqual(event_update_response.status_code, status.HTTP_200_OK)
         res_event = event_update_response.json()
         expect_event = _test_event_data[1]
         for key in [
@@ -734,7 +737,7 @@ class CreateEventsTestCase(BaseAPITestCase):
             _get_detail_url(self.event_id), {"pools": []}
         )
 
-        self.assertEqual(event_update_response.status_code, 200)
+        self.assertEqual(event_update_response.status_code, status.HTTP_200_OK)
         res_event = event_update_response.json()
         expect_event = _test_event_data[0]
         for key in [
@@ -755,13 +758,13 @@ class CreateEventsTestCase(BaseAPITestCase):
         test_event = _test_event_data[0].copy()
         test_event["youtubeUrl"] = "https://www.youtube.com/watch?v=KrzIaRwAMvc"
         self.response = self.client.post(_get_list_url(), test_event)
-        self.assertEqual(self.response.status_code, 201)
+        self.assertEqual(self.response.status_code, status.HTTP_201_CREATED)
 
     def test_event_wrong_youtube_url(self):
         test_event = _test_event_data[0].copy()
         test_event["youtubeUrl"] = "skra"
         self.response = self.client.post(_get_list_url(), test_event)
-        self.assertEqual(self.response.status_code, 400)
+        self.assertEqual(self.response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
 class PoolsTestCase(BaseAPITestCase):
@@ -779,26 +782,26 @@ class PoolsTestCase(BaseAPITestCase):
         AbakusGroup.objects.get(name="Webkom").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         pool_response = self.client.post(_get_pools_list_url(1), _test_pools_data[0])
-        self.assertEqual(pool_response.status_code, 201)
+        self.assertEqual(pool_response.status_code, status.HTTP_201_CREATED)
 
     def test_create_pool_as_bedkom(self):
         AbakusGroup.objects.get(name="Bedkom").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         pool_response = self.client.post(_get_pools_list_url(1), _test_pools_data[0])
-        self.assertEqual(pool_response.status_code, 201)
+        self.assertEqual(pool_response.status_code, status.HTTP_201_CREATED)
 
     def test_create_failing_pool_as_abakus(self):
         AbakusGroup.objects.get(name="Abakus").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         pool_response = self.client.post(_get_pools_list_url(1), _test_pools_data[0])
-        self.assertEqual(pool_response.status_code, 403)
+        self.assertEqual(pool_response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_delete_pool_with_registrations_as_admin(self):
         """Test that pool deletion is not possible when registrations are attached"""
         AbakusGroup.objects.get(name="Bedkom").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         pool_response = self.client.delete(_get_pools_detail_url(1, 1))
-        self.assertEqual(pool_response.status_code, 409)
+        self.assertEqual(pool_response.status_code, status.HTTP_409_CONFLICT)
 
     def test_delete_pool_without_registrations_as_admin(self):
         """Test that pool deletion is possible without attached registrations"""
@@ -809,7 +812,7 @@ class PoolsTestCase(BaseAPITestCase):
         AbakusGroup.objects.get(name="Bedkom").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         pool_response = self.client.delete(_get_pools_detail_url(1, pool.id))
-        self.assertEqual(pool_response.status_code, 204)
+        self.assertEqual(pool_response.status_code, status.HTTP_204_NO_CONTENT)
 
     def test_delete_pool_without_registrations_as_abakus(self):
         """Test that abakususer cannot delete pool"""
@@ -820,7 +823,7 @@ class PoolsTestCase(BaseAPITestCase):
         AbakusGroup.objects.get(name="Abakus").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         pool_response = self.client.delete(_get_pools_detail_url(1, pool.id))
-        self.assertEqual(pool_response.status_code, 403)
+        self.assertEqual(pool_response.status_code, status.HTTP_403_FORBIDDEN)
 
 
 @mock.patch("lego.apps.events.views.verify_captcha", return_value=True)
@@ -843,7 +846,7 @@ class RegistrationsTransactionTestCase(BaseAPITransactionTestCase):
         registration_response = self.client.post(
             _get_registrations_list_url(event.id), {}
         )
-        self.assertEqual(registration_response.status_code, 202)
+        self.assertEqual(registration_response.status_code, status.HTTP_202_ACCEPTED)
         reg_status = Registration.objects.get(
             pk=registration_response.json().get("id")
         ).status
@@ -862,7 +865,7 @@ class RegistrationsTransactionTestCase(BaseAPITransactionTestCase):
         registration_response = self.client.post(
             _get_registrations_list_url(event.id), {}
         )
-        self.assertEqual(registration_response.status_code, 202)
+        self.assertEqual(registration_response.status_code, status.HTTP_202_ACCEPTED)
         # We check the status against the database because the response is dependant
         # on whether we run celery in eager mode or not.
         reg_status = Registration.objects.get(
@@ -880,7 +883,7 @@ class RegistrationsTransactionTestCase(BaseAPITransactionTestCase):
         registration_response = self.client.post(
             _get_registrations_list_url(event.id), {}
         )
-        self.assertEqual(registration_response.status_code, 202)
+        self.assertEqual(registration_response.status_code, status.HTTP_202_ACCEPTED)
         reg_status = Registration.objects.get(
             pk=registration_response.json().get("id")
         ).status
@@ -896,7 +899,7 @@ class RegistrationsTransactionTestCase(BaseAPITransactionTestCase):
         registration_response = self.client.post(
             _get_registrations_list_url(event.id), {}
         )
-        self.assertEqual(registration_response.status_code, 202)
+        self.assertEqual(registration_response.status_code, status.HTTP_202_ACCEPTED)
         reg_status = Registration.objects.get(
             pk=registration_response.json().get("id")
         ).status
@@ -912,7 +915,7 @@ class RegistrationsTransactionTestCase(BaseAPITransactionTestCase):
         registration_response = self.client.post(
             _get_registrations_list_url(event.id), {}
         )
-        self.assertEqual(registration_response.status_code, 202)
+        self.assertEqual(registration_response.status_code, status.HTTP_202_ACCEPTED)
         reg_status = Registration.objects.get(
             pk=registration_response.json().get("id")
         ).status
@@ -932,8 +935,8 @@ class RegistrationsTransactionTestCase(BaseAPITransactionTestCase):
         get_unregistered = self.client.get(
             _get_registrations_detail_url(event.id, registration.id)
         )
-        self.assertEqual(registration_response.status_code, 202)
-        self.assertEqual(get_unregistered.status_code, 200)
+        self.assertEqual(registration_response.status_code, status.HTTP_202_ACCEPTED)
+        self.assertEqual(get_unregistered.status_code, status.HTTP_200_OK)
         self.assertEqual(get_unregistered.json().get("updatedBy"), self.abakus_user.id)
         self.assertIsNone(get_unregistered.json().get("pool"))
 
@@ -961,7 +964,7 @@ class RegistrationsTestCase(BaseAPITestCase):
         registration_response = self.client.post(
             _get_registrations_list_url(event.id), {}
         )
-        self.assertEqual(registration_response.status_code, 403)
+        self.assertEqual(registration_response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_update_feedback(self, *args):
         event = Event.objects.get(title="POOLS_NO_REGISTRATIONS")
@@ -972,7 +975,7 @@ class RegistrationsTestCase(BaseAPITestCase):
             _get_registrations_detail_url(event.id, registration_response.json()["id"]),
             {"feedback": "UPDATED"},
         )
-        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertEqual(res.json()["feedback"], "UPDATED")
 
     def test_update_presence_without_permission(self, *args):
@@ -985,7 +988,7 @@ class RegistrationsTestCase(BaseAPITestCase):
             _get_registrations_detail_url(event.id, registration_response.json()["id"]),
             {"presence": "PRESENT"},
         )
-        self.assertEqual(res.status_code, 403)
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_update_presence_with_permission(self, *args):
         """Test that admin can update presence"""
@@ -1000,7 +1003,7 @@ class RegistrationsTestCase(BaseAPITestCase):
             {"presence": "PRESENT"},
         )
         registration = Registration.objects.get(id=res.json()["id"])
-        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertEqual(res.json()["presence"], "PRESENT")
         self.assertEqual(registration.updated_by, self.abakus_user)
 
@@ -1017,7 +1020,7 @@ class RegistrationsTestCase(BaseAPITestCase):
             _get_registrations_detail_url(event.id, registration_response.json()["id"]),
             {"feedback": "UPDATED"},
         )
-        self.assertEqual(res.status_code, 403)
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_admin_update_registration(self, *args):
         event = Event.objects.get(title="POOLS_NO_REGISTRATIONS")
@@ -1033,7 +1036,7 @@ class RegistrationsTestCase(BaseAPITestCase):
             {"feedback": "UPDATED_BY_ADMIN"},
         )
         registration = Registration.objects.get(id=res.json()["id"])
-        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertEqual(res.json()["feedback"], "UPDATED_BY_ADMIN")
         self.assertEqual(registration.updated_by, self.webkom_user)
 
@@ -1048,7 +1051,7 @@ class RegistrationsTestCase(BaseAPITestCase):
             _get_registrations_detail_url(event.id, registration.id)
         )
 
-        self.assertEqual(registration_response.status_code, 403)
+        self.assertEqual(registration_response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_required_feedback_failing(self, *args):
         """Test that register returns 400 when not providing feedback when required"""
@@ -1058,7 +1061,7 @@ class RegistrationsTestCase(BaseAPITestCase):
         registration_response = self.client.post(
             _get_registrations_list_url(event.id), {}
         )
-        self.assertEqual(registration_response.status_code, 400)
+        self.assertEqual(registration_response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_required_feedback_success(self, *args):
         """Test that register returns 202 when providing feedback when required"""
@@ -1068,7 +1071,7 @@ class RegistrationsTestCase(BaseAPITestCase):
         registration_response = self.client.post(
             _get_registrations_list_url(event.id), {"feedback": "TEST"}
         )
-        self.assertEqual(registration_response.status_code, 202)
+        self.assertEqual(registration_response.status_code, status.HTTP_202_ACCEPTED)
 
     def test_update_payment_status_with_permissions(self, mock_verify_captcha):
         """Test user with permission can update payment_status"""
@@ -1082,7 +1085,7 @@ class RegistrationsTestCase(BaseAPITestCase):
             _get_registrations_detail_url(event.id, registration_response.json()["id"]),
             {"payment_status": "manual"},
         )
-        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
 
     def test_update_payment_status_wrongly_with_permissions(self, mock_verify_captcha):
         """Test user with permission fails in updating payment_status when giving wrong choice"""
@@ -1097,7 +1100,7 @@ class RegistrationsTestCase(BaseAPITestCase):
             _get_registrations_detail_url(event.id, registration_response.json()["id"]),
             {"payment_status": "feil-data"},
         )
-        self.assertEqual(res.status_code, 400)
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_update_payment_status_without_permissions(self, mock_verify_captcha):
         """Test that user without permission cannot update _status"""
@@ -1109,7 +1112,7 @@ class RegistrationsTestCase(BaseAPITestCase):
             _get_registrations_detail_url(event.id, registration_response.json()["id"]),
             {"payment_status": "manual"},
         )
-        self.assertEqual(res.status_code, 403)
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
 
 
 class EventAdministrateTestCase(BaseAPITestCase):
@@ -1130,7 +1133,7 @@ class EventAdministrateTestCase(BaseAPITestCase):
         event_response = self.client.get(
             f"{_get_detail_url(self.event.id)}administrate/"
         )
-        self.assertEqual(event_response.status_code, 200)
+        self.assertEqual(event_response.status_code, status.HTTP_200_OK)
         self.assertEqual(event_response.json().get("id"), self.event.id)
         self.assertEqual(len(event_response.json().get("pools")), 2)
 
@@ -1140,7 +1143,7 @@ class EventAdministrateTestCase(BaseAPITestCase):
         event_response = self.client.get(
             f"{_get_detail_url(self.event.id)}administrate/"
         )
-        self.assertEqual(event_response.status_code, 403)
+        self.assertEqual(event_response.status_code, status.HTTP_403_FORBIDDEN)
 
 
 class ExportInfoTestCase(BaseAPITestCase):
@@ -1170,7 +1173,7 @@ class ExportInfoTestCase(BaseAPITestCase):
         attendee_email = self.event.pools.first().registrations.first().user.email
 
         self.assertEqual(self.event.use_contact_tracing, True)
-        self.assertEqual(event_response.status_code, 200)
+        self.assertEqual(event_response.status_code, status.HTTP_200_OK)
         self.assertEqual(
             event_response.json()
             .get("pools")[0]
@@ -1229,7 +1232,7 @@ class CreateAdminRegistrationTestCase(BaseAPITestCase):
             },
         )
 
-        self.assertEqual(registration_response.status_code, 201)
+        self.assertEqual(registration_response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(self.pool.registrations.count(), 1)
         self.assertEqual(pool_two.registrations.count(), 0)
         self.assertEqual(
@@ -1254,7 +1257,7 @@ class CreateAdminRegistrationTestCase(BaseAPITestCase):
             },
         )
 
-        self.assertEqual(registration_response.status_code, 403)
+        self.assertEqual(registration_response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(self.event.number_of_registrations, 0)
 
     def test_with_nonexistant_pool(self):
@@ -1274,7 +1277,7 @@ class CreateAdminRegistrationTestCase(BaseAPITestCase):
             },
         )
 
-        self.assertEqual(registration_response.status_code, 400)
+        self.assertEqual(registration_response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(self.event.number_of_registrations, 0)
 
     def test_with_feedback(self):
@@ -1290,7 +1293,7 @@ class CreateAdminRegistrationTestCase(BaseAPITestCase):
             },
         )
 
-        self.assertEqual(registration_response.status_code, 201)
+        self.assertEqual(registration_response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(registration_response.json().get("feedback"), "TEST")
         self.assertEqual(
             registration_response.json()["createdBy"], self.request_user.id
@@ -1312,7 +1315,7 @@ class CreateAdminRegistrationTestCase(BaseAPITestCase):
             },
         )
 
-        self.assertEqual(registration_response.status_code, 400)
+        self.assertEqual(registration_response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_ar_to_waiting_list(self):
         AbakusGroup.objects.get(name="Webkom").add_user(self.request_user)
@@ -1324,7 +1327,7 @@ class CreateAdminRegistrationTestCase(BaseAPITestCase):
             {"user": self.user.id, "admin_registration_reason": "test"},
         )
 
-        self.assertEqual(registration_response.status_code, 201)
+        self.assertEqual(registration_response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(self.event.waiting_registrations.count(), 1)
 
 
@@ -1357,7 +1360,7 @@ class AdminUnregistrationTestCase(BaseAPITestCase):
             {"user": user.id, "admin_unregistration_reason": "test"},
         )
 
-        self.assertEqual(registration_response.status_code, 200)
+        self.assertEqual(registration_response.status_code, status.HTTP_200_OK)
         self.assertEqual(registration_response.json()["updatedBy"], self.webkom_user.id)
         self.assertEqual(self.event.number_of_registrations, registrations_before - 1)
 
@@ -1372,7 +1375,7 @@ class AdminUnregistrationTestCase(BaseAPITestCase):
             {"user": user.id, "admin_unregistration_reason": "test"},
         )
 
-        self.assertEqual(registration_response.status_code, 403)
+        self.assertEqual(registration_response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_without_admin_unregistration_reason(self):
         """Test that admin cannot unregister user without unregistration reason"""
@@ -1384,7 +1387,7 @@ class AdminUnregistrationTestCase(BaseAPITestCase):
             {"user": user.id, "admin_unregistration_reason": ""},
         )
 
-        self.assertEqual(registration_response.status_code, 400)
+        self.assertEqual(registration_response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
 @skipIf(not stripe.api_key, "No API Key set. Set STRIPE_TEST_KEY in ENV to run test.")
@@ -1442,7 +1445,7 @@ class StripePaymentTestCase(BaseAPITransactionTestCase):
         self.client.force_authenticate(self.abakus_user)
 
         res = self.get_payment_intent()
-        self.assertEqual(res.status_code, 202)
+        self.assertEqual(res.status_code, status.HTTP_202_ACCEPTED)
 
         registration = Registration.objects.get(id=self.registration.id)
 
@@ -1482,13 +1485,13 @@ class StripePaymentTestCase(BaseAPITransactionTestCase):
         mock_notify.assert_not_called()
 
         res = self.get_payment_intent()
-        self.assertEqual(res.status_code, 403)
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
 
         make_penalty_expire(p1)
         check_events_for_registrations_with_expired_penalties.delay()
 
         res = self.get_payment_intent()
-        self.assertEqual(res.status_code, 202)
+        self.assertEqual(res.status_code, status.HTTP_202_ACCEPTED)
         self.assertIsNone(reg.payment_intent_id)
 
         reg.refresh_from_db()
@@ -1724,21 +1727,21 @@ class CapacityExpansionTestCase(BaseAPITestCase):
         self.updated_event["pools"][0]["capacity"] = 11
         response = self.client.put(_get_detail_url(self.event.id), self.updated_event)
 
-        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.status_code, status.HTTP_200_OK)
         self.assertEquals(self.event.waiting_registrations.count(), 0)
 
     def test_bump_on_pool_creation(self):
         self.updated_event["pools"].append(_test_pools_data[0])
         response = self.client.put(_get_detail_url(self.event.id), self.updated_event)
 
-        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.status_code, status.HTTP_200_OK)
         self.assertEquals(self.event.waiting_registrations.count(), 0)
 
     def test_no_bump_on_reduced_pool_size(self):
         self.updated_event["pools"][0]["capacity"] = 9
         response = self.client.put(_get_detail_url(self.event.id), self.updated_event)
 
-        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.status_code, status.HTTP_200_OK)
         self.assertEquals(self.event.waiting_registrations.count(), 1)
 
 
@@ -1777,7 +1780,7 @@ class RegistrationSearchTestCase(BaseAPITestCase):
             _get_registration_search_url(self.event.pk),
             {"username": self.users[0].username},
         )
-        self.assertEquals(res.status_code, 200)
+        self.assertEquals(res.status_code, status.HTTP_200_OK)
         self.assertNotEqual(res.json().get("user", None), None)
 
     def test_asd_user(self):
@@ -1786,12 +1789,12 @@ class RegistrationSearchTestCase(BaseAPITestCase):
             _get_registration_search_url(self.event.pk),
             {"username": "asd007 xXx james bond"},
         )
-        self.assertEquals(res.status_code, 400)
+        self.assertEquals(res.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_no_username(self):
         self.client.force_authenticate(self.webkom_user)
         res = self.client.post(_get_registration_search_url(self.event.pk), {})
-        self.assertEquals(res.status_code, 400)
+        self.assertEquals(res.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_user_not_registered(self):
         self.client.force_authenticate(self.webkom_user)
@@ -1799,7 +1802,7 @@ class RegistrationSearchTestCase(BaseAPITestCase):
             _get_registration_search_url(self.event.pk),
             {"username": self.webkom_user.username},
         )
-        self.assertEquals(res.status_code, 400)
+        self.assertEquals(res.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_auth(self):
         self.client.force_authenticate(self.users[0])
@@ -1807,7 +1810,7 @@ class RegistrationSearchTestCase(BaseAPITestCase):
             _get_registration_search_url(self.event.pk),
             {"username": self.users[0].username},
         )
-        self.assertEquals(res.status_code, 403)
+        self.assertEquals(res.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_double_register(self):
         self.client.force_authenticate(self.webkom_user)
@@ -1819,7 +1822,7 @@ class RegistrationSearchTestCase(BaseAPITestCase):
             _get_registration_search_url(self.event.pk),
             {"username": self.users[0].username},
         )
-        self.assertEquals(res.status_code, 400)
+        self.assertEquals(res.status_code, status.HTTP_400_BAD_REQUEST)
 
 
 class UpcomingEventsTestCase(BaseAPITestCase):
@@ -1842,7 +1845,7 @@ class UpcomingEventsTestCase(BaseAPITestCase):
         AbakusGroup.objects.get(name="Abakus").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         event_response = self.client.get(_get_upcoming_url())
-        self.assertEqual(event_response.status_code, 200)
+        self.assertEqual(event_response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(event_response.json()), 2)
 
     def test_filter_out_old(self):
@@ -1854,10 +1857,10 @@ class UpcomingEventsTestCase(BaseAPITestCase):
         AbakusGroup.objects.get(name="Abakus").add_user(self.abakus_user)
         self.client.force_authenticate(self.abakus_user)
         event_response = self.client.get(_get_upcoming_url())
-        self.assertEqual(event_response.status_code, 200)
+        self.assertEqual(event_response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(event_response.json()), 1)
         self.assertNotEqual(event_response.json()[0]["id"], event.pk)
 
     def test_unauthenticated(self):
         event_response = self.client.get(_get_upcoming_url())
-        self.assertEqual(event_response.status_code, 401)
+        self.assertEqual(event_response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/lego/apps/flatpages/tests/test_api.py
+++ b/lego/apps/flatpages/tests/test_api.py
@@ -1,5 +1,7 @@
 import uuid
 
+from rest_framework import status
+
 from lego.apps.flatpages.models import Page
 from lego.apps.users.models import AbakusGroup, User
 from lego.apps.users.tests.utils import (
@@ -30,7 +32,7 @@ class PageAPITestCase(BaseAPITestCase):
 
     def test_get_pages(self):
         response = self.client.get("/api/v1/pages/")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.json()["results"]), 4)
         first = response.json()["results"][0]
         self.assertEqual(first["title"], self.pages.first().title)
@@ -41,14 +43,14 @@ class PageAPITestCase(BaseAPITestCase):
         slug = "webkom"
         response = self.client.get("/api/v1/pages/{0}/".format(slug))
         expected = self.pages.get(slug=slug)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["title"], expected.title)
         self.assertEqual(response.json()["slug"], expected.slug)
         self.assertEqual(response.json()["content"], expected.content)
 
     def test_non_existing_retrieve(self):
         response = self.client.get("/api/v1/pages/badslug/")
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_unauthenticated(self):
         slug = "webkom"
@@ -56,7 +58,7 @@ class PageAPITestCase(BaseAPITestCase):
         for method in methods:
             call = getattr(self.client, method)
             response = call("/api/v1/pages/{0}/".format(slug))
-            self.assertEqual(response.status_code, 401)
+            self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_unauthorized(self):
         slug = "webkom"
@@ -66,20 +68,20 @@ class PageAPITestCase(BaseAPITestCase):
         for method in methods:
             call = getattr(self.client, method)
             response = call("/api/v1/pages/{0}/".format(slug))
-            self.assertEqual(response.status_code, 403)
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_create_page(self):
         page = {"title": "cat", "content": "hei"}
         user = create_user_with_permissions("/sudo/admin/pages/")
         self.client.force_authenticate(user)
         response = self.client.post("/api/v1/pages/", data=page)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_list_with_keyword_permissions(self):
         user = create_user_with_permissions("/sudo/admin/pages/list/")
         self.client.force_authenticate(user)
         response = self.client.get("/api/v1/pages/")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.json()["results"]), 5)
 
     def test_edit_with_object_permissions(self):
@@ -94,7 +96,7 @@ class PageAPITestCase(BaseAPITestCase):
         response = self.client.patch(
             "/api/v1/pages/{0}/".format(slug), get_new_unique_page()
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_edit_without_object_permissions(self):
         slug = "webkom"
@@ -109,4 +111,4 @@ class PageAPITestCase(BaseAPITestCase):
         response = self.client.patch(
             "/api/v1/pages/{0}/".format(slug), get_new_unique_page()
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/lego/apps/frontpage/tests.py
+++ b/lego/apps/frontpage/tests.py
@@ -1,4 +1,5 @@
 from django.urls import reverse
+from rest_framework import status
 
 from lego.apps.users.models import AbakusGroup, User
 from lego.utils.test_utils import BaseAPITestCase
@@ -24,7 +25,7 @@ class FrontpageAPITestCase(BaseAPITestCase):
     def test_pinned_is_first(self):
         self.client.force_authenticate(self.user)
         res = self.client.get(_get_frontpage())
-        self.assertEquals(res.status_code, 200)
+        self.assertEquals(res.status_code, status.HTTP_200_OK)
         events = res.json()["events"]
         self.assertGreater(len(events), 1)
         first = events[0]
@@ -36,7 +37,7 @@ class FrontpageAPITestCase(BaseAPITestCase):
 
     def test_pinned_is_first_not_logged_in(self):
         res = self.client.get(_get_frontpage())
-        self.assertEquals(res.status_code, 200)
+        self.assertEquals(res.status_code, status.HTTP_200_OK)
         events = res.json()["events"]
         self.assertGreater(len(events), 1)
         first = events[0]

--- a/lego/apps/ical/tests/test_api.py
+++ b/lego/apps/ical/tests/test_api.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 
 from django.urls import reverse
 from django.utils import timezone
+from rest_framework import status
 
 from icalendar import Calendar
 
@@ -113,35 +114,35 @@ class IcalAuthenticationTestCase(BaseAPITestCase):
 
     def test_get_list(self, *args):
         res = self.client.get(_get_ical_list_url(self.token))
-        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
         res_token = res.json()["result"]["token"]["token"]
         self.assertEqual(res_token, self.token)
 
         res = self.client.get(_get_ical_list_url(self.token))
-        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
 
     def test_get_with_token(self, *args):
         for url in _get_all_ical_urls(self.token):
             res = self.client.get(url)
-            self.assertEqual(res.status_code, 200)
+            self.assertEqual(res.status_code, status.HTTP_200_OK)
             self.help_test_ical_content_permission(res.content, self.user)
 
     def test_get_ical_authenticated(self, *args):
         self.client.force_authenticate(self.user)
         for url in _get_all_ical_urls(""):
             res = self.client.get(url)
-            self.assertEqual(res.status_code, 200)
+            self.assertEqual(res.status_code, status.HTTP_200_OK)
             self.help_test_ical_content_permission(res.content, self.user)
 
     def test_get_ical_without_authentication(self, *args):
         for url in _get_all_ical_urls(""):
             res = self.client.get(url)
-            self.assertEqual(res.status_code, 401)
+            self.assertEqual(res.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_get_ical_with_invalid_token(self, *args):
         for url in _get_all_ical_urls("invalid-token-here"):
             res = self.client.get(url)
-            self.assertEqual(res.status_code, 401)
+            self.assertEqual(res.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
 class IcalPersonalTestCase(BaseAPITestCase):
@@ -249,7 +250,7 @@ class ICalTokenGenerateTestCase(BaseAPITestCase):
 
         res = self.client.get(_get_token_url())
         token = ICalToken.objects.get(user=self.abakommer)
-        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertEqual(res.json()["token"], token.token)
 
 
@@ -268,7 +269,7 @@ class ICalTokenRegenerateTestCase(BaseAPITestCase):
         new_token = ICalToken.objects.get(user=self.abakommer).token
 
         self.assertNotEqual(old_token, new_token)
-        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertEqual(res.json()["token"], new_token)
         self.assertNotEqual(res.json()["token"], old_token)
 
@@ -280,6 +281,6 @@ class ICalTokenRegenerateTestCase(BaseAPITestCase):
         new_token = ICalToken.objects.get(user=self.abakommer).token
 
         self.assertEqual(old_token, new_token)
-        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertEqual(res.json()["token"], new_token)
         self.assertEqual(res.json()["token"], old_token)

--- a/lego/apps/permissions/tests/test_permissions.py
+++ b/lego/apps/permissions/tests/test_permissions.py
@@ -1,3 +1,4 @@
+from rest_framework import status
 from rest_framework.test import APIRequestFactory, force_authenticate
 
 from lego.apps.permissions.tests.models import TestModel
@@ -40,7 +41,7 @@ class PermissionTestCase(BaseAPITestCase):
         response = view(request)
         created = response.data
 
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(created["name"], self.test_update_object["name"])
 
     def test_retrieve_successful(self):
@@ -51,7 +52,7 @@ class PermissionTestCase(BaseAPITestCase):
         response = view(request, pk=self.test_object.pk)
         test_object = response.data
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(test_object["name"], self.test_object.name)
 
     def test_retrieve_unsuccessful(self):
@@ -60,7 +61,7 @@ class PermissionTestCase(BaseAPITestCase):
         view = TestViewSet.as_view({"get": "retrieve"})
 
         response = view(request, pk=self.test_object.pk)
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_list_without_auth(self):
         shown_object = TestModel(name="shown", require_auth=False)
@@ -72,7 +73,7 @@ class PermissionTestCase(BaseAPITestCase):
         response = view(request)
         test_objects = response.data["results"]
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(test_objects), 1)
         self.assertEqual(test_objects[0]["name"], shown_object.name)
 
@@ -87,7 +88,7 @@ class PermissionTestCase(BaseAPITestCase):
         response = view(request)
         test_objects = response.data["results"]
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(test_objects), 2)
 
     def test_edit_successful(self):
@@ -98,7 +99,7 @@ class PermissionTestCase(BaseAPITestCase):
         response = view(request, pk=self.test_object.pk)
         edited_object = response.data
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(edited_object["name"], self.test_update_object["name"])
 
     def test_edit_unsuccessful(self):
@@ -108,7 +109,7 @@ class PermissionTestCase(BaseAPITestCase):
 
         response = view(request, pk=self.test_object.pk)
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_edit_own(self):
         request = self.factory.put("/permissiontest/", self.test_update_object)
@@ -118,7 +119,7 @@ class PermissionTestCase(BaseAPITestCase):
         response = view(request, pk=self.test_object.pk)
         edited_object = response.data
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(edited_object["name"], self.test_update_object["name"])
 
     def test_delete_successful(self):
@@ -128,7 +129,7 @@ class PermissionTestCase(BaseAPITestCase):
 
         response = view(request, pk=self.test_object.pk)
 
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
     def test_delete_unsuccessful(self):
         self.test_object.can_view_groups.add(self.webkom)
@@ -139,7 +140,7 @@ class PermissionTestCase(BaseAPITestCase):
 
         response = view(request, pk=self.test_object.pk)
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_edit_object_with_require_auth_false(self):
         """
@@ -150,4 +151,4 @@ class PermissionTestCase(BaseAPITestCase):
         response = self.client.put(
             f"/permissiontest/{self.test_object.id}/", self.test_update_object
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/lego/apps/tags/tests/test_api.py
+++ b/lego/apps/tags/tests/test_api.py
@@ -1,3 +1,5 @@
+from rest_framework import status
+
 import lego.apps.events.tests.test_events_api as event_api
 from lego.apps.events.models import Event
 from lego.apps.tags.models import Tag
@@ -23,7 +25,7 @@ class TagsTestCase(BaseAPITestCase):
         tag = Tag.objects.first()
         event_data["tags"] = [tag.tag]
         res = self.client.put(event_api._get_detail_url(pk), event_data)
-        self.assertEquals(res.status_code, 200)
+        self.assertEquals(res.status_code, status.HTTP_200_OK)
         self.assertTrue(tag.tag in res.json().pop("tags"))
 
     def test_remove_tag(self):
@@ -35,7 +37,7 @@ class TagsTestCase(BaseAPITestCase):
         removed = tags.pop()
         event_data["tags"] = tags
         res = self.client.put(event_api._get_detail_url(pk), event_data)
-        self.assertEquals(res.status_code, 200)
+        self.assertEquals(res.status_code, status.HTTP_200_OK)
         self.assertFalse(removed in res.json().pop("tags"))
 
     def test_add_duplicate_tag(self):
@@ -48,7 +50,7 @@ class TagsTestCase(BaseAPITestCase):
         event_data["tags"] = tags + tags
         total_tags_before = Tag.objects.count()
         res = self.client.put(event_api._get_detail_url(pk), event_data)
-        self.assertEquals(res.status_code, 200)
+        self.assertEquals(res.status_code, status.HTTP_200_OK)
         total_tags_after = Tag.objects.count()
         self.assertEquals(total_tags_before, total_tags_after)
         self.assertEquals(res.json()["tags"], tags)
@@ -64,7 +66,7 @@ class TagsTestCase(BaseAPITestCase):
 
         event_data["tags"] = [tag]
         res = self.client.put(event_api._get_detail_url(pk), event_data)
-        self.assertEquals(res.status_code, 200)
+        self.assertEquals(res.status_code, status.HTTP_200_OK)
         self.assertTrue(tag in res.json().pop("tags"))
         self.assertIsNotNone(Tag.objects.filter(tag=tag).first())
 
@@ -75,7 +77,7 @@ class TagsTestCase(BaseAPITestCase):
 
         event_data["tags"] = ["invalid tag with space"]
         response = self.client.patch(event_api._get_detail_url(pk), event_data)
-        self.assertEquals(response.status_code, 400)
+        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_preserve_tags(self):
         """Preserve tags when no tags is posted"""
@@ -89,7 +91,7 @@ class TagsTestCase(BaseAPITestCase):
         del event_data["cover"]
         del event_data["tags"]
         response = self.client.patch(event_api._get_detail_url(event.pk), event_data)
-        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.status_code, status.HTTP_200_OK)
         self.assertEquals(
             list(event.tags.values_list("pk", flat=True)), response.json()["tags"]
         )
@@ -104,7 +106,7 @@ class TagsTestCase(BaseAPITestCase):
         del event_data["cover"]
         event_data["tags"] = []
         response = self.client.patch(event_api._get_detail_url(event.pk), event_data)
-        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.status_code, status.HTTP_200_OK)
 
         event.refresh_from_db()
         self.assertEquals(list(event.tags.values_list("pk", flat=True)), [])

--- a/lego/apps/users/tests/test_abakusgroup_api.py
+++ b/lego/apps/users/tests/test_abakusgroup_api.py
@@ -1,4 +1,5 @@
 from django.urls import reverse
+from rest_framework import status
 
 from lego.apps.users import constants
 from lego.apps.users.constants import LEADER
@@ -42,7 +43,7 @@ class ListAbakusGroupAPITestCase(BaseAPITestCase):
         self.client.force_authenticate(user=user)
         response = self.client.get(_get_list_url())
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.json()["results"]), len(self.all_groups))
 
         for group in response.json()["results"]:
@@ -59,7 +60,7 @@ class ListAbakusGroupAPITestCase(BaseAPITestCase):
 
     def test_without_auth(self):
         response = self.client.get(_get_list_url())
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_with_auth(self):
         self.successful_list(self.user)
@@ -87,11 +88,11 @@ class RetrieveAbakusGroupAPITestCase(BaseAPITestCase):
     def successful_retrieve(self, user, pk):
         self.client.force_authenticate(user=user)
         response = self.client.get(_get_detail_url(pk))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_without_auth(self):
         response = self.client.get(_get_detail_url(1))
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_with_permission(self):
         self.successful_retrieve(self.with_permission, self.test_group.pk)
@@ -99,14 +100,14 @@ class RetrieveAbakusGroupAPITestCase(BaseAPITestCase):
     def test_own_group(self):
         self.client.force_authenticate(user=self.without_permission)
         response = self.client.get(_get_detail_url(self.test_group.pk))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_without_permission(self):
         new_group = AbakusGroup.objects.create(name="new_group")
 
         self.client.force_authenticate(user=self.without_permission)
         response = self.client.get(_get_detail_url(new_group.pk))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
 
 class CreateAbakusGroupAPITestCase(BaseAPITestCase):
@@ -132,7 +133,7 @@ class CreateAbakusGroupAPITestCase(BaseAPITestCase):
         self.client.force_authenticate(user=user)
         response = self.client.post(_get_list_url(), _test_group_data)
 
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         created_group = AbakusGroup.objects.get(name=_test_group_data["name"])
 
         for key, value in _test_group_data.items():
@@ -154,12 +155,12 @@ class CreateAbakusGroupAPITestCase(BaseAPITestCase):
         }
 
         response = self.client.post(_get_list_url(), group)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(expected_data, response.json())
 
     def test_without_auth(self):
         response = self.client.post(_get_list_url(), _test_group_data)
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_with_permission(self):
         self.successful_create(self.with_permission)
@@ -168,7 +169,7 @@ class CreateAbakusGroupAPITestCase(BaseAPITestCase):
         self.client.force_authenticate(user=self.without_permission)
         response = self.client.post(_get_list_url(), _test_group_data)
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertRaises(
             AbakusGroup.DoesNotExist,
             AbakusGroup.objects.get,
@@ -209,7 +210,7 @@ class UpdateAbakusGroupAPITestCase(BaseAPITestCase):
         )
         group = AbakusGroup.objects.get(pk=self.test_group.pk)
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         self.assertEqual(group.name, self.modified_group["name"])
         self.assertEqual(group.description, self.modified_group["description"])
@@ -219,7 +220,7 @@ class UpdateAbakusGroupAPITestCase(BaseAPITestCase):
         response = self.client.put(
             _get_detail_url(self.test_group.pk), self.modified_group
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_with_permission(self):
         self.successful_update(self.with_permission)
@@ -230,7 +231,7 @@ class UpdateAbakusGroupAPITestCase(BaseAPITestCase):
             _get_detail_url(self.test_group.pk), self.modified_group
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_as_leader(self):
         self.successful_update(self.leader)
@@ -256,7 +257,7 @@ class InterestGroupAPITestCase(BaseAPITestCase):
         self.client.force_authenticate(user=self.abakule)
         response = self.client.get(_get_membership_url(self.interest_group.pk))
 
-        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.status_code, status.HTTP_200_OK)
 
     def test_can_join_interest_group(self):
         self.client.force_authenticate(user=self.abakule)
@@ -264,7 +265,7 @@ class InterestGroupAPITestCase(BaseAPITestCase):
             _get_membership_url(self.interest_group.pk),
             {"user": self.abakule.pk, "role": "member"},
         )
-        self.assertEquals(response.status_code, 201)
+        self.assertEquals(response.status_code, status.HTTP_201_CREATED)
 
     def test_can_leave_interest_group(self):
         self.client.force_authenticate(user=self.abakule)
@@ -273,7 +274,7 @@ class InterestGroupAPITestCase(BaseAPITestCase):
             _get_membership_detail_url(self.interest_group.pk, membership.pk)
         )
 
-        self.assertEquals(response.status_code, 204)
+        self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)
 
     def test_cannot_join_for_another(self):
         self.client.force_authenticate(user=self.abakule)
@@ -281,7 +282,7 @@ class InterestGroupAPITestCase(BaseAPITestCase):
             _get_membership_url(self.interest_group.pk),
             {"user": self.abakommer.pk, "role": "member"},
         )
-        self.assertEquals(response.status_code, 403)
+        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_cannot_leave_for_another(self):
         self.client.force_authenticate(user=self.abakule)
@@ -289,7 +290,7 @@ class InterestGroupAPITestCase(BaseAPITestCase):
         response = self.client.delete(
             _get_membership_detail_url(self.interest_group.pk, membership.id)
         )
-        self.assertEquals(response.status_code, 403)
+        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_leader_can_kick(self):
         self.client.force_authenticate(user=self.leader)
@@ -298,7 +299,7 @@ class InterestGroupAPITestCase(BaseAPITestCase):
         response = self.client.delete(
             _get_membership_detail_url(self.interest_group.pk, membership.id)
         )
-        self.assertEquals(response.status_code, 204)
+        self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)
 
     def test_leader_cannot_join_for_another(self):
         self.client.force_authenticate(user=self.leader)
@@ -306,4 +307,4 @@ class InterestGroupAPITestCase(BaseAPITestCase):
             _get_membership_url(self.interest_group.pk),
             {"user": self.abakommer.pk, "role": "member"},
         )
-        self.assertEquals(response.status_code, 403)
+        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/lego/apps/users/tests/test_student_confirmation_api.py
+++ b/lego/apps/users/tests/test_student_confirmation_api.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 from django.urls import reverse
+from rest_framework import status
 
 from lego.apps.users import constants
 from lego.apps.users.models import AbakusGroup, User
@@ -33,7 +34,7 @@ class RetrieveStudentConfirmationAPITestCase(BaseAPITestCase):
 
     def test_with_unauthenticated_user(self):
         response = self.client.get(_get_list_request_url())
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_without_token(self):
         AbakusGroup.objects.get(name="Users").add_user(
@@ -41,7 +42,7 @@ class RetrieveStudentConfirmationAPITestCase(BaseAPITestCase):
         )
         self.client.force_authenticate(self.user_without_student_confirmation)
         response = self.client.get(_get_list_request_url())
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_with_empty_token(self):
         AbakusGroup.objects.get(name="Users").add_user(
@@ -49,7 +50,7 @@ class RetrieveStudentConfirmationAPITestCase(BaseAPITestCase):
         )
         self.client.force_authenticate(self.user_without_student_confirmation)
         response = self.client.get(_get_student_confirmation_token_request_url(""))
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_with_invalid_token(self):
         AbakusGroup.objects.get(name="Users").add_user(
@@ -59,7 +60,7 @@ class RetrieveStudentConfirmationAPITestCase(BaseAPITestCase):
         response = self.client.get(
             _get_student_confirmation_token_request_url("InvalidToken")
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_with_valid_token(self):
         AbakusGroup.objects.get(name="Users").add_user(
@@ -73,7 +74,7 @@ class RetrieveStudentConfirmationAPITestCase(BaseAPITestCase):
                 )
             )
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json().get("studentUsername"), "teststudentusername")
         self.assertEqual(response.json().get("course"), constants.DATA)
         self.assertEqual(response.json().get("member"), True)
@@ -90,7 +91,7 @@ class RetrieveStudentConfirmationAPITestCase(BaseAPITestCase):
                 )
             )
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json().get("studentUsername"), "teststudentusername")
         self.assertEqual(response.json().get("course"), constants.DATA)
         self.assertEqual(response.json().get("member"), True)
@@ -116,7 +117,7 @@ class CreateStudentConfirmationAPITestCase(BaseAPITestCase):
 
     def test_with_unauthenticated_user(self):
         response = self.client.post(_get_list_request_url())
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_without_data(self):
         AbakusGroup.objects.get(name="Users").add_user(
@@ -124,7 +125,7 @@ class CreateStudentConfirmationAPITestCase(BaseAPITestCase):
         )
         self.client.force_authenticate(self.user_without_student_confirmation)
         response = self.client.post(_get_list_request_url())
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @mock.patch(
         "lego.apps.users.serializers.student_confirmation.verify_captcha",
@@ -144,7 +145,7 @@ class CreateStudentConfirmationAPITestCase(BaseAPITestCase):
                 "captcha_response": "testCaptcha",
             },
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @mock.patch(
         "lego.apps.users.serializers.student_confirmation.verify_captcha",
@@ -164,7 +165,7 @@ class CreateStudentConfirmationAPITestCase(BaseAPITestCase):
                 "wrong_captcha_response": "testCaptcha",
             },
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @mock.patch(
         "lego.apps.users.serializers.student_confirmation.verify_captcha",
@@ -178,7 +179,7 @@ class CreateStudentConfirmationAPITestCase(BaseAPITestCase):
         invalid_data = self._test_student_confirmation_data.copy()
         invalid_data["student_username"] = "test_u$er@"
         response = self.client.post(_get_list_request_url(), invalid_data)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @mock.patch(
         "lego.apps.users.serializers.student_confirmation.verify_captcha",
@@ -192,7 +193,7 @@ class CreateStudentConfirmationAPITestCase(BaseAPITestCase):
         invalid_data = self._test_student_confirmation_data.copy()
         invalid_data["course"] = "test"
         response = self.client.post(_get_list_request_url(), invalid_data)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @mock.patch(
         "lego.apps.users.serializers.student_confirmation.verify_captcha",
@@ -206,7 +207,7 @@ class CreateStudentConfirmationAPITestCase(BaseAPITestCase):
         invalid_data = self._test_student_confirmation_data.copy()
         invalid_data["member"] = "test"
         response = self.client.post(_get_list_request_url(), invalid_data)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @mock.patch(
         "lego.apps.users.serializers.student_confirmation.verify_captcha",
@@ -220,7 +221,7 @@ class CreateStudentConfirmationAPITestCase(BaseAPITestCase):
         response = self.client.post(
             _get_list_request_url(), self._test_student_confirmation_data
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @mock.patch(
         "lego.apps.users.serializers.student_confirmation.verify_captcha",
@@ -234,7 +235,7 @@ class CreateStudentConfirmationAPITestCase(BaseAPITestCase):
         response = self.client.post(
             _get_list_request_url(), self._test_student_confirmation_data
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @mock.patch(
         "lego.apps.users.serializers.student_confirmation.verify_captcha",
@@ -248,7 +249,7 @@ class CreateStudentConfirmationAPITestCase(BaseAPITestCase):
         response = self.client.post(
             _get_list_request_url(), self._test_student_confirmation_data
         )
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
 
 class UpdateStudentConfirmationAPITestCase(BaseAPITestCase):
@@ -275,7 +276,7 @@ class UpdateStudentConfirmationAPITestCase(BaseAPITestCase):
         response = self.client.post(
             _get_student_confirmation_token_request_url("randomToken")
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_without_token(self):
         AbakusGroup.objects.get(name="Users").add_user(
@@ -283,7 +284,7 @@ class UpdateStudentConfirmationAPITestCase(BaseAPITestCase):
         )
         self.client.force_authenticate(self.user_without_student_confirmation)
         response = self.client.post(_get_list_perform_url())
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_with_empty_token(self):
         AbakusGroup.objects.get(name="Users").add_user(
@@ -291,7 +292,7 @@ class UpdateStudentConfirmationAPITestCase(BaseAPITestCase):
         )
         self.client.force_authenticate(self.user_without_student_confirmation)
         response = self.client.post(_get_list_perform_url())
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_with_invalid_token(self):
         AbakusGroup.objects.get(name="Users").add_user(
@@ -301,7 +302,7 @@ class UpdateStudentConfirmationAPITestCase(BaseAPITestCase):
         response = self.client.post(
             _get_student_confirmation_token_perform_url("InvalidToken")
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_with_already_confirmed_student_username(self):
         AbakusGroup.objects.get(name="Users").add_user(
@@ -310,7 +311,7 @@ class UpdateStudentConfirmationAPITestCase(BaseAPITestCase):
         self.client.force_authenticate(self.user_with_student_confirmation)
         token = self.create_token()
         response = self.client.post(_get_student_confirmation_token_perform_url(token))
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_without_abakus_member_checked_and_komtek_course(self):
         AbakusGroup.objects.get(name="Users").add_user(
@@ -319,7 +320,7 @@ class UpdateStudentConfirmationAPITestCase(BaseAPITestCase):
         self.client.force_authenticate(self.user_without_student_confirmation)
         token = self.create_token(course=constants.KOMTEK, member=False)
         response = self.client.post(_get_student_confirmation_token_perform_url(token))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         user = self.user_without_student_confirmation
         user_groups = user.all_groups
@@ -349,7 +350,7 @@ class UpdateStudentConfirmationAPITestCase(BaseAPITestCase):
         )
         token = self.create_token(course=constants.KOMTEK, member=True)
         response = self.client.post(_get_student_confirmation_token_perform_url(token))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         user = self.user_with_grade_group_but_no_student_confirmation
         user_groups = user.all_groups
@@ -376,7 +377,7 @@ class UpdateStudentConfirmationAPITestCase(BaseAPITestCase):
         self.client.force_authenticate(self.user_without_student_confirmation)
         token = self.create_token()
         response = self.client.post(_get_student_confirmation_token_perform_url(token))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         user = self.user_without_student_confirmation
         user_groups = user.all_groups

--- a/lego/apps/users/tests/test_users_api.py
+++ b/lego/apps/users/tests/test_users_api.py
@@ -65,18 +65,18 @@ class ListUsersAPITestCase(BaseAPITestCase):
         self.client.force_authenticate(user=user)
         response = self.client.get(_get_list_url())
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.json()["results"]), len(self.all_users))
 
     def test_without_auth(self):
         response = self.client.get(_get_list_url())
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_with_normal_user(self):
         self.client.force_authenticate(user=self.without_permission)
         response = self.client.get(_get_list_url())
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_with_useradmin(self):
         self.successful_list(self.with_permission)
@@ -101,21 +101,21 @@ class RetrieveUsersAPITestCase(BaseAPITestCase):
     def successful_retrieve(self, user):
         self.client.force_authenticate(user=user)
         response = self.client.get(_get_detail_url(self.test_user.username))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_without_auth(self):
         response = self.client.get(_get_detail_url(self.all_users.first().username))
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_with_normal_user(self):
         self.client.force_authenticate(user=self.without_perm)
         response = self.client.get(_get_detail_url(self.test_user.username))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_self_with_normal_user(self):
         self.client.force_authenticate(user=self.without_perm)
         response = self.client.get(_get_detail_url(self.without_perm.username))
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_with_useradmin(self):
         self.successful_retrieve(self.with_perm)
@@ -144,73 +144,73 @@ class CreateUsersAPITestCase(BaseAPITestCase):
     def test_with_authenticated_user(self):
         self.client.force_authenticate(user=self.existing_user)
         response = self.client.post(_get_registration_token_url("randomToken"))
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_without_token(self):
         response = self.client.post(_get_list_url())
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_with_empty_token(self):
         response = self.client.post(_get_registration_token_url(""))
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_with_invalid_token(self):
         response = self.client.post(_get_registration_token_url("InvalidToken"))
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_with_no_data(self):
         token = self.create_token()
         response = self.client.post(_get_registration_token_url(token), {})
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_with_existing_email(self):
         token = self.create_token("test1@user.com")
         response = self.client.post(
             _get_registration_token_url(token), self._test_registration_data
         )
-        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
 
     def test_with_existing_username(self):
         token = self.create_token(self.new_email_other)
         invalid_data = self._test_registration_data.copy()
         invalid_data["username"] = "test1"
         response = self.client.post(_get_registration_token_url(token), invalid_data)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_with_invalid_username(self):
         token = self.create_token(self.new_email_other)
         invalid_data = self._test_registration_data.copy()
         invalid_data["username"] = "$@@@@"
         response = self.client.post(_get_registration_token_url(token), invalid_data)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_with_email_as_username(self):
         token = self.create_token(self.new_email_other)
         invalid_data = self._test_registration_data.copy()
         invalid_data["username"] = self.new_email_other
         response = self.client.post(_get_registration_token_url(token), invalid_data)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_with_blank_username(self):
         token = self.create_token(self.new_email_other)
         invalid_data = self._test_registration_data.copy()
         invalid_data["username"] = ""
         response = self.client.post(_get_registration_token_url(token), invalid_data)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_with_blank_password(self):
         token = self.create_token(self.new_email_other)
         invalid_data = self._test_registration_data.copy()
         invalid_data["password"] = ""
         response = self.client.post(_get_registration_token_url(token), invalid_data)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_with_valid_data(self):
         token = self.create_token(self.new_email_other)
         response = self.client.post(
             _get_registration_token_url(token), self._test_registration_data
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         new_user = User.objects.get(email=self.new_email_other)
 
@@ -264,7 +264,7 @@ class UpdateUsersAPITestCase(BaseAPITestCase):
         response = self.client.patch(
             _get_detail_url(update_object.username), self.modified_user
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         for key, value in self.modified_user.items():
             self.assertEqual(response.json()[key], value)
@@ -282,7 +282,7 @@ class UpdateUsersAPITestCase(BaseAPITestCase):
         )
         user = User.objects.get(pk=self.test_user.pk)
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(user, self.test_user)
 
     def test_update_with_super_user(self):
@@ -399,7 +399,7 @@ class DeleteUsersAPITestCase(BaseAPITestCase):
         self.client.force_authenticate(user=user)
         response = self.client.delete(_get_detail_url(self.test_user.username))
 
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertRaises(User.DoesNotExist, User.objects.get, pk=self.test_user.pk)
 
     def test_with_normal_user(self):
@@ -407,7 +407,7 @@ class DeleteUsersAPITestCase(BaseAPITestCase):
         response = self.client.delete(_get_detail_url(self.test_user.username))
         users = User.objects.filter(pk=self.test_user.pk)
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertTrue(len(users))
 
     def test_with_useradmin(self):
@@ -429,7 +429,7 @@ class RetrieveSelfTestCase(BaseAPITestCase):
         self.client.force_authenticate(user=self.user)
         response = self.client.get(reverse("api:v1:user-me"))
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
             len(self.user.penalties.valid()), len(response.json()["penalties"])
         )
@@ -445,7 +445,7 @@ class RetrieveSelfTestCase(BaseAPITestCase):
 
     def test_self_unauthed(self):
         response = self.client.get(reverse("api:v1:user-me"))
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     @mock.patch("django.utils.timezone.now", return_value=fake_time(2016, 10, 1))
     def test_own_penalties_serializer(self, mock_now):
@@ -467,7 +467,7 @@ class RetrieveSelfTestCase(BaseAPITestCase):
         self.client.force_authenticate(user=self.user)
         response = self.client.get(reverse("api:v1:user-me"))
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         self.assertEqual(
             len(self.user.penalties.valid()), len(response.json()["penalties"])


### PR DESCRIPTION
Closes #2329

Replaces all hard-coded status codes in tests with constants imported from the `status` class within the `rest_framework` library.