### PR TITLE
Select registrations with user id instead of email

### DIFF
--- a/lego/apps/events/serializers/registrations.py
+++ b/lego/apps/events/serializers/registrations.py
@@ -161,6 +161,7 @@ class RegistrationReadDetailedExportSerializer(RegistrationReadDetailedSerialize
 
 class StripeMetaSerializer(serializers.Serializer):
     EVENT_ID = serializers.IntegerField()
+    USER_ID = serializers.IntegerField()
     USER = serializers.CharField()
     EMAIL = serializers.EmailField()
 

--- a/lego/apps/events/tasks.py
+++ b/lego/apps/events/tasks.py
@@ -395,7 +395,7 @@ def stripe_webhook_event(self, event_id, event_type, logger_context=None):
 
         metadata = serializer.data["metadata"]
         registration = Registration.objects.filter(
-            event_id=metadata["EVENT_ID"], user__email=metadata["EMAIL"]
+            event_id=metadata["EVENT_ID"], user__id=metadata["USER_ID"]
         ).first()
         if not registration:
             log.error("stripe_webhook_error", event_id=event_id, metadata=metadata)
@@ -430,7 +430,7 @@ def stripe_webhook_event(self, event_id, event_type, logger_context=None):
 
         metadata = serializer.data["metadata"]
         registration = Registration.objects.filter(
-            event_id=metadata["EVENT_ID"], user__email=metadata["EMAIL"]
+            event_id=metadata["EVENT_ID"], user__id=metadata["USER_ID"]
         ).first()
         if not registration:
             log.error("stripe_webhook_error", event_id=event_id, metadata=metadata)


### PR DESCRIPTION
Closes #2744

Association was not stable, since users can change their email address. The user id was already stored in the payment metadata.