### PR TITLE
Disallow users from approving their own quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If you want to check your test coverage, you can do the following
 
 ```bash
 # Install the packages needed
-$ pip install -r requirments/coverage.txt
+$ pip install -r requirements/coverage.txt
 
 # Run a full test run with coverage. This will run all tests in LEGO.
 $ coverage run --source=lego ./manage.py test

--- a/lego/apps/quotes/tests/test_api_quotes.py
+++ b/lego/apps/quotes/tests/test_api_quotes.py
@@ -88,6 +88,16 @@ class QuoteViewSetTestCase(BaseAPITestCase):
         quote = Quote.objects.get(id=3)
         self.assertTrue(quote.approved)
 
+    def test_approve_permission(self):
+        """Users should not have permission to approve their own quotes"""
+        self.client.force_authenticate(self.authenticated_user)
+        self.client.post(_get_list_url(), self.quote_data)
+        response = self.client.put(_get_approve_url(4))
+        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        quote = Quote.objects.get(id=4)
+        self.assertFalse(quote.approved)
+
     def test_approve_unauthenticated(self):
         """Users with no permissions should not be able to approve quotes"""
         self.client.force_authenticate(self.unauthenticated_user)

--- a/lego/apps/quotes/views.py
+++ b/lego/apps/quotes/views.py
@@ -33,6 +33,8 @@ class QuoteViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
     @action(detail=True, methods=["PUT"])
     def approve(self, *args, **kwargs):
         instance = self.get_object()
+        if instance.created_by == self.request.user:
+            return Response(status=status.HTTP_403_FORBIDDEN)
         instance.approve()
         return Response(status=status.HTTP_200_OK)
 


### PR DESCRIPTION
This was discussed in today's (08.03.2022) meeting. 

This has to be done in the backend, as the creator of quotes shall remain "anonymous" to the client. 
I thought doing the check on `approve` was a better approach than filtering the quotes from the list because one _might_ get confused as to why their quote is not showing up after creating one.