### PR TITLE
Add two year masters option to student confirmation

### DIFF
--- a/lego/apps/users/constants.py
+++ b/lego/apps/users/constants.py
@@ -61,6 +61,9 @@ COURSES_LONG = ((DATA_LONG, DATA_LONG), (KOMTEK_LONG, KOMTEK_LONG))
 FIRST_GRADE_DATA = "1. klasse Datateknologi"
 FIRST_GRADE_KOMTEK = "1. klasse Kommunikasjonsteknologi"
 
+FOURTH_GRADE_DATA = "4. klasse Datateknologi"
+FOURTH_GRADE_KOMTEK = "4. klasse Kommunikasjonsteknologi"
+
 FIRST_GRADES = (
     (FIRST_GRADE_DATA, FIRST_GRADE_DATA),
     (FIRST_GRADE_KOMTEK, FIRST_GRADE_KOMTEK),

--- a/lego/apps/users/registrations.py
+++ b/lego/apps/users/registrations.py
@@ -20,12 +20,15 @@ class Registrations:
             return None
 
     @staticmethod
-    def generate_student_confirmation_token(student_username, course, member):
+    def generate_student_confirmation_token(
+        student_username, course, member, is_two_years
+    ):
         data = signing.dumps(
             {
                 "student_username": student_username.lower(),
                 "course": course,
                 "member": member,
+                "is_two_years": is_two_years,
             }
         )
         token = TimestampSigner().sign(data)

--- a/lego/apps/users/serializers/student_confirmation.py
+++ b/lego/apps/users/serializers/student_confirmation.py
@@ -16,6 +16,7 @@ class StudentConfirmationSerializer(serializers.Serializer):
     captcha_response = serializers.CharField()
 
     course = serializers.ChoiceField(choices=(constants.DATA, constants.KOMTEK))
+    is_two_years = serializers.BooleanField(default=False)
     member = serializers.BooleanField()
 
     def validate_student_username(self, value):

--- a/lego/apps/users/tests/test_models.py
+++ b/lego/apps/users/tests/test_models.py
@@ -196,7 +196,7 @@ class UserTestCase(BaseTestCase):
 
     def test_validate_student_confirmation_token(self):
         student_confirmation_token = Registrations.generate_student_confirmation_token(
-            "teststudentusername", constants.DATA, True
+            "teststudentusername", constants.DATA, True, False
         )
         token = Registrations.validate_student_confirmation_token(
             student_confirmation_token
@@ -206,7 +206,7 @@ class UserTestCase(BaseTestCase):
         self.assertEqual(token["member"], True)
 
         student_confirmation_token = Registrations.generate_student_confirmation_token(
-            "teststudentusername", constants.DATA, True
+            "teststudentusername", constants.DATA, True, False
         )
         token = Registrations.validate_student_confirmation_token(
             student_confirmation_token

--- a/lego/apps/users/views/student_confirmation.py
+++ b/lego/apps/users/views/student_confirmation.py
@@ -54,6 +54,7 @@ class StudentConfirmationRequestViewSet(viewsets.GenericViewSet):
             student_username,
             serializer.validated_data.get("course"),
             serializer.validated_data.get("member"),
+            serializer.validated_data.get("is_two_years"),
         )
 
         send_email.delay(
@@ -93,14 +94,31 @@ class StudentConfirmationPerformViewSet(viewsets.GenericViewSet):
 
         user.student_username = student_confirmation["student_username"]
         course = student_confirmation["course"].lower()
+        is_two_years = student_confirmation["is_two_years"]
 
         if not user.has_grade_group:
             if course == constants.DATA:
-                grade_group = AbakusGroup.objects.get(name=constants.FIRST_GRADE_DATA)
-                grade_group.add_user(user)
+                if is_two_years:
+                    grade_group = AbakusGroup.objects.get(
+                        name=constants.FOURTH_GRADE_DATA
+                    )
+                    grade_group.add_user(user)
+                else:
+                    grade_group = AbakusGroup.objects.get(
+                        name=constants.FIRST_GRADE_DATA
+                    )
+                    grade_group.add_user(user)
             else:
-                grade_group = AbakusGroup.objects.get(name=constants.FIRST_GRADE_KOMTEK)
-                grade_group.add_user(user)
+                if is_two_years:
+                    grade_group = AbakusGroup.objects.get(
+                        name=constants.FOURTH_GRADE_KOMTEK
+                    )
+                    grade_group.add_user(user)
+                else:
+                    grade_group = AbakusGroup.objects.get(
+                        name=constants.FIRST_GRADE_KOMTEK
+                    )
+                    grade_group.add_user(user)
 
         if student_confirmation["member"]:
             member_group = AbakusGroup.objects.get(name=constants.MEMBER_GROUP)


### PR DESCRIPTION
Allows users to select whether they are enrolled in two year masters programme, so they are put in the right grade when registering.