### PR TITLE
Configure max pixel count on thumbor images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       SECURITY_KEY: 'lego-dev'
       MAX_WIDTH: 1000
       MAX_HEIGHT: 800
+      MAX_PIXELS: 110_000_000.0
       QUALITY: 98
       AUTO_WEBP: 'True'
       ALLOW_UNSAFE_URL: 1


### PR DESCRIPTION
[Default is 75 million](https://thumbor.readthedocs.io/en/latest/configuration.html), but due to people creating images which exceed this limit, I figured we could up it.

![image](https://user-images.githubusercontent.com/69514187/191980854-c0bf3532-8a2e-4c4d-9756-72802ee80ef9.png)
