### PR TITLE
Fix method to retrieve jwt token

### DIFF
--- a/lego/apps/websockets/auth.py
+++ b/lego/apps/websockets/auth.py
@@ -9,7 +9,8 @@ from lego.apps.jwt.authentication import Authentication
 
 
 class JWTQSAuthentication(Authentication):
-    def get_jwt_value(self, scope):
+    @classmethod
+    def get_token_from_request(cls, scope):
         if scope.get("type") != "websocket":
             raise exceptions.AuthenticationFailed("Websocket connection i required")
 

--- a/lego/settings/logging.py
+++ b/lego/settings/logging.py
@@ -74,7 +74,7 @@ LOGGING = {
             "handlers": [
                 "console",
             ],
-            "level": "CRITICAL",
+            "level": "INFO",
         },
     },
 }


### PR DESCRIPTION
This fixes the WS issues in prod. Also it enables some logging, since the server was throwing a
bunch of errors and crashing, but the logging config meant none of them got printed anywhere.


We recently upgraded to a fork of the jwt library we are using. This had
changed the method name used for retrieving the jwt token, breaking the
jwt middleware in the websocket server.
