### PR TITLE
Update sorting of members in interestgroups to fetch leaders first

### DIFF
--- a/lego/apps/users/views/memberships.py
+++ b/lego/apps/users/views/memberships.py
@@ -17,7 +17,7 @@ class MembershipViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
         filters.OrderingFilter,
         LegoPermissionFilter,
     )
-    ordering = "id"
+    ordering = ["role", "id"]
 
     def get_queryset(self):
         group = self.kwargs["group_pk"]


### PR DESCRIPTION
Purpose: To make all leaders of interestgroups be fetched even if all members are not fetched (pagination)