### PR TITLE
Fix all deprecated stuff

### DIFF
--- a/lego/api/test_urls.py
+++ b/lego/api/test_urls.py
@@ -16,5 +16,5 @@ class VersionRedirectTestCase(BaseTestCase):
 
     def test_default_router_redirect(self):
         response = self.client.get("/api/")
-        self.assertEquals(response.status_code, status.HTTP_302_FOUND)
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
         self.assertIn(settings.API_VERSION, response.url)

--- a/lego/api/tests/test_docs.py
+++ b/lego/api/tests/test_docs.py
@@ -16,9 +16,9 @@ class APIDocsTestCase(BaseTestCase):
 
     def test_get_without_auth(self):
         response = self.client.get("/api-docs/")
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
     def test_get_with_auth(self):
         self.client.force_login(User.objects.get(username="test1"))
         response = self.client.get("/api-docs/")
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)

--- a/lego/apps/articles/views.py
+++ b/lego/apps/articles/views.py
@@ -16,7 +16,7 @@ class ArticlesViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
     queryset = Article.objects.all()
     ordering = "-created_at"
     serializer_class = DetailedArticleSerializer
-    filter_class = ArticleFilterSet
+    filterset_class = ArticleFilterSet
 
     def get_queryset(self):
         queryset = self.queryset.select_related("created_by").prefetch_related("tags")

--- a/lego/apps/companies/views.py
+++ b/lego/apps/companies/views.py
@@ -65,6 +65,9 @@ class CompanyFilesViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
     ordering = "id"
 
     def get_queryset(self):
+        if self.request is None:
+            return CompanyFile.objects.none()
+
         company_id = self.kwargs["company_pk"]
         return CompanyFile.objects.filter(company=company_id)
 
@@ -74,6 +77,9 @@ class SemesterStatusViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
     serializer_class = SemesterStatusDetailSerializer
 
     def get_queryset(self):
+        if self.request is None:
+            return SemesterStatus.objects.none()
+
         company_id = self.kwargs["company_pk"]
         return SemesterStatus.objects.filter(company=company_id)
 
@@ -89,6 +95,9 @@ class CompanyContactViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
     serializer_class = CompanyContactSerializer
 
     def get_queryset(self):
+        if self.request is None:
+            return CompanyContact.objects.none()
+
         company_id = self.kwargs["company_pk"]
         return CompanyContact.objects.filter(company=company_id)
 

--- a/lego/apps/companies/views.py
+++ b/lego/apps/companies/views.py
@@ -94,7 +94,7 @@ class CompanyContactViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
 
 
 class SemesterViewSet(viewsets.ModelViewSet):
-    filter_class = SemesterFilterSet
+    filterset_class = SemesterFilterSet
 
     queryset = Semester.objects.all()
     serializer_class = SemesterSerializer
@@ -108,7 +108,7 @@ class CompanyInterestViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
 
     ordering = "-created_at"
     queryset = CompanyInterest.objects.all()
-    filter_class = CompanyInterestFilterSet
+    filterset_class = CompanyInterestFilterSet
 
     def get_serializer_class(self):
         if self.action == "list":

--- a/lego/apps/contact/tests/test_views.py
+++ b/lego/apps/contact/tests/test_views.py
@@ -32,7 +32,7 @@ class ContactViewSetTestCase(BaseAPITestCase):
                 "recipient_group": None,
             },
         )
-        self.assertEquals(status.HTTP_202_ACCEPTED, response.status_code)
+        self.assertEqual(status.HTTP_202_ACCEPTED, response.status_code)
         mock_verify_captcha.assert_called_once()
 
     @mock.patch("lego.apps.contact.views.send_message")
@@ -48,7 +48,7 @@ class ContactViewSetTestCase(BaseAPITestCase):
                 "recipient_group": None,
             },
         )
-        self.assertEquals(status.HTTP_400_BAD_REQUEST, response.status_code)
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
     @mock.patch("lego.apps.contact.views.send_message")
     @mock.patch("lego.apps.contact.serializers.verify_captcha", return_value=True)
@@ -64,7 +64,7 @@ class ContactViewSetTestCase(BaseAPITestCase):
                 "recipient_group": None,
             },
         )
-        self.assertEquals(status.HTTP_202_ACCEPTED, response.status_code)
+        self.assertEqual(status.HTTP_202_ACCEPTED, response.status_code)
         mock_verify_captcha.assert_called_once()
         mock_send_message.assert_called_once_with(
             "title", "message", self.user, True, None
@@ -84,7 +84,7 @@ class ContactViewSetTestCase(BaseAPITestCase):
                 "recipient_group": None,
             },
         )
-        self.assertEquals(status.HTTP_400_BAD_REQUEST, response.status_code)
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
         mock_verify_captcha.assert_called_once()
 
     @mock.patch("lego.apps.contact.views.send_message")
@@ -105,7 +105,7 @@ class ContactViewSetTestCase(BaseAPITestCase):
                 "recipient_group": webkom_id,
             },
         )
-        self.assertEquals(status.HTTP_202_ACCEPTED, response.status_code)
+        self.assertEqual(status.HTTP_202_ACCEPTED, response.status_code)
         mock_verify_captcha.assert_called_once()
         mock_send_message.assert_called_once_with(
             "title", "message", self.user, True, webkom

--- a/lego/apps/email/tests/test_views.py
+++ b/lego/apps/email/tests/test_views.py
@@ -146,14 +146,14 @@ class EmailListTestCase(BaseAPITestCase):
     def test_change_assigned_email(self):
         """It is'nt possible to change the email after the list is created"""
         response = self.client.patch(f"{self.url}1/", {"email": "changed"})
-        self.assertEquals(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
 
-        self.assertEquals("address", EmailList.objects.get(id=1).email_id)
+        self.assertEqual("address", EmailList.objects.get(id=1).email_id)
 
     def test_delete_endpoint_not_available(self):
         """The delete endpoint is'nt available."""
         response = self.client.delete(f"{self.url}1/")
-        self.assertEquals(status.HTTP_403_FORBIDDEN, response.status_code)
+        self.assertEqual(status.HTTP_403_FORBIDDEN, response.status_code)
 
 
 class UserEmailTestCase(BaseAPITestCase):
@@ -188,14 +188,14 @@ class UserEmailTestCase(BaseAPITestCase):
     def test_set_email(self):
         """It is possible to change from no email to one nobody has used"""
         response = self.client.patch(f"{self.url}2/", {"internalEmail": "testgroup"})
-        self.assertEquals(status.HTTP_404_NOT_FOUND, response.status_code)
+        self.assertEqual(status.HTTP_404_NOT_FOUND, response.status_code)
 
     def test_set_email_to_none(self):
         """It is not possible to set the email back to none"""
         User.objects.filter(id=1).update(internal_email="noassigned")
 
         response = self.client.patch(f"{self.url}1/", {"internalEmail": None})
-        self.assertEquals(status.HTTP_400_BAD_REQUEST, response.status_code)
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
     def test_set_email_to_new(self):
         """
@@ -204,12 +204,12 @@ class UserEmailTestCase(BaseAPITestCase):
         User.objects.filter(id=1).update(internal_email="noassigned")
 
         response = self.client.patch(f"{self.url}1/", {"internalEmail": "unused"})
-        self.assertEquals(status.HTTP_400_BAD_REQUEST, response.status_code)
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
     def test_set_email_to_an_assigned(self):
         """It is not possible to use an email used by another instance"""
         response = self.client.patch(f"{self.url}1/", {"internalEmail": "address"})
-        self.assertEquals(status.HTTP_400_BAD_REQUEST, response.status_code)
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
     def test_set_address_on_new_user(self):
         """Set an address on a user that has no address assigned"""
@@ -217,7 +217,7 @@ class UserEmailTestCase(BaseAPITestCase):
             self.url,
             {"user": 2, "internalEmail": "test2", "internalEmailEnabled": True},
         )
-        self.assertEquals(status.HTTP_201_CREATED, response.status_code)
+        self.assertEqual(status.HTTP_201_CREATED, response.status_code)
 
     def test_set_address_on_capitalized_internal_email(self):
         """Set an address that is capitalized to make sure it is lowercased in input sanitation"""
@@ -225,9 +225,9 @@ class UserEmailTestCase(BaseAPITestCase):
             self.url,
             {"user": 2, "internalEmail": "TestEmail123", "internalEmailEnabled": True},
         )
-        self.assertEquals(status.HTTP_201_CREATED, response.status_code)
-        self.assertEquals("testemail123", response.json()["internalEmail"])
-        self.assertEquals("testemail123", User.objects.get(pk=2).internal_email.email)
+        self.assertEqual(status.HTTP_201_CREATED, response.status_code)
+        self.assertEqual("testemail123", response.json()["internalEmail"])
+        self.assertEqual("testemail123", User.objects.get(pk=2).internal_email.email)
 
     def test_set_address_to_assigned(self):
         """Not possible to set an assigned email"""
@@ -235,7 +235,7 @@ class UserEmailTestCase(BaseAPITestCase):
             self.url,
             {"user": 2, "internalEmail": "address", "internalEmailEnabled": True},
         )
-        self.assertEquals(status.HTTP_400_BAD_REQUEST, response.status_code)
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
     def test_set_address_on_user_with_address(self):
         """Not possible to post to a user that already have an address"""
@@ -243,4 +243,4 @@ class UserEmailTestCase(BaseAPITestCase):
             self.url,
             {"user": 1, "internalEmail": "unknown", "internalEmailEnabled": True},
         )
-        self.assertEquals(status.HTTP_400_BAD_REQUEST, response.status_code)
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)

--- a/lego/apps/email/views.py
+++ b/lego/apps/email/views.py
@@ -28,7 +28,7 @@ class EmailListViewSet(
 
     queryset = EmailList.objects.all()
     ordering = "id"
-    filter_class = EmailListFilterSet
+    filterset_class = EmailListFilterSet
 
     def get_serializer_class(self):
         if self.action == "create":
@@ -58,7 +58,7 @@ class UserEmailViewSet(
     )
     serializer_class = UserEmailSerializer
     ordering = "id"
-    filter_class = EmailUserFilterSet
+    filterset_class = EmailUserFilterSet
     permission_handler = UserEmailPermissionHandler()
 
     def get_serializer_class(self):

--- a/lego/apps/events/tests/test_event_methods.py
+++ b/lego/apps/events/tests/test_event_methods.py
@@ -324,14 +324,14 @@ class EventMethodTest(BaseTestCase):
             registration = Registration.objects.get_or_create(event=event, user=user)[0]
             event.register(registration)
 
-        self.assertEquals(event.waiting_registrations.count(), 1)
+        self.assertEqual(event.waiting_registrations.count(), 1)
 
         pool.capacity = pool.capacity + 1
         pool.save()
 
         event.bump_on_pool_creation_or_expansion()
 
-        self.assertEquals(event.waiting_registrations.count(), 0)
+        self.assertEqual(event.waiting_registrations.count(), 0)
 
     def test_bump_on_pool_creation(self):
         event = Event.objects.get(title="POOLS_NO_REGISTRATIONS")
@@ -343,7 +343,7 @@ class EventMethodTest(BaseTestCase):
             registration = Registration.objects.get_or_create(event=event, user=user)[0]
             event.register(registration)
 
-        self.assertEquals(event.waiting_registrations.count(), 1)
+        self.assertEqual(event.waiting_registrations.count(), 1)
 
         pool = Pool.objects.create(
             name="Pool1",
@@ -355,7 +355,7 @@ class EventMethodTest(BaseTestCase):
 
         event.bump_on_pool_creation_or_expansion()
 
-        self.assertEquals(event.waiting_registrations.count(), 0)
+        self.assertEqual(event.waiting_registrations.count(), 0)
 
     def test_bump_on_pool_expansion_or_creation_when_no_change(self):
         event = Event.objects.get(title="POOLS_NO_REGISTRATIONS")
@@ -366,11 +366,11 @@ class EventMethodTest(BaseTestCase):
             registration = Registration.objects.get_or_create(event=event, user=user)[0]
             event.register(registration)
 
-        self.assertEquals(event.waiting_registrations.count(), 1)
+        self.assertEqual(event.waiting_registrations.count(), 1)
 
         event.bump_on_pool_creation_or_expansion()
 
-        self.assertEquals(event.waiting_registrations.count(), 1)
+        self.assertEqual(event.waiting_registrations.count(), 1)
 
     def test_bump_on_pool_expansion_or_creation_when_no_change_post_merge(self):
         event = Event.objects.get(title="POOLS_NO_REGISTRATIONS")
@@ -383,10 +383,10 @@ class EventMethodTest(BaseTestCase):
             registration = Registration.objects.get_or_create(event=event, user=user)[0]
             event.register(registration)
 
-        self.assertEquals(event.waiting_registrations.count(), 1)
+        self.assertEqual(event.waiting_registrations.count(), 1)
 
         last_user = users[-1]
         AbakusGroup.objects.get(name="Webkom").add_user(last_user)
         event.bump_on_pool_creation_or_expansion()
 
-        self.assertEquals(event.waiting_registrations.count(), 1)
+        self.assertEqual(event.waiting_registrations.count(), 1)

--- a/lego/apps/events/tests/test_events_api.py
+++ b/lego/apps/events/tests/test_events_api.py
@@ -1806,7 +1806,7 @@ class CapacityExpansionTestCase(BaseAPITestCase):
                 event=self.event, user=user
             )[0]
             self.event.register(registration)
-        self.assertEquals(self.event.waiting_registrations.count(), 1)
+        self.assertEqual(self.event.waiting_registrations.count(), 1)
         self.updated_event = deepcopy(event_data)
         self.updated_event["pools"][0]["id"] = self.event_response.json()["pools"][0][
             "id"
@@ -1816,22 +1816,22 @@ class CapacityExpansionTestCase(BaseAPITestCase):
         self.updated_event["pools"][0]["capacity"] = 11
         response = self.client.put(_get_detail_url(self.event.id), self.updated_event)
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(self.event.waiting_registrations.count(), 0)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(self.event.waiting_registrations.count(), 0)
 
     def test_bump_on_pool_creation(self):
         self.updated_event["pools"].append(_test_pools_data[0])
         response = self.client.put(_get_detail_url(self.event.id), self.updated_event)
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(self.event.waiting_registrations.count(), 0)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(self.event.waiting_registrations.count(), 0)
 
     def test_no_bump_on_reduced_pool_size(self):
         self.updated_event["pools"][0]["capacity"] = 9
         response = self.client.put(_get_detail_url(self.event.id), self.updated_event)
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(self.event.waiting_registrations.count(), 1)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(self.event.waiting_registrations.count(), 1)
 
 
 class RegistrationSearchTestCase(BaseAPITestCase):
@@ -1869,7 +1869,7 @@ class RegistrationSearchTestCase(BaseAPITestCase):
             _get_registration_search_url(self.event.pk),
             {"username": self.users[0].username},
         )
-        self.assertEquals(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertNotEqual(res.json().get("user", None), None)
 
     def test_asd_user(self):
@@ -1878,12 +1878,12 @@ class RegistrationSearchTestCase(BaseAPITestCase):
             _get_registration_search_url(self.event.pk),
             {"username": "asd007 xXx james bond"},
         )
-        self.assertEquals(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_no_username(self):
         self.client.force_authenticate(self.webkom_user)
         res = self.client.post(_get_registration_search_url(self.event.pk), {})
-        self.assertEquals(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_user_not_registered(self):
         self.client.force_authenticate(self.webkom_user)
@@ -1891,7 +1891,7 @@ class RegistrationSearchTestCase(BaseAPITestCase):
             _get_registration_search_url(self.event.pk),
             {"username": self.webkom_user.username},
         )
-        self.assertEquals(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_auth(self):
         self.client.force_authenticate(self.users[0])
@@ -1899,7 +1899,7 @@ class RegistrationSearchTestCase(BaseAPITestCase):
             _get_registration_search_url(self.event.pk),
             {"username": self.users[0].username},
         )
-        self.assertEquals(res.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_double_register(self):
         self.client.force_authenticate(self.webkom_user)
@@ -1911,7 +1911,7 @@ class RegistrationSearchTestCase(BaseAPITestCase):
             _get_registration_search_url(self.event.pk),
             {"username": self.users[0].username},
         )
-        self.assertEquals(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
 
 
 class UpcomingEventsTestCase(BaseAPITestCase):

--- a/lego/apps/events/tests/test_webhooks.py
+++ b/lego/apps/events/tests/test_webhooks.py
@@ -16,7 +16,7 @@ class StripeWebhookTestCase(BaseAPITestCase):
     def test_post_no_signature_header(self):
         """The api returns 403 when no header is provided"""
         response = self.client.post(self.url, {})
-        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @mock.patch(
         "lego.apps.events.webhooks.WebhookSignature.verify_header",
@@ -25,7 +25,7 @@ class StripeWebhookTestCase(BaseAPITestCase):
     def test_signature_verification_fails(self, mock_verify_header):
         """The api returns 403 when an invalid header is provided"""
         response = self.client.post(self.url, {}, HTTP_STRIPE_SIGNATURE="invalid")
-        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         mock_verify_header.assert_called_once_with("{}", "invalid", "test_secret", 300)
 
@@ -40,7 +40,7 @@ class StripeWebhookTestCase(BaseAPITestCase):
         payload = {"id": "id", "type": "charge.refunded"}
 
         response = self.client.post(self.url, payload, HTTP_STRIPE_SIGNATURE="valid")
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         mock_task.assert_called_once_with(event_id="id", event_type="charge.refunded")
         mock_verify_header.assert_called_once_with(
@@ -54,4 +54,4 @@ class StripeWebhookTestCase(BaseAPITestCase):
         payload = {"id": "id", "type": "charge.refunded"}
 
         response = self.client.post(self.url, payload, HTTP_STRIPE_SIGNATURE="valid")
-        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/lego/apps/events/views.py
+++ b/lego/apps/events/views.py
@@ -80,6 +80,9 @@ class EventViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
     permission_classes = [EventTypePermission]
 
     def get_queryset(self):
+        if self.request is None:
+            return Event.objects.none()
+
         user = self.request.user
         if self.action in ["list", "upcoming", "previous"]:
             queryset = Event.objects.select_related("company",).prefetch_related(

--- a/lego/apps/events/views.py
+++ b/lego/apps/events/views.py
@@ -68,7 +68,7 @@ from lego.utils.functions import verify_captcha
 
 class EventViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
 
-    filter_class = EventsFilterSet
+    filterset_class = EventsFilterSet
     filter_backends = (
         DjangoFilterBackend,
         filters.OrderingFilter,

--- a/lego/apps/feeds/views.py
+++ b/lego/apps/feeds/views.py
@@ -126,6 +126,9 @@ class UserFeedViewSet(FeedViewSet):
     permission_classes = [permissions.IsAuthenticated]
 
     def get_queryset(self):
+        if self.request is None:
+            return UserFeed.objects.none()
+
         user_id = self.kwargs["user_pk"]
         return feed_manager.retrieve_feed(UserFeed, user_id)
 
@@ -138,6 +141,9 @@ class PersonalFeedViewSet(FeedViewSet):
     permission_classes = [permissions.IsAuthenticated]
 
     def get_queryset(self):
+        if self.request is None:
+            return PersonalFeed.objects.none()
+
         return feed_manager.retrieve_feed(PersonalFeed, self.request.user.id)
 
 
@@ -149,4 +155,7 @@ class NotificationsViewSet(FeedMarkerViewSet, FeedViewSet):
     permission_classes = [permissions.IsAuthenticated]
 
     def get_queryset(self):
+        if self.request is None:
+            return NotificationFeed.objects.none()
+
         return feed_manager.retrieve_feed(NotificationFeed, self.request.user.id)

--- a/lego/apps/followers/tests/test_views.py
+++ b/lego/apps/followers/tests/test_views.py
@@ -22,40 +22,40 @@ class FollowEventViewTestCase(BaseAPITestCase):
     def test_list(self):
         """Try to list the follower apis with and without auth."""
         response = self.client.get(self.url)
-        self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
         self.client.force_authenticate(self.user)
         response = self.client.get(self.url)
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_create(self):
         """Try to follow an event, we should always store the follower as request.user"""
         response = self.client.post(self.url, {"target": 1})
-        self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
         self.client.force_authenticate(self.user)
         response = self.client.post(self.url, {"target": 1})
-        self.assertEquals(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         # Always use request.user to set the follower
         response = self.client.post(self.url, {"target": 2, "follower": 2})
-        self.assertEquals(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         result_id = response.json()["id"]
-        self.assertEquals(FollowEvent.objects.get(id=result_id).follower, self.user)
+        self.assertEqual(FollowEvent.objects.get(id=result_id).follower, self.user)
 
     def test_delete(self):
         """Try to delete follow items"""
         response = self.client.delete(f"{self.url}1/")
-        self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
         denied_user = User.objects.get(id=2)
         self.client.force_authenticate(denied_user)
         response = self.client.delete(f"{self.url}1/")
-        self.assertEquals(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
         self.client.force_authenticate(self.user)
         response = self.client.delete(f"{self.url}1/")
-        self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
 
 class FollowUserViewTestCase(BaseAPITestCase):
@@ -69,40 +69,40 @@ class FollowUserViewTestCase(BaseAPITestCase):
     def test_list(self):
         """Try to list the follower apis with and without auth."""
         response = self.client.get(self.url)
-        self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
         self.client.force_authenticate(self.user)
         response = self.client.get(self.url)
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_create(self):
         """Try to follow a user, we should always store the follower as request.user"""
         response = self.client.post(self.url, {"target": 1})
-        self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
         self.client.force_authenticate(self.user)
         response = self.client.post(self.url, {"target": 1})
-        self.assertEquals(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         # Always use request.user to set the follower
         response = self.client.post(self.url, {"target": 2, "follower": 2})
-        self.assertEquals(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         result_id = response.json()["id"]
-        self.assertEquals(FollowUser.objects.get(id=result_id).follower, self.user)
+        self.assertEqual(FollowUser.objects.get(id=result_id).follower, self.user)
 
     def test_delete(self):
         """Try to delete follow items"""
         response = self.client.delete(f"{self.url}1/")
-        self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
         denied_user = User.objects.get(id=2)
         self.client.force_authenticate(denied_user)
         response = self.client.delete(f"{self.url}1/")
-        self.assertEquals(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
         self.client.force_authenticate(self.user)
         response = self.client.delete(f"{self.url}1/")
-        self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
 
 class FollowCompanyViewTestCase(BaseAPITestCase):
@@ -121,37 +121,37 @@ class FollowCompanyViewTestCase(BaseAPITestCase):
     def test_list(self):
         """Try to list the follower apis with and without auth."""
         response = self.client.get(self.url)
-        self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
         self.client.force_authenticate(self.user)
         response = self.client.get(self.url)
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_create(self):
         """Try to follow a user, we should always store the follower as request.user"""
         response = self.client.post(self.url, {"target": 1})
-        self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
         self.client.force_authenticate(self.user)
         response = self.client.post(self.url, {"target": 1})
-        self.assertEquals(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         # Always use request.user to set the follower
         response = self.client.post(self.url, {"target": 2, "follower": 2})
-        self.assertEquals(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         result_id = response.json()["id"]
-        self.assertEquals(FollowCompany.objects.get(id=result_id).follower, self.user)
+        self.assertEqual(FollowCompany.objects.get(id=result_id).follower, self.user)
 
     def test_delete(self):
         """Try to delete follow items"""
         response = self.client.delete(f"{self.url}1/")
-        self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
         denied_user = User.objects.get(id=2)
         self.client.force_authenticate(denied_user)
         response = self.client.delete(f"{self.url}1/")
-        self.assertEquals(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
         self.client.force_authenticate(self.user)
         response = self.client.delete(f"{self.url}1/")
-        self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)

--- a/lego/apps/followers/views.py
+++ b/lego/apps/followers/views.py
@@ -26,16 +26,16 @@ class FollowerBaseViewSet(
 class FollowUserViewSet(FollowerBaseViewSet):
     serializer_class = FollowUserSerializer
     queryset = FollowUser.objects.all().select_related("follower")
-    filter_class = FollowUserFilterSet
+    filterset_class = FollowUserFilterSet
 
 
 class FollowEventViewSet(FollowerBaseViewSet):
     serializer_class = FollowEventSerializer
     queryset = FollowEvent.objects.all().select_related("follower")
-    filter_class = FollowEventFilterSet
+    filterset_class = FollowEventFilterSet
 
 
 class FollowCompanyViewSet(FollowerBaseViewSet):
     serializer_class = FollowCompanySerializer
     queryset = FollowCompany.objects.all().select_related("follower")
-    filter_class = FollowCompanyFilterSet
+    filterset_class = FollowCompanyFilterSet

--- a/lego/apps/followers/views.py
+++ b/lego/apps/followers/views.py
@@ -28,14 +28,29 @@ class FollowUserViewSet(FollowerBaseViewSet):
     queryset = FollowUser.objects.all().select_related("follower")
     filterset_class = FollowUserFilterSet
 
+    def get_queryset(self):
+        if self.request is None:
+            return FollowUser.objects.none()
+        return FollowUser.objects.all().select_related("follower")
+
 
 class FollowEventViewSet(FollowerBaseViewSet):
     serializer_class = FollowEventSerializer
     queryset = FollowEvent.objects.all().select_related("follower")
     filterset_class = FollowEventFilterSet
 
+    def get_queryset(self):
+        if self.request is None:
+            return FollowEvent.objects.none()
+        return FollowEvent.objects.all().select_related("follower")
+
 
 class FollowCompanyViewSet(FollowerBaseViewSet):
     serializer_class = FollowCompanySerializer
     queryset = FollowCompany.objects.all().select_related("follower")
     filterset_class = FollowCompanyFilterSet
+
+    def get_queryset(self):
+        if self.request is None:
+            return FollowCompany.objects.none()
+        return FollowCompany.objects.all().select_related("follower")

--- a/lego/apps/frontpage/tests.py
+++ b/lego/apps/frontpage/tests.py
@@ -25,7 +25,7 @@ class FrontpageAPITestCase(BaseAPITestCase):
     def test_pinned_is_first(self):
         self.client.force_authenticate(self.user)
         res = self.client.get(_get_frontpage())
-        self.assertEquals(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
         events = res.json()["events"]
         self.assertGreater(len(events), 1)
         first = events[0]
@@ -37,7 +37,7 @@ class FrontpageAPITestCase(BaseAPITestCase):
 
     def test_pinned_is_first_not_logged_in(self):
         res = self.client.get(_get_frontpage())
-        self.assertEquals(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
         events = res.json()["events"]
         self.assertGreater(len(events), 1)
         first = events[0]

--- a/lego/apps/gallery/views.py
+++ b/lego/apps/gallery/views.py
@@ -22,7 +22,7 @@ from .serializers import (
 class GalleryViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
 
     queryset = Gallery.objects.all().select_related("event", "cover")
-    filter_class = GalleryFilterSet
+    filterset_class = GalleryFilterSet
     serializer_class = GallerySerializer
     ordering = "-taken_at"
 

--- a/lego/apps/joblistings/views.py
+++ b/lego/apps/joblistings/views.py
@@ -13,7 +13,7 @@ from lego.apps.permissions.api.views import AllowedPermissionsMixin
 
 class JoblistingViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
     pagination_class = None
-    filter_class = JoblistingFilterSet
+    filterset_class = JoblistingFilterSet
     ordering = "-created_at"
 
     def get_serializer_class(self):

--- a/lego/apps/meetings/fixtures/development_meetings.yaml
+++ b/lego/apps/meetings/fixtures/development_meetings.yaml
@@ -3,18 +3,18 @@
   fields:
     title: Webkommøte
     location: Webkomkontoret
-    start_time: '2016-09-30T16:15:00+00:00'
-    end_time: '2016-10-01T02:00:00+00:00'
-    report: '# Plebkomworkshop! Halla damer, dette var et bra event.'
+    start_time: "2016-09-30T16:15:00+00:00"
+    end_time: "2016-10-01T02:00:00+00:00"
+    report: "<h2>Plebkomworkshop!</h2> <p>Halla damer, dette var et bra event.</p>"
     report_author: 1
 - model: meetings.Meeting
   pk: 2
   fields:
     title: Samf
     location: hehe
-    start_time: '2016-10-30T16:15:00+00:00'
-    end_time: '2017-10-01T02:00:00+00:00'
-    report: '# xdddd   hehe hva skjer a  ;)'
+    start_time: "2016-10-30T16:15:00+00:00"
+    end_time: "2017-10-01T02:00:00+00:00"
+    report: "<p>xdddd   hehe hva skjer a  ;)</p>"
     report_author: 1
 
 - model: meetings.MeetingInvitation

--- a/lego/apps/meetings/fixtures/test_meetings.yaml
+++ b/lego/apps/meetings/fixtures/test_meetings.yaml
@@ -3,9 +3,9 @@
   fields:
     title: Bra møte
     location: TBA
-    start_time: '2016-10-01T17:15:00+00:00'
-    end_time: '2016-10-01T18:00:00+00:00'
-    report: '# Fresh\n\n halla hva skjer a?'
+    start_time: "2016-10-01T17:15:00+00:00"
+    end_time: "2016-10-01T18:00:00+00:00"
+    report: "<h2>Fresh</h2> <p>halla hva skjer a?</p>"
     report_author: 1
 
 - model: meetings.Meeting
@@ -13,9 +13,9 @@
   fields:
     title: Genvors
     location: EL5
-    start_time: '2017-02-01T17:15:00+00:00'
-    end_time: '2017-02-01T23:59:00+00:00'
-    report: '#Genvors\n\nVi fikk en fin gjeng til neste HS :)'
+    start_time: "2017-02-01T17:15:00+00:00"
+    end_time: "2017-02-01T23:59:00+00:00"
+    report: "<h2>Genvors</h2> <p>Vi fikk en fin gjeng til neste HS :)</p>"
     report_author: 3
 
 - model: meetings.Meeting
@@ -23,7 +23,7 @@
   fields:
     title: Tomt møte
     location: "null"
-    start_time: '2010-02-01T17:15:00+00:00'
-    end_time: '2011-02-01T23:59:00+00:00'
-    report: 'tomp'
+    start_time: "2010-02-01T17:15:00+00:00"
+    end_time: "2011-02-01T23:59:00+00:00"
+    report: "tomp"
     report_author: 3

--- a/lego/apps/meetings/views.py
+++ b/lego/apps/meetings/views.py
@@ -20,7 +20,7 @@ from lego.apps.permissions.utils import get_permission_handler
 
 class MeetingViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
 
-    filter_class = MeetingFilterSet
+    filterset_class = MeetingFilterSet
     serializer_class = MeetingDetailSerializer
 
     def get_queryset(self):

--- a/lego/apps/meetings/views.py
+++ b/lego/apps/meetings/views.py
@@ -24,6 +24,9 @@ class MeetingViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
     serializer_class = MeetingDetailSerializer
 
     def get_queryset(self):
+        if self.request is None:
+            return Meeting.objects.none()
+
         permission_handler = get_permission_handler(Meeting)
         return permission_handler.filter_queryset(
             self.request.user,
@@ -93,6 +96,9 @@ class MeetingInvitationViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
         return MeetingInvitationSerializer
 
     def get_queryset(self):
+        if self.request is None:
+            return MeetingInvitation.objects.none()
+
         return MeetingInvitation.objects.filter(meeting=self.kwargs["meeting_pk"])
 
 

--- a/lego/apps/notifications/tests/test_models.py
+++ b/lego/apps/notifications/tests/test_models.py
@@ -18,7 +18,7 @@ class NotificationSettingTestCase(BaseTestCase):
         notification_type
         """
         user = User.objects.get(pk=1)
-        self.assertEquals(
+        self.assertEqual(
             NotificationSetting.active_channels(user, constants.WEEKLY_MAIL),
             constants.CHANNELS,
         )
@@ -35,10 +35,10 @@ class NotificationSettingTestCase(BaseTestCase):
         user2 = User.objects.get(pk=2)
         user3 = User.objects.get(pk=3)
 
-        self.assertEquals(
+        self.assertEqual(
             NotificationSetting.active_channels(user2, constants.WEEKLY_MAIL), []
         )
-        self.assertEquals(
+        self.assertEqual(
             NotificationSetting.active_channels(user3, constants.WEEKLY_MAIL), []
         )
 
@@ -46,7 +46,7 @@ class NotificationSettingTestCase(BaseTestCase):
         """enabled=True should return a list with valid channels"""
         user = User.objects.get(pk=4)
 
-        self.assertEquals(
+        self.assertEqual(
             NotificationSetting.active_channels(user, constants.WEEKLY_MAIL),
             [constants.EMAIL],
         )

--- a/lego/apps/notifications/tests/test_views.py
+++ b/lego/apps/notifications/tests/test_views.py
@@ -20,13 +20,13 @@ class NotificationSettingsViewSetTestCase(BaseAPITestCase):
 
     def test_no_auth(self):
         response = self.client.get(self.url)
-        self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
         response = self.client.post(
             self.url,
             {"notificationType": "weekly_mail", "enabled": True, "channels": ["email"]},
         )
-        self.assertEquals(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_list(self):
         self.client.force_authenticate(self.user)
@@ -34,7 +34,7 @@ class NotificationSettingsViewSetTestCase(BaseAPITestCase):
     def test_alternatives(self):
         self.client.force_authenticate(self.user)
         response = self.client.get(f"{self.url}alternatives/")
-        self.assertEquals(
+        self.assertEqual(
             response.json(),
             {
                 "notificationTypes": constants.NOTIFICATION_TYPES,
@@ -48,7 +48,7 @@ class NotificationSettingsViewSetTestCase(BaseAPITestCase):
         response = self.client.post(
             self.url, {"notificationType": "weekly_mail", "enabled": True}
         )
-        self.assertEquals(
+        self.assertEqual(
             response.json(),
             {
                 "notificationType": "weekly_mail",
@@ -65,7 +65,7 @@ class NotificationSettingsViewSetTestCase(BaseAPITestCase):
             self.url, {"notificationType": constants.MEETING_INVITE}
         )
 
-        self.assertEquals(
+        self.assertEqual(
             response.json(),
             {
                 "notificationType": constants.MEETING_INVITE,
@@ -107,7 +107,7 @@ class AnnouncementViewSetTestCase(BaseAPITestCase):
         response = self.client.post(
             self.url, {"message": "test_message", "groups": [2], "events": [1]}
         )
-        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_authorized_create(self):
         """
@@ -120,13 +120,13 @@ class AnnouncementViewSetTestCase(BaseAPITestCase):
             self.url,
             {"message": message, "groups": [2], "events": [1], "fromGroup": 11},
         )
-        self.assertEquals(response.status_code, status.HTTP_201_CREATED)
-        self.assertEquals(response.data["from_group"]["id"], 11)
-        self.assertEquals(response.data["message"], message)
-        self.assertEquals(len(response.data["groups"]), 1)
-        self.assertEquals(response.data["groups"][0]["id"], 2)
-        self.assertEquals(len(response.data["events"]), 1)
-        self.assertEquals(response.data["events"][0]["id"], 1)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["from_group"]["id"], 11)
+        self.assertEqual(response.data["message"], message)
+        self.assertEqual(len(response.data["groups"]), 1)
+        self.assertEqual(response.data["groups"][0]["id"], 2)
+        self.assertEqual(len(response.data["events"]), 1)
+        self.assertEqual(response.data["events"][0]["id"], 1)
 
     def test_authorized_create_from_nonexistent_group(self):
         """
@@ -139,7 +139,7 @@ class AnnouncementViewSetTestCase(BaseAPITestCase):
             self.url,
             {"message": "test_message", "groups": [2], "events": [1], "fromGroup": 29},
         )
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_authorized_create_invalid_recipient_groups(self):
         """
@@ -152,7 +152,7 @@ class AnnouncementViewSetTestCase(BaseAPITestCase):
             self.url,
             {"message": "test_message", "groups": [59], "events": [3], "fromGroup": 11},
         )
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_authorized_patch(self):
         """
@@ -169,7 +169,7 @@ class AnnouncementViewSetTestCase(BaseAPITestCase):
                 "events": [1],
             },
         )
-        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_authorized_list_own(self):
         """
@@ -178,9 +178,9 @@ class AnnouncementViewSetTestCase(BaseAPITestCase):
 
         self.client.force_authenticate(self.authorized_user_2)
         response = self.client.get(self.url)
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data["results"]), 1)
-        self.assertEquals(response.data["results"][0]["id"], 6)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertEqual(response.data["results"][0]["id"], 6)
 
     def test_authorized_detail_not_own(self):
         """
@@ -190,7 +190,7 @@ class AnnouncementViewSetTestCase(BaseAPITestCase):
 
         self.client.force_authenticate(self.authorized_user)
         response = self.client.get(f"{self.url}1/")
-        self.assertEquals(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_authorized_detail_own(self):
         """
@@ -200,7 +200,7 @@ class AnnouncementViewSetTestCase(BaseAPITestCase):
 
         self.client.force_authenticate(self.authorized_user)
         response = self.client.get(f"{self.url}5/")
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_unauthorized_list(self):
         """
@@ -209,7 +209,7 @@ class AnnouncementViewSetTestCase(BaseAPITestCase):
 
         self.client.force_authenticate(self.unauthorized_user)
         response = self.client.get(self.url)
-        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_send_own_announcement_authorized(self):
         """
@@ -218,7 +218,7 @@ class AnnouncementViewSetTestCase(BaseAPITestCase):
 
         self.client.force_authenticate(self.authorized_user)
         response = self.client.post(f"{self.url}{self.unsent_announcement.id}/send/")
-        self.assertEquals(response.status_code, status.HTTP_202_ACCEPTED)
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         self.assertTrue(Announcement.objects.get(pk=self.unsent_announcement.id).sent)
 
     def test_send_not_own_announcement_authorized(self):
@@ -230,7 +230,7 @@ class AnnouncementViewSetTestCase(BaseAPITestCase):
         response = self.client.post(
             f"{self.url}{self.unsent_not_own_announcement.id}/send/"
         )
-        self.assertEquals(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_send_announcement_unauthorized(self):
         """
@@ -239,4 +239,4 @@ class AnnouncementViewSetTestCase(BaseAPITestCase):
 
         self.client.force_authenticate(self.unauthorized_user)
         response = self.client.post(f"{self.url}{self.unsent_announcement.id}/send/")
-        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/lego/apps/notifications/views.py
+++ b/lego/apps/notifications/views.py
@@ -2,7 +2,9 @@ from rest_framework import decorators, exceptions, permissions, status, viewsets
 from rest_framework.response import Response
 
 from push_notifications.api.rest_framework import (
+    APNSDevice,
     APNSDeviceAuthorizedViewSet,
+    GCMDevice,
     GCMDeviceAuthorizedViewSet,
 )
 
@@ -34,6 +36,9 @@ class NotificationSettingsViewSet(
     pagination_class = None
 
     def get_queryset(self):
+        if self.request is None:
+            return NotificationSetting.objects.none()
+
         user = self.request.user
         return NotificationSetting.objects.filter(user=user)
 
@@ -77,10 +82,20 @@ class APNSDeviceViewSet(APNSDeviceAuthorizedViewSet):
 
     ordering = ("date_created",)
 
+    def get_queryset(self):
+        if self.request is None:
+            return APNSDevice.objects.none()
+        return APNSDevice.get_queryset()
+
 
 class GCMDeviceViewSet(GCMDeviceAuthorizedViewSet):
 
     ordering = ("date_created",)
+
+    def get_queryset(self):
+        if self.request is None:
+            return GCMDevice.objects.none()
+        return GCMDevice.get_queryset()
 
 
 class AnnouncementViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
@@ -88,6 +103,9 @@ class AnnouncementViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
     serializer_class = AnnouncementDetailSerializer
 
     def get_queryset(self):
+        if self.request is None:
+            return Announcement.objects.none()
+
         if self.request.user.is_authenticated:
             return Announcement.objects.filter(
                 created_by=self.request.user

--- a/lego/apps/oauth/views.py
+++ b/lego/apps/oauth/views.py
@@ -44,6 +44,9 @@ class AccessTokenViewSet(
     ordering = "id"
 
     def get_queryset(self):
+        if self.request is None:
+            return AccessToken.objects.none()
+
         return AccessToken.objects.filter(user=self.request.user).select_related(
             "application"
         )

--- a/lego/apps/quotes/tests/test_api_quotes.py
+++ b/lego/apps/quotes/tests/test_api_quotes.py
@@ -83,7 +83,7 @@ class QuoteViewSetTestCase(BaseAPITestCase):
         """Users with permissions should be able to approve quotes"""
         self.client.force_authenticate(self.authenticated_user)
         response = self.client.put(_get_approve_url(3))
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         quote = Quote.objects.get(id=3)
         self.assertTrue(quote.approved)
@@ -93,7 +93,7 @@ class QuoteViewSetTestCase(BaseAPITestCase):
         self.client.force_authenticate(self.authenticated_user)
         self.client.post(_get_list_url(), self.quote_data)
         response = self.client.put(_get_approve_url(4))
-        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         quote = Quote.objects.get(id=4)
         self.assertFalse(quote.approved)
@@ -102,7 +102,7 @@ class QuoteViewSetTestCase(BaseAPITestCase):
         """Users with no permissions should not be able to approve quotes"""
         self.client.force_authenticate(self.unauthenticated_user)
         response = self.client.put(_get_approve_url(3))
-        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_list_unapproved_authenticated(self):
         """Users with permissions should be able to see unapproved quotes"""
@@ -118,7 +118,7 @@ class QuoteViewSetTestCase(BaseAPITestCase):
         self.client.force_authenticate(self.unauthenticated_user)
 
         response = self.client.get(_get_list_unapproved_url())
-        self.assertEquals(status.HTTP_403_FORBIDDEN, response.status_code)
+        self.assertEqual(status.HTTP_403_FORBIDDEN, response.status_code)
 
     def test_list_approved_unauthorized(self):
         """Users with regular permissions should be able to see approved quotes"""
@@ -127,7 +127,7 @@ class QuoteViewSetTestCase(BaseAPITestCase):
         self.client.force_authenticate(self.authenticated_user)
 
         response = self.client.get(_get_list_approved_url())
-        self.assertEquals(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertTrue(len(response.json()["results"]) > 0)
 
     def test_list_unapproved_unauthorized(self):
@@ -137,5 +137,5 @@ class QuoteViewSetTestCase(BaseAPITestCase):
         self.client.force_authenticate(self.authenticated_user)
 
         response = self.client.get(_get_list_unapproved_url())
-        self.assertEquals(status.HTTP_200_OK, response.status_code)
-        self.assertEquals(len(response.json()["results"]), 0)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(len(response.json()["results"]), 0)

--- a/lego/apps/quotes/views.py
+++ b/lego/apps/quotes/views.py
@@ -19,6 +19,9 @@ class QuoteViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
     ordering = "-created_at"
 
     def get_queryset(self):
+        if self.request is None:
+            return Quote.objects.none()
+
         access_unapproved = self.request.user.has_perm(EDIT, self.queryset)
 
         if not access_unapproved:

--- a/lego/apps/quotes/views.py
+++ b/lego/apps/quotes/views.py
@@ -15,7 +15,7 @@ from lego.apps.quotes.serializers import QuoteCreateAndUpdateSerializer, QuoteSe
 class QuoteViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
 
     queryset = Quote.objects.all().prefetch_related("tags")
-    filter_class = QuotesFilterSet
+    filterset_class = QuotesFilterSet
     ordering = "-created_at"
 
     def get_queryset(self):

--- a/lego/apps/restricted/tests/test_message.py
+++ b/lego/apps/restricted/tests/test_message.py
@@ -12,14 +12,14 @@ class MessageTestCase(BaseTestCase):
 
     def test_create_message(self):
         """Test message properties"""
-        self.assertEquals(self.message.recipient, "recipient")
-        self.assertEquals(self.message.from_email, "sender")
+        self.assertEqual(self.message.recipient, "recipient")
+        self.assertEqual(self.message.from_email, "sender")
         self.assertIsInstance(self.message.msg, Message)
-        self.assertEquals(self.message.msg["To"], "recipient")
+        self.assertEqual(self.message.msg["To"], "recipient")
 
     def test_recipients(self):
         """The recipient function returns a list with all recipients"""
-        self.assertEquals(self.message.recipients(), ["recipient"])
+        self.assertEqual(self.message.recipients(), ["recipient"])
 
     def test_message(self):
         """

--- a/lego/apps/restricted/tests/test_parser.py
+++ b/lego/apps/restricted/tests/test_parser.py
@@ -19,6 +19,6 @@ class EmailParserTestCase(BaseTestCase):
         message = parser.parse()
 
         self.assertIsInstance(message, Message)
-        self.assertEquals(message.original_size, len(raw_message))
-        self.assertEquals(message["X-MailFrom"], "test@test.com")
-        self.assertEquals(message["To"], "restricted@abakus.no")
+        self.assertEqual(message.original_size, len(raw_message))
+        self.assertEqual(message["X-MailFrom"], "test@test.com")
+        self.assertEqual(message["To"], "restricted@abakus.no")

--- a/lego/apps/restricted/tests/test_processor.py
+++ b/lego/apps/restricted/tests/test_processor.py
@@ -37,7 +37,7 @@ class MessageProcessorTestCase(BaseTestCase):
         Return sender configured in the settings when RESTRICTED_ALLOW_ORIGINAL_SENDER is False
         """
         restricted_mail = RestrictedMail.objects.get(id=1)
-        self.assertEquals(
+        self.assertEqual(
             "restricted@test.com", self.processor.get_sender(restricted_mail)
         )
 
@@ -47,7 +47,7 @@ class MessageProcessorTestCase(BaseTestCase):
     def test_get_sender(self):
         """Return the original sender when the settings allow it"""
         restricted_mail = RestrictedMail.objects.get(id=1)
-        self.assertEquals("test@test.com", self.processor.get_sender(restricted_mail))
+        self.assertEqual("test@test.com", self.processor.get_sender(restricted_mail))
 
     @override_settings(
         RESTRICTED_ALLOW_ORIGINAL_SENDER=True, RESTRICTED_FROM="restricted@test.com"
@@ -58,7 +58,7 @@ class MessageProcessorTestCase(BaseTestCase):
         restricted_mail.hide_sender = True
         restricted_mail.save()
 
-        self.assertEquals(
+        self.assertEqual(
             "restricted@test.com", self.processor.get_sender(restricted_mail)
         )
 
@@ -104,7 +104,7 @@ class MessageProcessorTestCase(BaseTestCase):
         messages = self.processor.send(
             ["test1@test.com", "test2@test.com"], "test@test.com", new_message
         )
-        self.assertEquals(2, messages)
+        self.assertEqual(2, messages)
 
         outbox = mail.outbox
         first_message = outbox[0].message()
@@ -119,4 +119,4 @@ class MessageProcessorTestCase(BaseTestCase):
         processor = MessageProcessor("test-wrong-from-addr@test.com", self.message, {})
         await processor.process_message()
 
-        self.assertEquals(1, len(mail.outbox))
+        self.assertEqual(1, len(mail.outbox))

--- a/lego/apps/restricted/tests/test_utils.py
+++ b/lego/apps/restricted/tests/test_utils.py
@@ -18,9 +18,9 @@ class EmailTokenTestCase(BaseTestCase):
         payloads = len(message.get_payload())
 
         token = get_mail_token(message)
-        self.assertEquals("test_token", token)
+        self.assertEqual("test_token", token)
 
-        self.assertEquals(len(message.get_payload()), payloads - 1)
+        self.assertEqual(len(message.get_payload()), payloads - 1)
 
     def test_parse_message_no_token(self):
         """Parsing a message with no token has no effect, the function returns None"""

--- a/lego/apps/restricted/tests/test_views.py
+++ b/lego/apps/restricted/tests/test_views.py
@@ -25,29 +25,29 @@ class RestrictedViewTestCase(BaseAPITestCase):
         self.client.force_authenticate(self.allowed_user)
 
         response = self.client.get(self.url)
-        self.assertEquals(len(response.json()["results"]), 1)
+        self.assertEqual(len(response.json()["results"]), 1)
 
     def test_list_no_perms(self):
         """A user tries to list with no permissions"""
         self.client.force_authenticate(self.denied_user)
 
         response = self.client.get(self.url)
-        self.assertEquals(status.HTTP_403_FORBIDDEN, response.status_code)
+        self.assertEqual(status.HTTP_403_FORBIDDEN, response.status_code)
 
     def test_get_token_valid_instance(self):
         """Return a token file for a valid instance"""
         token = RestrictedMail.objects.get(id="1").token_query_param()
 
         response = self.client.get(f"{self.url}1/token/?auth={token}")
-        self.assertEquals(status.HTTP_200_OK, response.status_code)
-        self.assertEquals(
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(
             'attachment; filename="token"', response["Content-Disposition"]
         )
 
         content = response.content.decode()
-        self.assertEquals("LEGOTOKENtoken", content)
+        self.assertEqual("LEGOTOKENtoken", content)
 
     def test_get_token_no_auth(self):
         """Return 401 on invalid token"""
         response = self.client.get(f"{self.url}1/token/?auth=invalid")
-        self.assertEquals(status.HTTP_401_UNAUTHORIZED, response.status_code)
+        self.assertEqual(status.HTTP_401_UNAUTHORIZED, response.status_code)

--- a/lego/apps/restricted/views.py
+++ b/lego/apps/restricted/views.py
@@ -24,6 +24,9 @@ class RestrictedMailViewSet(
     filterset_class = RestrictedMailFilterSet
 
     def get_queryset(self):
+        if self.request is None:
+            return RestrictedMail.objects.none()
+
         if self.request.user.is_authenticated:
             queryset = RestrictedMail.objects.filter(created_by=self.request.user)
             if self.action == "retrieve":

--- a/lego/apps/restricted/views.py
+++ b/lego/apps/restricted/views.py
@@ -21,7 +21,7 @@ class RestrictedMailViewSet(
     viewsets.GenericViewSet,
 ):
 
-    filter_class = RestrictedMailFilterSet
+    filterset_class = RestrictedMailFilterSet
 
     def get_queryset(self):
         if self.request.user.is_authenticated:

--- a/lego/apps/surveys/tests/test_submissions_api.py
+++ b/lego/apps/surveys/tests/test_submissions_api.py
@@ -154,13 +154,13 @@ class SubmissionViewSetTestCase(APITestCase):
         """Users who attended the event should not be able to see list view"""
         self.client.force_authenticate(user=self.attended_user)
         response = self.client.get(_get_list_url(1))
-        self.assertEquals(status.HTTP_403_FORBIDDEN, response.status_code)
+        self.assertEqual(status.HTTP_403_FORBIDDEN, response.status_code)
 
     def test_list_regular(self):
         """Regular users should not be able to see submissions list view"""
         self.client.force_authenticate(user=self.regular_user)
         response = self.client.get(_get_list_url(1))
-        self.assertEquals(status.HTTP_403_FORBIDDEN, response.status_code)
+        self.assertEqual(status.HTTP_403_FORBIDDEN, response.status_code)
 
     # Edit
     def test_edit_admin(self):

--- a/lego/apps/surveys/tests/test_surveys_api.py
+++ b/lego/apps/surveys/tests/test_surveys_api.py
@@ -194,13 +194,13 @@ class SurveyViewSetTestCase(APITestCase):
         """Regular users should not be able to see surveys list view"""
         self.client.force_authenticate(user=self.regular_user)
         response = self.client.get(_get_list_url())
-        self.assertEquals(status.HTTP_403_FORBIDDEN, response.status_code)
+        self.assertEqual(status.HTTP_403_FORBIDDEN, response.status_code)
 
     def test_list_attended(self):
         """Users who attended an event should not be able to see surveys list view"""
         self.client.force_authenticate(user=self.attended_user)
         response = self.client.get(_get_list_url())
-        self.assertEquals(status.HTTP_403_FORBIDDEN, response.status_code)
+        self.assertEqual(status.HTTP_403_FORBIDDEN, response.status_code)
 
     # Edit permissions
     def test_edit_admin(self):
@@ -348,7 +348,7 @@ class SurveyViewSetTestCase(APITestCase):
         response = self.client.post(url)
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         self.assertTrue(response.json())
-        self.assertNotEquals(response.json()["token"], None)
+        self.assertNotEqual(response.json()["token"], None)
 
     def test_survey_hiding(self):
         """Test that you can remove a token to unshare an event"""
@@ -360,7 +360,7 @@ class SurveyViewSetTestCase(APITestCase):
         response = self.client.post(_get_detail_url(response.json()["id"]) + "hide/")
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         self.assertTrue(response.json())
-        self.assertEquals(response.json()["token"], None)
+        self.assertEqual(response.json()["token"], None)
 
     def test_survey_export_admin(self):
         """Test that admins can export a survey as csv"""

--- a/lego/apps/surveys/tests/test_templates_api.py
+++ b/lego/apps/surveys/tests/test_templates_api.py
@@ -99,7 +99,7 @@ class SurveyTemplateViewSetTestCase(APITestCase):
         """Regular users should not be able to see templates list view"""
         self.client.force_authenticate(user=self.regular_user)
         response = self.client.get(_get_list_url())
-        self.assertEquals(status.HTTP_403_FORBIDDEN, response.status_code)
+        self.assertEqual(status.HTTP_403_FORBIDDEN, response.status_code)
 
     # Edit permissions
     def test_edit_admin(self):

--- a/lego/apps/surveys/views.py
+++ b/lego/apps/surveys/views.py
@@ -153,6 +153,9 @@ class SubmissionViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
     filter_backends = (DjangoFilterBackend,)
 
     def get_queryset(self):
+        if self.request is None:
+            return Submission.objects.none()
+
         survey_id = self.kwargs["survey_pk"]
         return Submission.objects.filter(survey=survey_id)
 

--- a/lego/apps/surveys/views.py
+++ b/lego/apps/surveys/views.py
@@ -32,7 +32,7 @@ from lego.apps.surveys.serializers import (
 class SurveyViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
     queryset = Survey.objects.all().prefetch_related("questions", "submissions")
     permission_classes = [SurveyPermissions]
-    filter_class = SurveyFilterSet
+    filterset_class = SurveyFilterSet
     filter_backends = (DjangoFilterBackend,)
 
     ordering = ("-active_from", "title")
@@ -148,7 +148,7 @@ class SurveyTemplateViewSet(
 class SubmissionViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
     queryset = Submission.objects.all()
     permission_classes = [SubmissionPermissions]
-    filter_class = SubmissionFilterSet
+    filterset_class = SubmissionFilterSet
     pagination_class = None
     filter_backends = (DjangoFilterBackend,)
 

--- a/lego/apps/tags/tests/test_api.py
+++ b/lego/apps/tags/tests/test_api.py
@@ -21,11 +21,11 @@ class TagsTestCase(BaseAPITestCase):
         del event_data["cover"]
         # Make sure that we're not adding a tag which is there already.
         # The simplest way to do this is to ensure that the event has no tags.
-        self.assertEquals(len(event_data.pop("tags")), 0)
+        self.assertEqual(len(event_data.pop("tags")), 0)
         tag = Tag.objects.first()
         event_data["tags"] = [tag.tag]
         res = self.client.put(event_api._get_detail_url(pk), event_data)
-        self.assertEquals(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertTrue(tag.tag in res.json().pop("tags"))
 
     def test_remove_tag(self):
@@ -37,7 +37,7 @@ class TagsTestCase(BaseAPITestCase):
         removed = tags.pop()
         event_data["tags"] = tags
         res = self.client.put(event_api._get_detail_url(pk), event_data)
-        self.assertEquals(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertFalse(removed in res.json().pop("tags"))
 
     def test_add_duplicate_tag(self):
@@ -50,10 +50,10 @@ class TagsTestCase(BaseAPITestCase):
         event_data["tags"] = tags + tags
         total_tags_before = Tag.objects.count()
         res = self.client.put(event_api._get_detail_url(pk), event_data)
-        self.assertEquals(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
         total_tags_after = Tag.objects.count()
-        self.assertEquals(total_tags_before, total_tags_after)
-        self.assertEquals(res.json()["tags"], tags)
+        self.assertEqual(total_tags_before, total_tags_after)
+        self.assertEqual(res.json()["tags"], tags)
 
     def test_add_new_tag(self):
         pk = 1
@@ -66,7 +66,7 @@ class TagsTestCase(BaseAPITestCase):
 
         event_data["tags"] = [tag]
         res = self.client.put(event_api._get_detail_url(pk), event_data)
-        self.assertEquals(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertTrue(tag in res.json().pop("tags"))
         self.assertIsNotNone(Tag.objects.filter(tag=tag).first())
 
@@ -77,7 +77,7 @@ class TagsTestCase(BaseAPITestCase):
 
         event_data["tags"] = ["invalid tag with space"]
         response = self.client.patch(event_api._get_detail_url(pk), event_data)
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_preserve_tags(self):
         """Preserve tags when no tags is posted"""
@@ -91,11 +91,11 @@ class TagsTestCase(BaseAPITestCase):
         del event_data["cover"]
         del event_data["tags"]
         response = self.client.patch(event_api._get_detail_url(event.pk), event_data)
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
             list(event.tags.values_list("pk", flat=True)), response.json()["tags"]
         )
-        self.assertEquals(len(response.json()["tags"]), 1)
+        self.assertEqual(len(response.json()["tags"]), 1)
 
     def test_clear_tags(self):
         """Clear tags when [] is posted"""
@@ -106,7 +106,7 @@ class TagsTestCase(BaseAPITestCase):
         del event_data["cover"]
         event_data["tags"] = []
         response = self.client.patch(event_api._get_detail_url(event.pk), event_data)
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         event.refresh_from_db()
-        self.assertEquals(list(event.tags.values_list("pk", flat=True)), [])
+        self.assertEqual(list(event.tags.values_list("pk", flat=True)), [])

--- a/lego/apps/users/tests/test_abakusgroup_api.py
+++ b/lego/apps/users/tests/test_abakusgroup_api.py
@@ -260,7 +260,7 @@ class InterestGroupAPITestCase(BaseAPITestCase):
         self.client.force_authenticate(user=self.abakule)
         response = self.client.get(_get_membership_url(self.interest_group.pk))
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_can_join_interest_group(self):
         self.client.force_authenticate(user=self.abakule)
@@ -268,7 +268,7 @@ class InterestGroupAPITestCase(BaseAPITestCase):
             _get_membership_url(self.interest_group.pk),
             {"user": self.abakule.pk, "role": "member"},
         )
-        self.assertEquals(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_can_leave_interest_group(self):
         self.client.force_authenticate(user=self.abakule)
@@ -277,7 +277,7 @@ class InterestGroupAPITestCase(BaseAPITestCase):
             _get_membership_detail_url(self.interest_group.pk, membership.pk)
         )
 
-        self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
     def test_cannot_join_for_another(self):
         self.client.force_authenticate(user=self.abakule)
@@ -285,7 +285,7 @@ class InterestGroupAPITestCase(BaseAPITestCase):
             _get_membership_url(self.interest_group.pk),
             {"user": self.abakommer.pk, "role": "member"},
         )
-        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_cannot_leave_for_another(self):
         self.client.force_authenticate(user=self.abakule)
@@ -293,7 +293,7 @@ class InterestGroupAPITestCase(BaseAPITestCase):
         response = self.client.delete(
             _get_membership_detail_url(self.interest_group.pk, membership.id)
         )
-        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_leader_can_kick(self):
         self.client.force_authenticate(user=self.leader)
@@ -302,7 +302,7 @@ class InterestGroupAPITestCase(BaseAPITestCase):
         response = self.client.delete(
             _get_membership_detail_url(self.interest_group.pk, membership.id)
         )
-        self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
     def test_leader_cannot_join_for_another(self):
         self.client.force_authenticate(user=self.leader)
@@ -310,4 +310,4 @@ class InterestGroupAPITestCase(BaseAPITestCase):
             _get_membership_url(self.interest_group.pk),
             {"user": self.abakommer.pk, "role": "member"},
         )
-        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/lego/apps/users/tests/test_grade_bump.py
+++ b/lego/apps/users/tests/test_grade_bump.py
@@ -58,63 +58,63 @@ class AbakusGroupHierarchyTestCase(BaseTestCase):
         """Data students should be bumped"""
         user = self.user
         self.data_1.add_user(user)
-        self.assertEquals(get_groups(user), [self.data_1])
+        self.assertEqual(get_groups(user), [self.data_1])
 
         bump_users()
         reset_user_bump_date(user)
-        self.assertEquals(get_groups(user), [self.data_2])
+        self.assertEqual(get_groups(user), [self.data_2])
 
         bump_users()
         reset_user_bump_date(user)
-        self.assertEquals(get_groups(user), [self.data_3])
+        self.assertEqual(get_groups(user), [self.data_3])
 
         bump_users()
         reset_user_bump_date(user)
-        self.assertEquals(get_groups(user), [self.data_4])
+        self.assertEqual(get_groups(user), [self.data_4])
 
         bump_users()
         reset_user_bump_date(user)
-        self.assertEquals(get_groups(user), [self.data_5])
+        self.assertEqual(get_groups(user), [self.data_5])
 
         bump_users()
         reset_user_bump_date(user)
-        self.assertEquals(get_groups(user), [])
+        self.assertEqual(get_groups(user), [])
 
     def test_bump_komtek(self):
         """Komtek students should be bumped"""
         user = self.user
         self.komtek_1.add_user(user)
-        self.assertEquals(get_groups(user), [self.komtek_1])
+        self.assertEqual(get_groups(user), [self.komtek_1])
 
         bump_users()
         reset_user_bump_date(user)
-        self.assertEquals(get_groups(user), [self.komtek_2])
+        self.assertEqual(get_groups(user), [self.komtek_2])
 
         bump_users()
         reset_user_bump_date(user)
-        self.assertEquals(get_groups(user), [self.komtek_3])
+        self.assertEqual(get_groups(user), [self.komtek_3])
 
         bump_users()
         reset_user_bump_date(user)
-        self.assertEquals(get_groups(user), [self.komtek_4])
+        self.assertEqual(get_groups(user), [self.komtek_4])
 
         bump_users()
         reset_user_bump_date(user)
-        self.assertEquals(get_groups(user), [self.komtek_5])
+        self.assertEqual(get_groups(user), [self.komtek_5])
 
         bump_users()
         reset_user_bump_date(user)
-        self.assertEquals(get_groups(user), [])
+        self.assertEqual(get_groups(user), [])
 
     def test_multibump_should_not_bump(self):
         """Bumping multiple times should not bump the same user more than once"""
         user = self.user
         self.komtek_1.add_user(user)
-        self.assertEquals(get_groups(user), [self.komtek_1])
+        self.assertEqual(get_groups(user), [self.komtek_1])
         bump_users()
         bump_users()
         bump_users()
-        self.assertEquals(get_groups(user), [self.komtek_2])
+        self.assertEqual(get_groups(user), [self.komtek_2])
 
     def test_bump_after_recent_bump(self):
         """Bumping short after last bump should not bump the same user more than once"""
@@ -123,7 +123,7 @@ class AbakusGroupHierarchyTestCase(BaseTestCase):
         reset_user_bump_date(user, months=2)
         bump_users()
         bump_users()
-        self.assertEquals(get_groups(user), [self.komtek_1])
+        self.assertEqual(get_groups(user), [self.komtek_1])
 
     def test_discover_users_with_two_grades(self):
         """It should exit if a user has two grades"""

--- a/lego/apps/users/tests/test_membership_history.py
+++ b/lego/apps/users/tests/test_membership_history.py
@@ -14,13 +14,13 @@ class MembershipHistoryViewSetTestCase(BaseAPITestCase):
 
     def test_list_without_auth(self):
         response = self.client.get(self.url)
-        self.assertEquals(status.HTTP_401_UNAUTHORIZED, response.status_code)
+        self.assertEqual(status.HTTP_401_UNAUTHORIZED, response.status_code)
 
     def test_list_history_as_admin(self):
         user = User.objects.get(username="test1")
         admin_group = AbakusGroup.objects.get(name="Webkom")
         group = AbakusGroup.objects.get(id=3)
-        self.assertEquals(GROUP_OTHER, group.type)
+        self.assertEqual(GROUP_OTHER, group.type)
 
         admin_group.add_user(user)
         group.add_user(user)
@@ -28,18 +28,18 @@ class MembershipHistoryViewSetTestCase(BaseAPITestCase):
 
         self.client.force_authenticate(user)
         response = self.client.get(self.url)
-        self.assertEquals(status.HTTP_200_OK, response.status_code)
-        self.assertEquals(1, len(response.json()["results"]))
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(1, len(response.json()["results"]))
 
     def test_list_history_as_authenticated(self):
         user = User.objects.get(username="test1")
         group = AbakusGroup.objects.get(id=3)
-        self.assertEquals(GROUP_OTHER, group.type)
+        self.assertEqual(GROUP_OTHER, group.type)
 
         group.add_user(user)
         group.remove_user(user)
 
         self.client.force_authenticate(user)
         response = self.client.get(self.url)
-        self.assertEquals(status.HTTP_200_OK, response.status_code)
-        self.assertEquals(0, len(response.json()["results"]))
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(0, len(response.json()["results"]))

--- a/lego/apps/users/tests/test_password_change.py
+++ b/lego/apps/users/tests/test_password_change.py
@@ -18,7 +18,7 @@ class TestPasswordChange(BaseAPITestCase):
             self.url,
             {"password": "test", "newPassword": "test1", "retypeNewPassword": "test1"},
         )
-        self.assertEquals(status.HTTP_401_UNAUTHORIZED, response.status_code)
+        self.assertEqual(status.HTTP_401_UNAUTHORIZED, response.status_code)
 
     def test_invalid_password(self):
         self.client.force_authenticate(self.user)
@@ -26,7 +26,7 @@ class TestPasswordChange(BaseAPITestCase):
             self.url,
             {"password": "error", "newPassword": "test1", "retypeNewPassword": "test1"},
         )
-        self.assertEquals(status.HTTP_400_BAD_REQUEST, response.status_code)
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
     def test_not_equal_new_passwords(self):
         self.client.force_authenticate(self.user)
@@ -38,14 +38,14 @@ class TestPasswordChange(BaseAPITestCase):
                 "retypeNewPassword": "not_equal_new_password",
             },
         )
-        self.assertEquals(status.HTTP_400_BAD_REQUEST, response.status_code)
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
     def test_new_password_not_valid(self):
         self.client.force_authenticate(self.user)
         response = self.client.post(
             self.url, {"password": "test", "newPassword": "x", "retypeNewPassword": "x"}
         )
-        self.assertEquals(status.HTTP_400_BAD_REQUEST, response.status_code)
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
     def test_new_password_success(self):
         self.client.force_authenticate(self.user)
@@ -57,7 +57,7 @@ class TestPasswordChange(BaseAPITestCase):
                 "retypeNewPassword": "new_secret_password123",
             },
         )
-        self.assertEquals(status.HTTP_204_NO_CONTENT, response.status_code)
+        self.assertEqual(status.HTTP_204_NO_CONTENT, response.status_code)
         self.assertTrue(
             authenticate(username="test1", password="new_secret_password123")
         )

--- a/lego/apps/users/tests/test_users_api.py
+++ b/lego/apps/users/tests/test_users_api.py
@@ -322,7 +322,7 @@ class UpdateUsersAPITestCase(BaseAPITestCase):
             _get_detail_url(self.without_perm.username),
             {"username": "usEradmin_TeSt"},  # Existing username with other casing
         )
-        self.assertEquals(status.HTTP_400_BAD_REQUEST, response.status_code)
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
     def test_update_username_to_self(self):
         """Try to change casing on the current username"""
@@ -331,7 +331,7 @@ class UpdateUsersAPITestCase(BaseAPITestCase):
             _get_detail_url(self.without_perm.username),
             {"username": self.without_perm.username.upper()},
         )
-        self.assertEquals(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
 
     def test_update_abakus_membership(self):
         """Try to change the is_abakus_member"""
@@ -340,15 +340,15 @@ class UpdateUsersAPITestCase(BaseAPITestCase):
         response = self.client.patch(
             _get_detail_url(self.without_perm.username), {"isAbakusMember": True}
         )
-        self.assertEquals(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
         response = self.client.patch(
             _get_detail_url(self.without_perm.username), {"isAbakusMember": False}
         )
-        self.assertEquals(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
         response = self.client.patch(
             _get_detail_url(self.without_perm.username), {"isAbakusMember": True}
         )
-        self.assertEquals(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual(response.json()["isAbakusMember"], True)
 
     def test_update_abakus_membership_when_not_student(self):
@@ -358,7 +358,7 @@ class UpdateUsersAPITestCase(BaseAPITestCase):
         response = self.client.patch(
             _get_detail_url(user.username), {"is_abakus_member": True}
         )
-        self.assertEquals(status.HTTP_400_BAD_REQUEST, response.status_code)
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
     def test_update_not_failing_when_not_student(self):
         """Test the update method not failing when the user is not a student"""
@@ -374,7 +374,7 @@ class UpdateUsersAPITestCase(BaseAPITestCase):
         response = self.client.patch(
             _get_detail_url(user.username), {"profilePicture": None}
         )
-        self.assertEquals(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertTrue(
             response.json()["profilePicture"].endswith(user.get_default_picture())
         )

--- a/lego/apps/users/views/abakus_groups.py
+++ b/lego/apps/users/views/abakus_groups.py
@@ -17,7 +17,7 @@ class AbakusGroupViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
 
     queryset = AbakusGroup.objects.all()
     ordering = "id"
-    filter_class = AbakusGroupFilterSet
+    filterset_class = AbakusGroupFilterSet
     pagination_class = None
 
     def get_serializer_class(self):

--- a/lego/apps/users/views/membership_history.py
+++ b/lego/apps/users/views/membership_history.py
@@ -17,6 +17,9 @@ class MembershipHistoryViewSet(
     ordering = "id"
 
     def get_queryset(self):
+        if self.request is None:
+            return MembershipHistory.objects.none()
+
         queryset = MembershipHistory.objects.filter(
             abakus_group__deleted=False
         ).select_related("user", "abakus_group")

--- a/lego/apps/users/views/membership_history.py
+++ b/lego/apps/users/views/membership_history.py
@@ -13,7 +13,7 @@ class MembershipHistoryViewSet(
 
     permission_classes = (permissions.IsAuthenticated,)
     serializer_class = MembershipHistorySerializer
-    filter_class = MembershipHistoryFilterSet
+    filterset_class = MembershipHistoryFilterSet
     ordering = "id"
 
     def get_queryset(self):

--- a/lego/apps/users/views/memberships.py
+++ b/lego/apps/users/views/memberships.py
@@ -10,7 +10,7 @@ from lego.apps.users.serializers.memberships import MembershipSerializer
 
 class MembershipViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
     serializer_class = MembershipSerializer
-    filter_class = MembershipFilterSet
+    filterset_class = MembershipFilterSet
     ordering_fields = ["id", "role"]
     filter_backends = (
         DjangoFilterBackend,

--- a/lego/apps/users/views/memberships.py
+++ b/lego/apps/users/views/memberships.py
@@ -20,6 +20,9 @@ class MembershipViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
     ordering = "id"
 
     def get_queryset(self):
+        if self.request is None:
+            return Membership.objects.none()
+
         group = self.kwargs["group_pk"]
         descendants = self.request.query_params.get("descendants", None)
         if descendants == "true":

--- a/lego/apps/users/views/penalties.py
+++ b/lego/apps/users/views/penalties.py
@@ -16,4 +16,4 @@ class PenaltyViewSet(
 ):
     queryset = Penalty.objects.all()
     serializer_class = PenaltySerializer
-    filter_class = PenaltyFilterSet
+    filterset_class = PenaltyFilterSet

--- a/lego/apps/users/views/student_confirmation.py
+++ b/lego/apps/users/views/student_confirmation.py
@@ -68,6 +68,9 @@ class StudentConfirmationRequestViewSet(viewsets.GenericViewSet):
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
+    def get_queryset(self):
+        pass
+
 
 class StudentConfirmationPerformViewSet(viewsets.GenericViewSet):
 

--- a/lego/utils/test_utils.py
+++ b/lego/utils/test_utils.py
@@ -1,4 +1,4 @@
-import asyncio
+import functools
 
 from django.test import TestCase
 from django.utils import timezone
@@ -29,10 +29,11 @@ def fake_time(y, m, d):
 
 
 def async_test(f):
-    def wrapper(*args, **kwargs):
-        coro = asyncio.coroutine(f)
-        future = coro(*args, **kwargs)
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(future)
+    def wrapper(f):
+        @functools.wraps(f)
+        async def wrapped(*args, **kwargs):
+            return await f(*args, **kwargs)
+
+        return wrapped
 
     return wrapper

--- a/lego/utils/tests/test_content_types.py
+++ b/lego/utils/tests/test_content_types.py
@@ -18,16 +18,16 @@ class ContentTypesTestCase(BaseTestCase):
         )
 
     def test_split_string(self):
-        self.assertEquals(
+        self.assertEqual(
             content_types.split_string("test.model-1"), ("test.model", "1")
         )
 
-        self.assertEquals(
+        self.assertEqual(
             content_types.split_string("test.model-1-2"), ("test.model", "1-2")
         )
 
     def test_string_to_model_cls(self):
-        self.assertEquals(content_types.string_to_model_cls("users.user"), User)
+        self.assertEqual(content_types.string_to_model_cls("users.user"), User)
 
         self.assertRaises(
             content_types.VALIDATION_EXCEPTIONS,

--- a/lego/utils/tests/test_renderers.py
+++ b/lego/utils/tests/test_renderers.py
@@ -8,4 +8,4 @@ class JSONRendererTestCase(BaseTestCase):
 
     def test_empty_data(self):
         """The renderer should return an empty object when data is None"""
-        self.assertEquals(self.renderer.render(None), b"")
+        self.assertEqual(self.renderer.render(None), b"")

--- a/lego/utils/tests/test_views.py
+++ b/lego/utils/tests/test_views.py
@@ -13,9 +13,9 @@ class SiteMetaViewSetTestCase(BaseAPITestCase):
 
     def test_access_without_auth(self):
         response = self.client.get(self.url)
-        self.assertEquals(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
 
     def test_access_with_user(self):
         self.client.force_authenticate(User.objects.first())
         response = self.client.get(self.url)
-        self.assertEquals(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)


### PR DESCRIPTION
There was a bunch of super annoying deprecated stuff laying around, which would all raise a myriad of warnings when running tests. This fixes all of them:

- [Use assertEqual() instead of assertEquals()](https://github.com/webkom/lego/commit/f154fbbb98c7e22dc70b301ce988a2030b942c9f) 

- [ViewSet.filter_class attribute renamed filterset_class](https://github.com/webkom/lego/commit/b7183be9946ca9910f8fe3bf9ae1d6d5b9b9b766) 
 
- [Resolve incompatible ViewSets](https://github.com/webkom/lego/commit/cfa7b98cc27d82d5e5c2e30a6cc1ad4d433663c1) 

- [Change markup in meeting fixtures to html](https://github.com/webkom/lego/commit/70e3918a64bab138da8bfe4d3205b3b5ee1d1439) 

- [Replace @coroutine decorator with async/await](https://github.com/webkom/lego/commit/043e6c205c113de970e7244ee4537c4e6cd99fe7)

### From this
<p align="center">
  <img src="https://user-images.githubusercontent.com/69514187/181599074-280fc0f1-e982-4012-aa09-ab9b9136121c.png" width="400" />
  <img src="https://user-images.githubusercontent.com/69514187/181599102-d61fce0d-2270-4310-b926-f8f9274a2513.png" width="400" />
</p>


### To this 😍 
The one small error left will be fixed in #2801

![image](https://user-images.githubusercontent.com/69514187/181599055-b170444e-104b-45d0-8637-86db8f83e8e7.png)
