### PR TITLE
Use first name instead of full name on all mails

### DIFF
--- a/lego/apps/comments/notifications.py
+++ b/lego/apps/comments/notifications.py
@@ -16,7 +16,7 @@ class CommentNotification(Notification):
         return self._delay_mail(
             to_email=self.user.email,
             context={
-                "name": self.user.full_name,
+                "first_name": self.user.first_name,
                 "target": target_string,
                 "author_name": author.full_name,
                 "text": text,
@@ -42,7 +42,7 @@ class CommentReplyNotification(Notification):
         return self._delay_mail(
             to_email=self.user.email,
             context={
-                "name": self.user.full_name,
+                "first_name": self.user.first_name,
                 "target": target_string,
                 "author_name": author.full_name,
                 "text": text,

--- a/lego/apps/comments/templates/comments/email/comment.html
+++ b/lego/apps/comments/templates/comments/email/comment.html
@@ -14,7 +14,7 @@
 
     <tr>
         <td class="content-block">
-            Hei, {{ name }}!
+            Hei, {{ first_name }}!
         </td>
     </tr>
 

--- a/lego/apps/comments/templates/comments/email/comment.txt
+++ b/lego/apps/comments/templates/comments/email/comment.txt
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-Hei, {{ name }}!
+Hei, {{ first_name }}!
 
 {{ author_name }} har kommentert på {{ target }}:
 

--- a/lego/apps/comments/templates/comments/email/comment_reply.html
+++ b/lego/apps/comments/templates/comments/email/comment_reply.html
@@ -14,7 +14,7 @@
 
     <tr>
         <td class="content-block">
-            Hei, {{ name }}!
+            Hei, {{ first_name }}!
         </td>
     </tr>
 

--- a/lego/apps/comments/templates/comments/email/comment_reply.txt
+++ b/lego/apps/comments/templates/comments/email/comment_reply.txt
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-Hei, {{ name }}!
+Hei, {{ first_name }}!
 
 {{ author_name }} har svart på din kommentar på {{ target }}:
 

--- a/lego/apps/comments/tests/test_notifications.py
+++ b/lego/apps/comments/tests/test_notifications.py
@@ -57,9 +57,7 @@ class CommentNotificationTestCase(BaseTestCase):
         self.assertEmailContains(send_mail_mock, content)
 
     def test_generate_email_name(self, send_mail_mock):
-        opening = (
-            "Hei, " + self.recipient.first_name + " " + self.recipient.last_name + "!"
-        )
+        opening = "Hei, " + self.recipient.first_name + "!"
         self.assertEmailContains(send_mail_mock, opening)
 
     def test_generate_email_url(self, send_mail_mock):
@@ -114,9 +112,7 @@ class CommentReplyNotificationTestCase(BaseTestCase):
         self.assertEmailContains(send_mail_mock, content)
 
     def test_generate_email_name(self, send_mail_mock):
-        opening = (
-            "Hei, " + self.recipient.first_name + " " + self.recipient.last_name + "!"
-        )
+        opening = "Hei, " + self.recipient.first_name + "!"
         self.assertEmailContains(send_mail_mock, opening)
 
     def test_generate_email_url(self, send_mail_mock):

--- a/lego/apps/events/notifications.py
+++ b/lego/apps/events/notifications.py
@@ -21,7 +21,11 @@ class EventBumpNotification(Notification):
 
         return self._delay_mail(
             to_email=self.user.email,
-            context={"event": event.title, "name": self.user.full_name, "id": event.id},
+            context={
+                "event": event.title,
+                "first_name": self.user.first_name,
+                "id": event.id,
+            },
             subject=f"Du er flyttet opp fra ventelisten på arrangementet {event.title}",
             plain_template="events/email/bump.txt",
             html_template="events/email/bump.html",
@@ -54,7 +58,7 @@ class EventPaymentOverdueNotification(Notification):
             to_email=self.user.email,
             context={
                 "event": event.title,
-                "name": self.user.full_name,
+                "first_name": self.user.first_name,
                 "due_date": due_date,
                 "id": event.id,
             },
@@ -86,7 +90,7 @@ class EventPaymentOverdueCreatorNotification(Notification):
             context={
                 "event": event.title,
                 "users": users,
-                "name": self.user.full_name,
+                "first_name": self.user.first_name,
                 "id": event.id,
             },
             subject=f"Følgende registrerte har ikke betalt påmeldingen til arrangementet"
@@ -108,7 +112,7 @@ class EventAdminRegistrationNotification(Notification):
             to_email=self.user.email,
             context={
                 "event": event.title,
-                "name": self.user.full_name,
+                "first_name": self.user.first_name,
                 "reason": reason,
                 "id": event.id,
             },
@@ -142,7 +146,7 @@ class EventAdminUnregistrationNotification(Notification):
                 "event": event.title,
                 "creator_name": creator.full_name,
                 "creator_email": creator.email,
-                "name": self.user.full_name,
+                "first_name": self.user.first_name,
                 "reason": reason,
                 "id": event.id,
             },

--- a/lego/apps/events/templates/events/email/admin_registration.html
+++ b/lego/apps/events/templates/events/email/admin_registration.html
@@ -14,7 +14,7 @@
 
     <tr>
         <td class="content-block">
-            Hei {{ name }}!
+            Hei, {{ first_name }}!
         </td>
     </tr>
 

--- a/lego/apps/events/templates/events/email/admin_registration.txt
+++ b/lego/apps/events/templates/events/email/admin_registration.txt
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-Hei {{ name }}!
+Hei, {{ first_name }}!
 
 En administrator har meldt deg på arrangementet {{ event }} på grunn av:
 

--- a/lego/apps/events/templates/events/email/admin_unregistration.html
+++ b/lego/apps/events/templates/events/email/admin_unregistration.html
@@ -4,7 +4,7 @@
 
     <tr>
         <td class="alert alert-bad">
-            Fjernet fra event
+            Fjernet fra arrangement
         </td>
     </tr>
 
@@ -14,7 +14,7 @@
 
     <tr>
         <td class="content-block">
-            Hei {{ name }}!
+            Hei, {{ first_name }}!
         </td>
     </tr>
 

--- a/lego/apps/events/templates/events/email/admin_unregistration.txt
+++ b/lego/apps/events/templates/events/email/admin_unregistration.txt
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-Hei {{ name }}!
+Hei, {{ first_name }}!
 
 En administrator har fjernet deg fra arrangementet {{ event }} på grunn av:
 

--- a/lego/apps/events/templates/events/email/bump.html
+++ b/lego/apps/events/templates/events/email/bump.html
@@ -14,7 +14,7 @@
 
     <tr>
         <td class="content-block">
-            Hei {{ name }}!
+            Hei, {{ first_name }}!
         </td>
     </tr>
 

--- a/lego/apps/events/templates/events/email/bump.txt
+++ b/lego/apps/events/templates/events/email/bump.txt
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-Hei {{ name }}!
+Hei, {{ first_name }}!
 
 Du har blitt flyttet opp fra ventelisten på arrangementet {{ event }}.
 

--- a/lego/apps/events/templates/events/email/payment_overdue.html
+++ b/lego/apps/events/templates/events/email/payment_overdue.html
@@ -14,7 +14,7 @@
 
     <tr>
         <td class="content-block">
-            Hei {{ name }}!
+            Hei, {{ first_name }}!
         </td>
     </tr>
 

--- a/lego/apps/events/templates/events/email/payment_overdue.txt
+++ b/lego/apps/events/templates/events/email/payment_overdue.txt
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-Hei {{ name }}!
+Hei, {{ first_name }}!
 
 Du har ikke betalt for {{ event }}.
 

--- a/lego/apps/events/templates/events/email/payment_overdue_author.html
+++ b/lego/apps/events/templates/events/email/payment_overdue_author.html
@@ -14,7 +14,7 @@
 
     <tr>
         <td class="content-block">
-            Hei {{ name }}!
+            Hei, {{ first_name }}!
         </td>
     </tr>
 
@@ -39,12 +39,12 @@
             <!--[if mso]>
             <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{ frontend_url }}/events/{{ id }}/administrate" style="height:45px;v-text-anchor:middle;width:155px;" arcsize="15%" strokecolor="#ffffff" fillcolor="#c0392b">
                 <w:anchorlock/>
-                <center style="color:#ffffff;font-family:Helvetica, Arial, sans-serif;font-size:14px;font-weight:regular;">Administrer Arrangement</center>
+                <center style="color:#ffffff;font-family:Helvetica, Arial, sans-serif;font-size:14px;font-weight:regular;">Administrer arrangement</center>
             </v:roundrect>
             <![endif]-->
             <a class="btn-primary" href="{{ frontend_url }}/events/{{ id }}/administrate"
                 style="background-color:#c0392b;border-radius:5px;color:#ffffff;display:inline-block;font-family:'Cabin', Helvetica, Arial, sans-serif;font-size:14px;font-weight:regular;line-height:45px;text-align:center;text-decoration:none;width:155px;-webkit-text-size-adjust:none;mso-hide:all;">
-                Administrer Arrangement
+                Administrer arrangement
             </a>
           </div>
         </td>

--- a/lego/apps/events/templates/events/email/payment_overdue_author.txt
+++ b/lego/apps/events/templates/events/email/payment_overdue_author.txt
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-Hei {{ name }}!
+Hei, {{ first_name }}!
 
 Her er en liste over de som ikke har betalt for {{ event }}:
 

--- a/lego/apps/followers/notifications.py
+++ b/lego/apps/followers/notifications.py
@@ -12,7 +12,7 @@ class RegistrationReminderNotification(Notification):
         return self._delay_mail(
             to_email=self.user.email,
             context={
-                "name": self.user.full_name,
+                "first_name": self.user.first_name,
                 "event": event.title,
                 "event_id": event.id,
             },
@@ -26,6 +26,6 @@ class RegistrationReminderNotification(Notification):
 
         return self._delay_push(
             template="followers/email/reminder.txt",
-            context={"name": self.user.full_name, "event": event.title},
+            context={"first_name": self.user.first_name, "event": event.title},
             instance=event,
         )

--- a/lego/apps/followers/templates/followers/email/reminder.html
+++ b/lego/apps/followers/templates/followers/email/reminder.html
@@ -14,7 +14,7 @@
 
     <tr>
         <td class="content-block">
-            Hei, {{ name }}!
+            Hei, {{ first_name }}!
         </td>
     </tr>
 

--- a/lego/apps/followers/templates/followers/email/reminder.txt
+++ b/lego/apps/followers/templates/followers/email/reminder.txt
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-Hei, {{ name }}!
+Hei, {{ first_name }}!
 
 Nå er det under en time til påmelding til {{ event }} starter.
 

--- a/lego/apps/followers/tests/test_reminder_mail.py
+++ b/lego/apps/followers/tests/test_reminder_mail.py
@@ -41,13 +41,7 @@ class RegistrationReminderTestCase(BaseTestCase):
         self.assertIn(content, email_args["html_message"])
 
     def test_generate_email_name(self, send_mail_mock):
-        opening = (
-            "Hei, "
-            + str(self.recipient.first_name)
-            + " "
-            + self.recipient.last_name
-            + "!"
-        )
+        opening = "Hei, " + self.recipient.first_name + "!"
         self.assertEmailContains(send_mail_mock, opening)
 
     def test_generate_email_event(self, send_mail_mock):

--- a/lego/apps/meetings/notifications.py
+++ b/lego/apps/meetings/notifications.py
@@ -26,7 +26,7 @@ class MeetingInvitationNotification(Notification):
         return self._delay_mail(
             to_email=self.user.email_address,
             context={
-                "name": self.user.full_name,
+                "first_name": self.user.first_name,
                 "owner": meeting.created_by.full_name,
                 "meeting_id": meeting.id,
                 "meeting_title": meeting.title,

--- a/lego/apps/meetings/templates/meetings/email/meeting_invitation.html
+++ b/lego/apps/meetings/templates/meetings/email/meeting_invitation.html
@@ -14,7 +14,7 @@
 
     <tr>
         <td class="content-block">
-            Hei {{ name }}!
+            Hei, {{ first_name }}!
         </td>
     </tr>
 

--- a/lego/apps/meetings/templates/meetings/email/meeting_invitation.txt
+++ b/lego/apps/meetings/templates/meetings/email/meeting_invitation.txt
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-Hei {{ name }}!
+Hei, {{ first_name }}!
 
 {{owner}} inviterte deg til et møte med tittel {{meeting_title}}.
 

--- a/lego/apps/meetings/tests/test_notifications.py
+++ b/lego/apps/meetings/tests/test_notifications.py
@@ -40,5 +40,5 @@ class MeetingInvitationNotificationTestCase(BaseTestCase):
         self.assertEmailContains(send_mail_mock, content)
 
     def test_generate_email_name(self, send_mail_mock):
-        opening = "Hei test user1!"
+        opening = "Hei, test!"
         self.assertEmailContains(send_mail_mock, opening)

--- a/lego/apps/notifications/notifications.py
+++ b/lego/apps/notifications/notifications.py
@@ -23,7 +23,7 @@ class AnnouncementNotification(Notification):
         return self._delay_mail(
             to_email=self.user.email_address,
             context={
-                "name": self.user.full_name,
+                "first_name": self.user.first_name,
                 "sender": sender,
                 "message": announcement.message,
             },

--- a/lego/apps/notifications/templates/notifications/email/announcement.html
+++ b/lego/apps/notifications/templates/notifications/email/announcement.html
@@ -4,7 +4,7 @@
 
     <tr>
         <td class="alert alert-info">
-            Viktig melding
+            Viktig melding!
         </td>
     </tr>
 
@@ -14,7 +14,7 @@
 
     <tr>
         <td class="content-block">
-            Hei {{ name }}!
+            Hei, {{ first_name }}!
         </td>
     </tr>
 

--- a/lego/apps/notifications/templates/notifications/email/announcement.txt
+++ b/lego/apps/notifications/templates/notifications/email/announcement.txt
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-Hei {{ name }}!
+Hei, {{ first_name }}!
 
 {{ sender }} sendte deg en viktig melding.
 

--- a/lego/apps/restricted/notifications.py
+++ b/lego/apps/restricted/notifications.py
@@ -9,7 +9,7 @@ class RestrictedMailSentNotification(Notification):
     def generate_mail(self):
         return self._delay_mail(
             to_email=self.user.email,
-            context={"name": self.user.full_name},
+            context={"first_name": self.user.first_name},
             subject="Begrenset epost sendt ut",
             plain_template="restricted/email/process_success.txt",
             html_template="restricted/email/process_success.html",

--- a/lego/apps/restricted/templates/restricted/email/process_success.html
+++ b/lego/apps/restricted/templates/restricted/email/process_success.html
@@ -14,13 +14,13 @@
 
     <tr>
         <td class="content-block">
-            Hei {{ name }}!
+            Hei, {{ first_name }}!
         </td>
     </tr>
 
     <tr>
         <td class="content-block">
-            Begrenset epost er nå sendt ut til alle mottakere.
+            Begrenset e-post er nå sendt ut til alle mottakere.
         </td>
     </tr>
 

--- a/lego/apps/restricted/templates/restricted/email/process_success.txt
+++ b/lego/apps/restricted/templates/restricted/email/process_success.txt
@@ -2,8 +2,8 @@
 
 {% block content %}
 
-Hei {{ name }}!
+Hei, {{ first_name }}!
 
-Begrenset epost er nå sendt ut til alle mottakere.
+Begrenset e-post er nå sendt ut til alle mottakere.
 
 {% endblock %}

--- a/lego/apps/surveys/notifications.py
+++ b/lego/apps/surveys/notifications.py
@@ -12,7 +12,7 @@ class SurveyNotification(Notification):
         return self._delay_mail(
             to_email=self.user.email,
             context={
-                "name": self.user.full_name,
+                "first_name": self.user.first_name,
                 "survey": survey.id,
                 "event": survey.event.title,
                 "active_from": survey.active_from,

--- a/lego/apps/surveys/templates/surveys/email/survey.html
+++ b/lego/apps/surveys/templates/surveys/email/survey.html
@@ -14,7 +14,7 @@
 
     <tr>
         <td class="content-block">
-            Hei, {{ name }}!
+            Hei, {{ first_name }}!
         </td>
     </tr>
 

--- a/lego/apps/surveys/templates/surveys/email/survey.txt
+++ b/lego/apps/surveys/templates/surveys/email/survey.txt
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-Hei, {{ name }}!
+Hei, {{ first_name }}!
 
 Du har en ny undersøkelse å svare på for arrangementet {{ event }}. 
 

--- a/lego/apps/surveys/tests/test_surveys_mail.py
+++ b/lego/apps/surveys/tests/test_surveys_mail.py
@@ -30,9 +30,7 @@ class SurveyMailTestCase(BaseTestCase):
         self.assertIn(content, email_args["html_message"])
 
     def test_generate_email_name(self, send_mail_mock):
-        opening = (
-            "Hei, " + self.recipient.first_name + " " + self.recipient.last_name + "!"
-        )
+        opening = "Hei, " + self.recipient.first_name + "!"
         self.assertEmailContains(send_mail_mock, opening)
 
     def test_generate_email_event(self, send_mail_mock):

--- a/lego/apps/users/fixtures/test_abakus_groups.py
+++ b/lego/apps/users/fixtures/test_abakus_groups.py
@@ -195,7 +195,7 @@ test_tree = {
                             "permissions": [],
                             "description": "Interessegruppe for abaGolf",
                             "text": "Hei, er du en person som liker å klaske baller på grønne "
-                            "baner?Da er Abakus golf gruppa for deg.\nVi tenker at dette vil "
+                            "baner? Da er Abakus golf gruppa for deg.\nVi tenker at dette vil "
                             "være en portal for oss som ønsker åkomme oss ut på banene med "
                             "noen hyggelige folk fra Abakus.\nDet vil også bli blestet om "
                             "eventuelleturnerninger som måtte dukke opp.\nSamt vil det være "

--- a/lego/apps/users/fixtures/test_abakus_groups.yaml
+++ b/lego/apps/users/fixtures/test_abakus_groups.yaml
@@ -451,7 +451,7 @@
     parent: 14
     logo: null
     type: interesse
-    text: "Hei, er du en person som liker \xE5 klaske baller p\xE5 gr\xF8nne baner?Da
+    text: "Hei, er du en person som liker \xE5 klaske baller p\xE5 gr\xF8nne baner? Da
       er Abakus golf gruppa for deg.\nVi tenker at dette vil v\xE6re en portal for
       oss som \xF8nsker \xE5komme oss ut p\xE5 banene med noen hyggelige folk fra
       Abakus.\nDet vil ogs\xE5 bli blestet om eventuelleturnerninger som m\xE5tte

--- a/lego/apps/users/notifications.py
+++ b/lego/apps/users/notifications.py
@@ -12,7 +12,7 @@ class PenaltyNotification(Notification):
         return self._delay_mail(
             to_email=self.user.email,
             context={
-                "name": self.user.full_name,
+                "first_name": self.user.first_name,
                 "weight": penalty.weight,
                 "event": penalty.source_event.title,
                 "reason": penalty.reason,

--- a/lego/apps/users/templates/users/email/penalty.html
+++ b/lego/apps/users/templates/users/email/penalty.html
@@ -14,7 +14,7 @@
 
     <tr>
         <td class="content-block">
-            Hei {{ name }}!
+            Hei, {{ first_name }}!
         </td>
     </tr>
 

--- a/lego/apps/users/templates/users/email/penalty.txt
+++ b/lego/apps/users/templates/users/email/penalty.txt
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-Hei {{ name }}!
+Hei, {{ first_name }}!
 
 Du har fått en prikk med vekt {{ weight }} fra {{ event }} på grunn av:
 

--- a/lego/apps/users/templates/users/email/registration.html
+++ b/lego/apps/users/templates/users/email/registration.html
@@ -14,7 +14,7 @@
 
     <tr>
         <td class="content-block">
-            Hei,
+            Hei!
         </td>
     </tr>
 
@@ -45,7 +45,7 @@
     <tr>
         <td class="content-block">
             <p>
-                Staret ikke du registreringen? Ignorer denne mailen, du kan eventuelt ta kontakt
+                Staret ikke du registreringen? Ignorer denne mailen. Du kan eventuelt ta kontakt
                 med {{ owner }} om du har spørsmål ({{ contact_email }}).
             </p>
         </td>

--- a/lego/apps/users/templates/users/email/registration.txt
+++ b/lego/apps/users/templates/users/email/registration.txt
@@ -2,14 +2,14 @@
 
 {% block content %}
 
-Hei,
+Hei!
 
 Noen har startet registrering av en ny bruker på Abakus.no.
 For å fullføre registreringen, trykk på lenken under:
 
 {{ frontend_url }}/users/registration/?token={{ token }}
 
-Staret ikke du registreringen? Ignorer denne mailen, du kan eventuelt ta kontakt
+Staret ikke du registreringen? Ignorer denne mailen. Du kan eventuelt ta kontakt
 med {{ owner }} om du har spørsmål ({{ contact_email }}).
 
 {% endblock %}

--- a/lego/apps/users/templates/users/email/reset_password.html
+++ b/lego/apps/users/templates/users/email/reset_password.html
@@ -14,7 +14,7 @@
 
     <tr>
         <td class="content-block">
-            Hei, {{ name }}
+            Hei, {{ first_name }}!
         </td>
     </tr>
 
@@ -44,7 +44,7 @@
     <tr>
         <td class="content-block">
             <p>
-                Ikke du som vil tilbakestille passordet? Ignorer denne mailen, du kan eventuelt ta
+                Ikke du som vil tilbakestille passordet? Ignorer denne mailen. Du kan eventuelt ta
                 kontakt med Webkom om du har spørsmål ({{ contact_email }}).
             </p>
         </td>

--- a/lego/apps/users/templates/users/email/reset_password.txt
+++ b/lego/apps/users/templates/users/email/reset_password.txt
@@ -2,13 +2,13 @@
 
 {% block content %}
 
-Hei, {{ name }}
+Hei, {{ first_name }}!
 
 For å nullstille ditt passord på abakus.no, trykk på lenken under:
 
 {{ frontend_url }}/users/reset-password/?token={{ token }}
 
-Ikke du som vil tilbakestille passordet? Ignorer denne mailen, du kan eventuelt ta
+Ikke du som vil tilbakestille passordet? Ignorer denne mailen. Du kan eventuelt ta
 kontakt med Webkom om du har spørsmål ({{ contact_email }}).
 
 {% endblock %}

--- a/lego/apps/users/templates/users/email/student_confirmation.html
+++ b/lego/apps/users/templates/users/email/student_confirmation.html
@@ -4,7 +4,7 @@
 
     <tr>
         <td class="alert alert-info">
-            Bekreft student kontoen din på Abakus.no
+            Bekreft studentkontoen din på Abakus.no
         </td>
     </tr>
 
@@ -14,13 +14,13 @@
 
     <tr>
         <td class="content-block">
-            Hei {{ first_name }},
+            Hei, {{ first_name }}!
         </td>
     </tr>
 
     <tr>
         <td class="content-block">
-            <p>For å bekrefte NTNU student kontoen din, trykk på knappen under.</p>
+            <p>For å bekrefte NTNU studentkontoen din, trykk på knappen under.</p>
         </td>
     </tr>
 
@@ -30,12 +30,12 @@
             <!--[if mso]>
             <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{ frontend_url }}/users/me/settings/student-confirmation/?token={{ token }}" style="height:45px;v-text-anchor:middle;width:155px;" arcsize="15%" strokecolor="#ffffff" fillcolor="#c0392b">
                 <w:anchorlock/>
-                <center style="color:#ffffff;font-family:Helvetica, Arial, sans-serif;font-size:14px;font-weight:regular;">Bekreft student konto</center>
+                <center style="color:#ffffff;font-family:Helvetica, Arial, sans-serif;font-size:14px;font-weight:regular;">Bekreft studentkonto</center>
             </v:roundrect>
             <![endif]-->
             <a class="btn-primary" href="{{ frontend_url }}/users/me/settings/student-confirmation/?token={{ token }}"
                 style="background-color:#c0392b;border-radius:5px;color:#ffffff;display:inline-block;font-family:'Cabin', Helvetica, Arial, sans-serif;font-size:14px;font-weight:regular;line-height:45px;text-align:center;text-decoration:none;width:155px;-webkit-text-size-adjust:none;mso-hide:all;">
-                Bekreft student konto
+                Bekreft studentkonto
             </a>
           </div>
         </td>

--- a/lego/apps/users/templates/users/email/student_confirmation.txt
+++ b/lego/apps/users/templates/users/email/student_confirmation.txt
@@ -2,9 +2,9 @@
 
 {% block content %}
 
-Hei {{ first_name }},
+Hei, {{ first_name }}!
 
-For å bekrefte NTNU student kontoen din, trykk på lenken under:
+For å bekrefte NTNU studentkontoen din, trykk på lenken under:
 
 {{ frontend_url }}/users/me/settings/student-confirmation/?token={{ token }}
 


### PR DESCRIPTION
It's been bugging me a lot lately that the mails we send out use people's full names, and not their first. I believe a first name is more personal, and feels less "automated", in an otherwise quite automated mail ... 😄 In addition, my inner ocd kicked in once I realized we were inconsistently utilizing commas and exclamation marks 😢 