### PR TITLE
Fix ContentField img sanitizer

### DIFF
--- a/lego/apps/content/fields.py
+++ b/lego/apps/content/fields.py
@@ -3,11 +3,14 @@ from django.db.models import TextField
 from rest_framework import serializers
 
 from bs4 import BeautifulSoup
+from structlog import get_logger
 
 from lego.apps.content.utils import sanitize_html
 from lego.apps.files.constants import IMAGE, READY
 from lego.apps.files.models import File
 from lego.apps.files.thumbor import generate_url
+
+log = get_logger()
 
 
 class ContentField(TextField):
@@ -48,8 +51,8 @@ class ContentField(TextField):
             if data_key is not None:
                 images.append(data_key)
             else:
-                raise ValidationError(
-                    "Found img tag without the data-file-key property"
+                log.warn(
+                    f"Found img tag without the data-file-key property in ContentField with value: {value}"
                 )
 
         if images:


### PR DESCRIPTION
In some events the text contains broken images, instead of raising errors and not being able to update the text for the event or remove it, it's better to just log a warning. 

In the front end the broken image is shown like this:
![image](https://user-images.githubusercontent.com/55149662/162642196-9148d7b4-9edb-4961-94be-c4abc56e49a1.png)

