### PR TITLE
Add icon for interestgroups in frontpageview

### DIFF
--- a/lego/apps/users/views/abakus_groups.py
+++ b/lego/apps/users/views/abakus_groups.py
@@ -1,4 +1,8 @@
-from rest_framework import viewsets
+from random import sample
+
+from rest_framework import status, viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
 
 from lego.apps.permissions.api.views import AllowedPermissionsMixin
 from lego.apps.permissions.constants import EDIT
@@ -43,3 +47,21 @@ class AbakusGroupViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
             return AbakusGroup.objects_with_text.prefetch_related("users").all()
 
         return self.queryset
+
+    @action(detail=False, methods=["GET"])
+    def random_interests(self, request):
+        queryset = self.get_queryset().filter(type="interesse", active=True)
+
+        values = queryset.values_list("pk", flat=True)
+        if not values:
+            return Response(status=status.HTTP_204_NO_CONTENT)
+
+        values = list(values)
+
+        if len(values) > 3:
+            values = sample(values, 3)
+
+        random_qs = queryset.filter(pk__in=values)
+
+        serializer = self.get_serializer(random_qs, many=True)
+        return Response(serializer.data)


### PR DESCRIPTION
The new frontpage (webkom/lego-webapp#2311) shows three randomly selected interestgroups I need them:)

Note: This was the only required change in the backend, which is why I'm adding it straight into production