### PR TITLE
Fix bug in restricted notifications

### DIFF
--- a/lego/apps/restricted/notifications.py
+++ b/lego/apps/restricted/notifications.py
@@ -8,7 +8,7 @@ class RestrictedMailSentNotification(Notification):
 
     def generate_mail(self):
         return self._delay_mail(
-            to_email=self.user.email.address,
+            to_email=self.user.email,
             context={"first_name": self.user.first_name},
             subject="Begrenset epost sendt ut",
             plain_template="restricted/email/process_success.txt",


### PR DESCRIPTION
Fix a bug in the notifications for restricted mail, that causes 550 to be returned even though the mails have been delivered successfully. @Arashfa0301 was there a reason you changed this line?