### PR TITLE
Optimize photo_consents queries on administrate endpoint

### DIFF
--- a/lego/apps/events/fields.py
+++ b/lego/apps/events/fields.py
@@ -1,8 +1,9 @@
 from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied
 
-from lego.apps.events.models import Event
+from lego.apps.events.models import Event, Registration
 from lego.apps.permissions.constants import EDIT
+from lego.apps.users.serializers.photo_consents import PhotoConsentSerializer
 
 
 # Personal....Fields for registrations will only return values if the authenticated
@@ -176,6 +177,15 @@ class ConsentField(serializers.ChoiceField):
         ):
             return super().to_internal_value(data)
         raise PermissionDenied()
+
+
+class PhotoConsentField(serializers.Field):
+    def get_attribute(self, instance):
+        return instance
+
+    def to_representation(self, value: Registration):
+        instances = value.user.photo_consents  # type: ignore
+        return PhotoConsentSerializer(instances, many=True).data
 
 
 class PublicEventField(serializers.PrimaryKeyRelatedField):

--- a/lego/apps/events/fixtures/test_events.yaml
+++ b/lego/apps/events/fixtures/test_events.yaml
@@ -59,6 +59,7 @@
     end_time: "2012-09-01T13:20:30+03:00"
     created_by: 1
     require_auth: False
+    use_consent: true
 
 - model: events.Event
   pk: 5

--- a/lego/apps/events/models.py
+++ b/lego/apps/events/models.py
@@ -28,6 +28,7 @@ from lego.apps.events.permissions import (
 from lego.apps.files.models import FileField
 from lego.apps.followers.models import FollowEvent
 from lego.apps.permissions.models import ObjectPermissionsModel
+from lego.apps.users.constants import AUTUMN, SPRING
 from lego.apps.users.models import AbakusGroup, Penalty, User
 from lego.utils.models import BasisModel
 from lego.utils.youtube_validator import youtube_validator
@@ -273,11 +274,7 @@ class Event(Content, BasisModel, ObjectPermissionsModel):
         if self.use_contact_tracing and user.phone_number is None:
             raise NoPhoneNumber()
 
-        from lego.apps.users import constants
-
-        current_semester = (
-            constants.AUTUMN if self.start_time.month > 7 else constants.SPRING
-        )
+        current_semester = AUTUMN if self.start_time.month > 7 else SPRING
         if self.use_consent and not user.has_registered_photo_consents_for_semester(
             self.start_time.year,
             current_semester,

--- a/lego/apps/events/serializers/registrations.py
+++ b/lego/apps/events/serializers/registrations.py
@@ -9,6 +9,7 @@ from lego.apps.events.fields import (
     PersonalFeedbackField,
     PersonalPaymentStatusField,
     PersonalPresenceField,
+    PhotoConsentField,
     PresenceField,
     SetPaymentStatusField,
 )
@@ -128,6 +129,7 @@ class RegistrationPaymentReadSerializer(RegistrationReadSerializer):
 
 class RegistrationReadDetailedSerializer(BasisModelSerializer):
     user = AdministrateUserSerializer()
+    photo_consents = PhotoConsentField()
 
     class Meta:
         model = Registration
@@ -149,6 +151,7 @@ class RegistrationReadDetailedSerializer(BasisModelSerializer):
             "payment_amount",
             "payment_amount_refunded",
             "LEGACY_photo_consent",
+            "photo_consents",
         )
         read_only = True
 

--- a/lego/apps/users/models.py
+++ b/lego/apps/users/models.py
@@ -1,5 +1,5 @@
 import operator
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from django.conf import settings
 from django.contrib.auth.models import (
@@ -554,7 +554,7 @@ class PhotoConsent(BasisModel):
 
     def get_consents(self, user):
         now = timezone.now()
-        current_semester = constants.AUTUMN if now.month > 7 else constants.SPRING
+        current_semester = PhotoConsent.get_semester(now)
         current_year = now.year
 
         PhotoConsent.objects.get_or_create(
@@ -571,3 +571,7 @@ class PhotoConsent(BasisModel):
             domain=constants.WEBSITE_DOMAIN,
         )
         return PhotoConsent.objects.filter(user=user)
+
+    @staticmethod
+    def get_semester(time: datetime):
+        return constants.AUTUMN if time.month > 7 else constants.SPRING

--- a/lego/apps/users/serializers/users.py
+++ b/lego/apps/users/serializers/users.py
@@ -109,14 +109,7 @@ class AdministrateUserSerializer(PublicUserSerializer):
         fields = PublicUserSerializer.Meta.fields + (  # type: ignore
             "abakus_groups",
             "allergies",
-            "photo_consents",
         )
-
-    photo_consents = serializers.SerializerMethodField()
-
-    def get_photo_consents(self, user):
-        pc = PhotoConsent.get_consents(self, user)
-        return PhotoConsentSerializer(instance=pc, many=True).data
 
 
 class AdministrateUserExportSerializer(PublicUserSerializer):


### PR DESCRIPTION
Fixes #2909

The administrate endpoint was super slow, since we did several queries per user registered to the
event. Each user registered would produce 3 extra queries to the DB. So for an event with just 9
registrations, we previously had 75 queries. With this, we are down to 20.

For context, for an event with 100 registered users, this would be ~350 queries.
