### PR TITLE
Inactive counter is reset on login

### DIFF
--- a/lego/apps/jwt/authentication.py
+++ b/lego/apps/jwt/authentication.py
@@ -18,5 +18,7 @@ class Authentication(JSONWebTokenAuthentication):
             user = authentication[0]
             log.bind(current_user=user.id)
             update_last_login(None, user)
+            user.inactive_notified_counter = 0
+            user.save()
 
         return authentication


### PR DESCRIPTION
The counter is never reset as of now. If a user receives enough mails and logs in again and later is inactive, a mail may not be sent before deletion.  