### PR TITLE
Add pending registration to event serializer

### DIFF
--- a/lego/apps/events/fields.py
+++ b/lego/apps/events/fields.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied
 
-from lego.apps.events.models import Event
+from lego.apps.events.models import Event, Registration
 from lego.apps.permissions.constants import EDIT
 
 

--- a/lego/apps/events/serializers/registrations.py
+++ b/lego/apps/events/serializers/registrations.py
@@ -99,6 +99,8 @@ class RegistrationReadSerializer(RegistrationPublicReadSerializer):
             "shared_memberships",
             "presence",
             "photo_consent",
+            "status",
+            "event",
         )
 
 


### PR DESCRIPTION
And add event id to registration create/update serializer.
This allows us to keep track of any registrations currently being worked
on, which is useful when registrations take longer time to process.
