### PR TITLE
Revert "Update sorting of members in interestgroups to fetch leaders first"

### DIFF
--- a/lego/apps/users/views/memberships.py
+++ b/lego/apps/users/views/memberships.py
@@ -17,7 +17,7 @@ class MembershipViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
         filters.OrderingFilter,
         LegoPermissionFilter,
     )
-    ordering = ["role", "id"]
+    ordering = "id"
 
     def get_queryset(self):
         group = self.kwargs["group_pk"]


### PR DESCRIPTION
This reverts commit 4da1ccb39c965632d265d6a63c3e8565fa83a10f.

Ref. discussion on slack, also see https://github.com/encode/django-rest-framework/discussions/7888 for ref.

Since the role is not very unique, this makes pagination fail since there are too many similar things, and it results in all membership fetching to go in loop since the same cursor is returned every time..