### PR TITLE
fix typo and owner field in registration email template

### DIFF
--- a/lego/apps/users/templates/users/email/registration.html
+++ b/lego/apps/users/templates/users/email/registration.html
@@ -45,8 +45,8 @@
     <tr>
         <td class="content-block">
             <p>
-                Staret ikke du registreringen? Ignorer denne mailen. Du kan eventuelt ta kontakt
-                med {{ owner }} om du har spørsmål ({{ contact_email }}).
+                Startet ikke du registreringen? Ignorer denne mailen. Du kan eventuelt ta kontakt
+                med Webkom om du har spørsmål ({{ contact_email }}).
             </p>
         </td>
     </tr>

--- a/lego/apps/users/templates/users/email/registration.txt
+++ b/lego/apps/users/templates/users/email/registration.txt
@@ -9,7 +9,7 @@ For å fullføre registreringen, trykk på lenken under:
 
 {{ frontend_url }}/users/registration/?token={{ token }}
 
-Staret ikke du registreringen? Ignorer denne mailen. Du kan eventuelt ta kontakt
-med {{ owner }} om du har spørsmål ({{ contact_email }}).
+Startet ikke du registreringen? Ignorer denne mailen. Du kan eventuelt ta kontakt
+med Webkom om du har spørsmål ({{ contact_email }}).
 
 {% endblock %}


### PR DESCRIPTION
### Changes

- fix typo in registration email template
- fix defunct `owner` field in registration email template

On receiving the registration confirmation email, I noticed a typo and a missing word, shown below:
<img width="592" alt="abakus_registraiton_email_screenshot" src="https://user-images.githubusercontent.com/48361621/163842020-0f5fc4d2-332a-4bff-85fc-fdd6e9b79512.png">

The missing word comes from the template [trying to insert an `owner` field](https://github.com/webkom/lego/blob/master/lego/apps/users/templates/users/email/registration.html#L49). The view for the template [does not pass an `owner`](https://github.com/webkom/lego/blob/36a6dc671e14710b69cd011fd37b9c6c2c1859c4/lego/apps/users/views/registration.py#L49), and thus only passes the [default context](https://github.com/webkom/lego/blob/36a6dc671e14710b69cd011fd37b9c6c2c1859c4/lego/utils/email.py#L61). This PR changes the template to use the static "Webkom", which is more in line with other templates, [such as `reset_password`](https://github.com/webkom/lego/blob/master/lego/apps/users/templates/users/email/reset_password.html#L48).
