### PR TITLE
Add LQ images for progressive image loading

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       MAX_HEIGHT: 800
       QUALITY: 98
       AUTO_WEBP: 'True'
-      ALLOW_UNSAFE_URL: 0
+      ALLOW_UNSAFE_URL: 1
       ALLOW_OLD_URLS: 0
       AWS_ACCESS_KEY_ID: 'lego-dev'
       AWS_SECRET_ACCESS_KEY: 'lego-dev'

--- a/lego/apps/articles/serializers.py
+++ b/lego/apps/articles/serializers.py
@@ -17,6 +17,9 @@ class DetailedArticleSerializer(TagSerializerMixin, BasisModelSerializer):
     author = PublicUserSerializer(read_only=True, source="created_by")
     comments = CommentSerializer(read_only=True, many=True)
     cover = ImageField(required=False, options={"height": 500})
+    cover_placeholder = ImageField(
+        source="cover", required=False, options={"height": 50, "filters": ["blur(20)"]}
+    )
     content_target = CharField(read_only=True)
     content = ContentSerializerField(source="text")
     reactions_grouped = serializers.SerializerMethodField()
@@ -31,6 +34,7 @@ class DetailedArticleSerializer(TagSerializerMixin, BasisModelSerializer):
             "id",
             "title",
             "cover",
+            "cover_placeholder",
             "author",
             "description",
             "comments",
@@ -75,6 +79,9 @@ class SearchArticleSerializer(BasisModelSerializer):
 class PublicArticleSerializer(TagSerializerMixin, BasisModelSerializer):
 
     cover = ImageField(required=False, options={"height": 300})
+    cover_placeholder = ImageField(
+        source="cover", required=False, options={"height": 30, "filters": ["blur(20)"]}
+    )
     author = PublicUserSerializer(read_only=True, source="created_by")
 
     class Meta:
@@ -83,6 +90,7 @@ class PublicArticleSerializer(TagSerializerMixin, BasisModelSerializer):
             "id",
             "title",
             "cover",
+            "cover_placeholder",
             "author",
             "description",
             "tags",

--- a/lego/apps/companies/serializers.py
+++ b/lego/apps/companies/serializers.py
@@ -86,6 +86,9 @@ class CompanyFileSerializer(serializers.ModelSerializer):
 
 class CompanyListSerializer(BasisModelSerializer):
     logo = ImageField(required=False, options={"height": 500})
+    logo_placeholder = ImageField(
+        source="logo", required=False, options={"height": 50, "filters": ["blur(20)"]}
+    )
     thumbnail = ImageField(
         source="logo",
         required=False,
@@ -113,6 +116,7 @@ class CompanyListSerializer(BasisModelSerializer):
             "company_type",
             "address",
             "logo",
+            "logo_placeholder",
             "thumbnail",
             "active",
         )
@@ -136,6 +140,9 @@ class CompanyAdminListSerializer(BasisModelSerializer):
 
 class CompanyDetailSerializer(BasisModelSerializer):
     logo = ImageField(required=False, options={"height": 500})
+    logo_placeholder = ImageField(
+        source="logo", required=False, options={"height": 50, "filters": ["blur(20)"]}
+    )
 
     class Meta:
         model = Company
@@ -148,6 +155,7 @@ class CompanyDetailSerializer(BasisModelSerializer):
             "website",
             "address",
             "logo",
+            "logo_placeholder",
         )
 
 

--- a/lego/apps/events/serializers/events.py
+++ b/lego/apps/events/serializers/events.py
@@ -57,6 +57,9 @@ class EventPublicSerializer(BasisModelSerializer):
 class EventReadSerializer(TagSerializerMixin, BasisModelSerializer):
     company = CompanyField(queryset=Company.objects.all())
     cover = ImageField(required=False, options={"height": 500})
+    cover_placeholder = ImageField(
+        source="cover", required=False, options={"height": 50, "filters": ["blur(20)"]}
+    )
     thumbnail = ImageField(
         source="cover",
         required=False,
@@ -72,6 +75,7 @@ class EventReadSerializer(TagSerializerMixin, BasisModelSerializer):
             "title",
             "description",
             "cover",
+            "cover_placeholder",
             "event_type",
             "event_status_type",
             "location",
@@ -93,6 +97,9 @@ class EventReadDetailedSerializer(TagSerializerMixin, BasisModelSerializer):
     comments = CommentSerializer(read_only=True, many=True)
     content_target = CharField(read_only=True)
     cover = ImageField(required=False, options={"height": 500})
+    cover_placeholder = ImageField(
+        source="cover", required=False, options={"height": 50, "filters": ["blur(20)"]}
+    )
     company = CompanyField(queryset=Company.objects.all())
     responsible_group = AbakusGroupField(
         queryset=AbakusGroup.objects.all(), required=False, allow_null=True
@@ -112,6 +119,7 @@ class EventReadDetailedSerializer(TagSerializerMixin, BasisModelSerializer):
             "title",
             "description",
             "cover",
+            "cover_placeholder",
             "text",
             "event_type",
             "event_status_type",
@@ -381,6 +389,9 @@ class EventCreateAndUpdateSerializer(TagSerializerMixin, BasisModelSerializer):
 
 class FrontpageEventSerializer(serializers.ModelSerializer):
     cover = ImageField(required=False, options={"height": 500})
+    cover_placeholder = ImageField(
+        source="cover", required=False, options={"height": 50, "filters": ["blur(20)"]}
+    )
     thumbnail = ImageField(
         source="cover",
         required=False,
@@ -397,6 +408,7 @@ class FrontpageEventSerializer(serializers.ModelSerializer):
             "title",
             "description",
             "cover",
+            "cover_placeholder",
             "text",
             "event_type",
             "event_status_type",

--- a/lego/apps/flatpages/serializers.py
+++ b/lego/apps/flatpages/serializers.py
@@ -16,15 +16,33 @@ class PageListSerializer(BasisModelSerializer):
 class PageDetailSerializer(BasisModelSerializer, ObjectPermissionsSerializerMixin):
     content = ContentSerializerField()
     picture = ImageField(required=False, options={"height": 500})
+    picture_placeholder = ImageField(
+        source="picture",
+        required=False,
+        options={"height": 50, "filters": ["blur(20)"]},
+    )
 
     class Meta:
         model = Page
-        fields = ("pk", "title", "slug", "content", "picture", "category")
+        fields = (
+            "pk",
+            "title",
+            "slug",
+            "content",
+            "picture",
+            "picture_placeholder",
+            "category",
+        )
 
 
 class PageDetailAuthSerializer(BasisModelSerializer, ObjectPermissionsSerializerMixin):
     content = ContentSerializerField()
     picture = ImageField(required=False, options={"height": 500})
+    picture_placeholder = ImageField(
+        source="picture",
+        required=False,
+        options={"height": 50, "filters": ["blur(20)"]},
+    )
 
     class Meta:
         model = Page

--- a/lego/apps/users/serializers/abakus_groups.py
+++ b/lego/apps/users/serializers/abakus_groups.py
@@ -41,6 +41,11 @@ class DetailedAbakusGroupSerializer(serializers.ModelSerializer):
 
 class PublicAbakusGroupSerializer(serializers.ModelSerializer):
     logo = ImageField(required=False, options={"height": 400, "width": 400})
+    logo_placeholder = ImageField(
+        source="logo",
+        required=False,
+        options={"height": 40, "width": 40, "filters": ["blur(20)"]},
+    )
 
     class Meta:
         model = AbakusGroup
@@ -51,6 +56,7 @@ class PublicAbakusGroupSerializer(serializers.ModelSerializer):
             "contact_email",
             "parent",
             "logo",
+            "logo_placeholder",
             "type",
             "show_badge",
             "active",

--- a/lego/apps/users/serializers/users.py
+++ b/lego/apps/users/serializers/users.py
@@ -20,6 +20,11 @@ class DetailedUserSerializer(serializers.ModelSerializer):
     past_memberships = PastMembershipSerializer(many=True)
     penalties = serializers.SerializerMethodField("get_valid_penalties")
     profile_picture = ImageField(required=False, options={"height": 200, "width": 200})
+    profile_picture_placeholder = ImageField(
+        source="profile_picture",
+        required=False,
+        options={"height": 20, "width": 20, "filters": ["blur(20)"]},
+    )
 
     def get_valid_penalties(self, user):
         qs = Penalty.objects.valid().filter(user=user)
@@ -39,6 +44,7 @@ class DetailedUserSerializer(serializers.ModelSerializer):
             "email_address",
             "email_lists_enabled",
             "profile_picture",
+            "profile_picture_placeholder",
             "allergies",
             "is_active",
             "penalties",
@@ -51,6 +57,11 @@ class DetailedUserSerializer(serializers.ModelSerializer):
 class PublicUserSerializer(serializers.ModelSerializer):
 
     profile_picture = ImageField(required=False, options={"height": 200, "width": 200})
+    profile_picture_placeholder = ImageField(
+        source="profile_picture",
+        required=False,
+        options={"height": 20, "width": 20, "filters": ["blur(20)"]},
+    )
 
     class Meta:
         model = User
@@ -62,6 +73,7 @@ class PublicUserSerializer(serializers.ModelSerializer):
             "full_name",
             "gender",
             "profile_picture",
+            "profile_picture_placeholder",
             "internal_email_address",
         )
         read_only_fields = ("username",)
@@ -111,6 +123,11 @@ class AdministrateUserExportSerializer(PublicUserSerializer):
 class SearchUserSerializer(serializers.ModelSerializer):
 
     profile_picture = ImageField(required=False, options={"height": 200, "width": 200})
+    profile_picture_placeholder = ImageField(
+        source="profile_picture",
+        required=False,
+        options={"height": 20, "width": 20, "filters": ["blur(20)"]},
+    )
 
     class Meta:
         model = User
@@ -122,6 +139,7 @@ class SearchUserSerializer(serializers.ModelSerializer):
             "full_name",
             "gender",
             "profile_picture",
+            "profile_picture_placeholder",
         )
 
 
@@ -178,6 +196,11 @@ class MeSerializer(serializers.ModelSerializer):
     profile_picture = ImageField(
         required=False, options={"height": 200, "width": 200}, allow_null=True
     )
+    profile_picture_placeholder = ImageField(
+        source="profile_picture",
+        required=False,
+        options={"height": 20, "width": 20, "filters": ["blur(20)"]},
+    )
     ical_token = serializers.SerializerMethodField("get_user_ical_token")
     penalties = serializers.SerializerMethodField("get_valid_penalties")
     is_student = serializers.SerializerMethodField()
@@ -226,6 +249,7 @@ class MeSerializer(serializers.ModelSerializer):
             "phone_number",
             "email_lists_enabled",
             "profile_picture",
+            "profile_picture_placeholder",
             "gender",
             "allergies",
             "is_active",

--- a/lego/apps/users/tests/test_abakusgroup_api.py
+++ b/lego/apps/users/tests/test_abakusgroup_api.py
@@ -53,9 +53,14 @@ class ListAbakusGroupAPITestCase(BaseAPITestCase):
             fields = list(PublicAbakusGroupSerializer.Meta.fields)
             fields.remove("contact_email")
             fields.remove("show_badge")
+            fields.remove("logo_placeholder")
 
             self.assertEqual(
-                keys, set(fields + ["numberOfUsers", "contactEmail", "showBadge"])
+                keys,
+                set(
+                    fields
+                    + ["numberOfUsers", "contactEmail", "showBadge", "logoPlaceholder"]
+                ),
             )
 
     def test_without_auth(self):


### PR DESCRIPTION
~This field can be used to automatically create a placeholder image beside the full image, that can be used as a placeholder.~

Adds plenty of `*_placeholder` images used for progressive image loading.
