### PR TITLE
Revert "Bump flower from 0.9.7 to 1.0.0"

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,4 +1,4 @@
 -r base.txt
 
 uwsgi
-flower==1.0.0
+flower==0.9.7


### PR DESCRIPTION
Reverts webkom/lego#2411

Flower 1.0.0 depends on celery >= 5.0.5. We have 4.4.2