### PR TITLE
Return group type from AbakusGroup field

### DIFF
--- a/lego/apps/events/fixtures/development_events.yaml
+++ b/lego/apps/events/fixtures/development_events.yaml
@@ -1383,6 +1383,7 @@
     cover: test_event_cover.png
     company: 1
     created_by: 3
+    responsible_group: 6
     require_auth: False
   model: events.Event
   pk: 50
@@ -1450,6 +1451,7 @@
     price_guest: 35000
     cover: test_event_cover.png
     created_by: 3
+    responsible_group: 4
     require_auth: False
   model: events.Event
   pk: 54

--- a/lego/apps/users/fields.py
+++ b/lego/apps/users/fields.py
@@ -15,6 +15,7 @@ class AbakusGroupField(serializers.PrimaryKeyRelatedField):
             "id": value.id,
             "name": value.name,
             "contact_email": value.contact_email,
+            "type": value.type,
         }
 
 


### PR DESCRIPTION
Group `type` was "used" by the webapp on its event pages, but was for obvious reasons `undefined`.

![image](https://user-images.githubusercontent.com/69514187/187080166-1fa6a488-d035-4cd9-b371-d41d9f507a3f.png)
