### PR TITLE
Add created_after filtering for joblistings

### DIFF
--- a/lego/apps/companies/serializers.py
+++ b/lego/apps/companies/serializers.py
@@ -92,7 +92,12 @@ class CompanyListSerializer(BasisModelSerializer):
     thumbnail = ImageField(
         source="logo",
         required=False,
-        options={"height": 500, "width": 500, "smart": True},
+        options={
+            "fit_in": True,
+            "height": 500,
+            "width": 500,
+            "filters": ["fill(white)"],
+        },
     )
 
     event_count = serializers.SerializerMethodField()

--- a/lego/apps/joblistings/filters.py
+++ b/lego/apps/joblistings/filters.py
@@ -1,9 +1,11 @@
-from django_filters import FilterSet
+from django_filters import DateFilter, FilterSet
 
 from lego.apps.joblistings.models import Joblisting
 
 
 class JoblistingFilterSet(FilterSet):
+    created_after = DateFilter("created_at", lookup_expr="gte")
+
     class Meta:
         model = Joblisting
         fields = ("company",)


### PR DESCRIPTION
Also fixes thumbnails on joblistings to not be cropped. The new
parameters mean that images are filled with white color instead of
cropped in the other direction.


This is needed for the new slack notifications for new joblistings.
