### PR TITLE
feat: add meeting search index

### DIFF
--- a/lego/apps/meetings/search_indexes.py
+++ b/lego/apps/meetings/search_indexes.py
@@ -1,0 +1,32 @@
+from lego.apps.meetings.models import Meeting
+from lego.apps.meetings.serializers import MeetingSearchSerializer
+from lego.apps.search import register
+from lego.apps.search.index import SearchIndex
+
+
+class MeetingModelIndex(SearchIndex):
+
+    queryset = Meeting.objects.all()
+    serializer_class = MeetingSearchSerializer
+    result_fields = (
+        "title",
+        "description",
+        "report",
+        "start_time",
+    )
+    autocomplete_result_fields = ("title", "start_time")
+
+    autocomplete_fields = ("title", "description")
+    search_fields = ("title", "description", "report")
+
+    def get_autocomplete(self, instance):
+        return instance.title
+
+    def search(self, query):
+        return super().search(query).order_by("-start_time")
+
+    def autocomplete(self, query):
+        return super().autocomplete(query).order_by("-start_time")
+
+
+register(MeetingModelIndex)

--- a/lego/apps/meetings/serializers.py
+++ b/lego/apps/meetings/serializers.py
@@ -107,3 +107,18 @@ class MeetingListSerializer(BasisModelSerializer):
             "report_author",
             "mazemap_poi",
         )
+
+
+class MeetingSearchSerializer(serializers.ModelSerializer):
+    report = ContentSerializerField()
+
+    class Meta:
+        model = Meeting
+        fields = (
+            "id",
+            "title",
+            "description",
+            "report",
+            "start_time",
+        )
+        read_only = True


### PR DESCRIPTION
Add meeting search index for meetings.

This makes it possible to search for meeting titles, meeting descriptions and meeting reports.

Relevant frontend PR: webkom/lego-webapp#2584

