### PR TITLE
Only allow one pinned item at a time

### DIFF
--- a/lego/apps/articles/models.py
+++ b/lego/apps/articles/models.py
@@ -15,6 +15,13 @@ class Article(Content, BasisModel, ObjectPermissionsModel):
         max_length=200, default="", validators=[youtube_validator], blank=True
     )
 
+    def save(self, *args, **kwargs):
+        if self.pinned:
+            for pinned_item in Article.objects.filter(pinned=True).exclude(pk=self.pk):
+                pinned_item.pinned = False
+                pinned_item.save()
+        super().save(*args, **kwargs)
+
     class Meta:
         abstract = False
 

--- a/lego/apps/events/models.py
+++ b/lego/apps/events/models.py
@@ -113,7 +113,12 @@ class Event(Content, BasisModel, ObjectPermissionsModel):
             for pool in self.pools.select_for_update().all():
                 pool.counter = pool.registrations.count()
                 pool.save(update_fields=["counter"])
-            return super().save(*args, **kwargs)
+            super().save(*args, **kwargs)
+
+        if self.pinned:
+            for pinned_item in Event.objects.filter(pinned=True).exclude(pk=self.pk):
+                pinned_item.pinned = False
+                pinned_item.save()
 
     def user_should_see_regs(self, user):
         return (

--- a/lego/apps/events/tests/test_events_api.py
+++ b/lego/apps/events/tests/test_events_api.py
@@ -681,6 +681,13 @@ class CreateEventsTestCase(BaseAPITestCase):
         event = Event.objects.get(id=self.event_id)
         self.assertEqual(0, event.can_view_groups.count())
 
+    def test_event_pinned_only_one(self):
+        """Test that there is only one pinned event at a time"""
+        self.client.patch(_get_detail_url(self.event_id), {"pinned": True})
+        event = Event.objects.get(id=self.event_id)
+        self.assertTrue(event.pinned)
+        self.assertEqual(Event.objects.filter(pinned=True).count(), 1)
+
     def test_event_update_with_pool_creation(self):
         """Test updating event attributes and add a pool"""
         expect_event = _test_event_data[1]


### PR DESCRIPTION
This commit will set `pinned=False` for all other objects when setting
it to true for an object. For both events and articles.

Fixes https://github.com/webkom/lego/issues/1710
