### PR TITLE
Create new photo consents for not-open pools

### DIFF
--- a/lego/apps/events/serializers/events.py
+++ b/lego/apps/events/serializers/events.py
@@ -246,7 +246,10 @@ class EventReadUserDetailedSerializer(EventReadDetailedSerializer):
 
         # Only return consents for events that use consent
         # and the user is allowed to register
-        if not obj.use_consent or len(obj.get_possible_pools(request.user)) == 0:
+        if (
+            not obj.use_consent
+            or len(obj.get_possible_pools(request.user, future=True)) == 0
+        ):
             return []
 
         pc = PhotoConsent.get_consents(request.user, time=obj.start_time)

--- a/lego/apps/events/tests/test_events_api.py
+++ b/lego/apps/events/tests/test_events_api.py
@@ -2053,6 +2053,11 @@ class EventPhotoConsentTestCase(BaseAPITestCase):
             event.end_time = date + timedelta(days=10, hours=4)
             event.save()
 
+            # Make sure that we test for pools that are not open yet
+            for pool in event.pools.all():
+                pool.activation_date = date + timedelta(days=1)
+                pool.save()
+
     def test_event_with_consent_in_future(self):
         """
         Getting an event that is some time in the future that the user can register for should


### PR DESCRIPTION
I made an oopsie :grimacing:


There was a bug here where we did not check for pools which are not
open. Meaning that the photo consent objects would only be created for
already open pools.
