### PR TITLE
Save phone number from registration form

### DIFF
--- a/lego/apps/users/serializers/registration.py
+++ b/lego/apps/users/serializers/registration.py
@@ -41,4 +41,5 @@ class RegistrationConfirmationSerializer(serializers.ModelSerializer):
             "gender",
             "password",
             "allergies",
+            "phone_number",
         )


### PR DESCRIPTION
Fixes #2028

`phone_number` was missing from the registration serializer. This caused phone numbers entered into the registration form to be ignored.