### PR TITLE
Attatch users' photo consents on event & make sure consent for event exists before registration

### DIFF
--- a/lego/apps/users/serializers/users.py
+++ b/lego/apps/users/serializers/users.py
@@ -220,7 +220,7 @@ class MeSerializer(serializers.ModelSerializer):
         return serializer.data
 
     def get_photo_consents(self, user):
-        pc = PhotoConsent.get_consents(self, user)
+        pc = PhotoConsent.get_consents(user)
         return PhotoConsentSerializer(instance=pc, many=True).data
 
     def get_is_student(self, user):


### PR DESCRIPTION
Previously, we checked photo_consent status for an event in the frontend
by comparing the users registered photo consents with the event
start_time.

This among other things, led to a bug where the user does not have any
photo_consents for an event if the event is in the next semester, and
the user cannot attend the event if `use_consent=True`. This fixes that
by attaching and creating photo consents for that specific event.

This PR adds `photo_consents` on the `UserEventSerializer`, and will create the relevant photo
consent objects if they don't exist. Note that we don't create the photo consents unless the user
can register for the event _and_ the event enforces photo consent usage. This is just to avoid
creating photo consents for events far in the future, as well as events that have already happened.
