### PR TITLE
Make sure possible_pools are distinct

### DIFF
--- a/lego/apps/events/models.py
+++ b/lego/apps/events/models.py
@@ -226,7 +226,7 @@ class Event(Content, BasisModel, ObjectPermissionsModel):
             is_admitted = self.is_admitted(user)
         if is_admitted:
             return []
-        queryset = all_pools.filter(permission_groups__in=user.all_groups)
+        queryset = all_pools.filter(permission_groups__in=user.all_groups).distinct()
         if future:
             return queryset
         return queryset.filter(activation_date__lte=timezone.now())

--- a/lego/apps/events/views.py
+++ b/lego/apps/events/views.py
@@ -97,7 +97,7 @@ class EventViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
                         "pools",
                         queryset=Pool.objects.filter(
                             permission_groups__in=self.request.user.all_groups
-                        ),
+                        ).distinct(),
                         to_attr="possible_pools",
                     ),
                     Prefetch(


### PR DESCRIPTION
Due to the way django querysets filter on many-to-many relationships, it
will return duplicate values for _each of the relationships_ where the
filter condition is true. Slapping a `.distinct()` fixes this.

This fixes an issue where the `spots_left` count is wrong for certain users
if the pool contains several permission groups overlapping with the users' groups.
I.e. if you are in 5.th grade, and the pool contains **both** `Abakus` and `5. klasse`,
then the `spots_left` attribute would count the spots left for _each_ of these groups, even though
they are both in just _one_ pool.

See https://stackoverflow.com/a/30262473 for more info on why this happens.
