### PR TITLE
Select for update initial registration

### DIFF
--- a/lego/apps/events/views.py
+++ b/lego/apps/events/views.py
@@ -312,11 +312,15 @@ class RegistrationViewSet(
         current_user = request.user
 
         with transaction.atomic():
-            registration = Registration.objects.get_or_create(
+            registration = Registration.objects.select_for_update(
+                of=("self",)
+            ).get_or_create(
                 event_id=event_id,
                 user_id=current_user.id,
                 defaults={"updated_by": current_user, "created_by": current_user},
-            )[0]
+            )[
+                0
+            ]
             feedback = serializer.data.get("feedback", "")
             if registration.event.feedback_required and not feedback:
                 raise ValidationError({"error": "Feedback is required"})


### PR DESCRIPTION
Blind fix with zero testing. 
My _guess_ is that simultaneous registration attempts ends up changing it back from `SUCCESS_REGISTER` to `PENDING_REGISTER`, then becoming `FAILURE_REGISTER`. The create api did not use the select for update lock atleast :)

I slapped on an `of=("self",)` in case it locks the event and user, dont remember if it does that for primary keys – but still ok to explicitly only lock the registration.