### PR TITLE
Retrieve surveys in reverse order

### DIFF
--- a/lego/apps/surveys/views.py
+++ b/lego/apps/surveys/views.py
@@ -35,6 +35,8 @@ class SurveyViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
     filter_class = SurveyFilterSet
     filter_backends = (DjangoFilterBackend,)
 
+    ordering = ("-active_from", "title")
+
     def get_serializer_class(self):
         if self.action in ["create"]:
             return SurveyCreateSerializer


### PR DESCRIPTION
I don't know if you agree that this makes sence, but it's really annoying that i always get the survey from 2018 at the top, and the one from 2022 at the bottom...﻿
