### PR TITLE
Fix hard coded groups

### DIFF
--- a/lego/apps/users/action_handlers.py
+++ b/lego/apps/users/action_handlers.py
@@ -4,7 +4,7 @@ from lego.apps.feeds.activity import Activity
 from lego.apps.feeds.feed_manager import feed_manager
 from lego.apps.feeds.models import NotificationFeed, PersonalFeed, UserFeed
 from lego.apps.feeds.verbs import GroupJoinVerb, PenaltyVerb
-from lego.apps.users.constants import GROUP_COMMITTEE, GROUP_INTEREST
+from lego.apps.users.constants import PUBLIC_GROUPS
 from lego.apps.users.models import Membership, Penalty
 from lego.apps.users.notifications import PenaltyNotification
 
@@ -15,7 +15,7 @@ class MembershipHandler(Handler):
 
     def handle_create(self, instance, **kwargs):
         group = instance.abakus_group
-        if group.type not in (GROUP_COMMITTEE, GROUP_INTEREST):
+        if group.type not in PUBLIC_GROUPS:
             return
 
         activity = self.get_activity(instance)

--- a/lego/apps/users/permissions.py
+++ b/lego/apps/users/permissions.py
@@ -104,7 +104,7 @@ class MembershipPermissionHandler(PermissionHandler):
 
         abakus_group = AbakusGroup.objects.get(id=abakus_group_pk)
 
-        if abakus_group.type == constants.GROUP_COMMITTEE:
+        if abakus_group.type in constants.PUBLIC_GROUPS:
             if perm == LIST:
                 return True
 

--- a/lego/apps/users/views/membership_history.py
+++ b/lego/apps/users/views/membership_history.py
@@ -1,7 +1,7 @@
 from rest_framework import mixins, permissions, viewsets
 
 from lego.apps.permissions.constants import EDIT
-from lego.apps.users.constants import GROUP_COMMITTEE, GROUP_INTEREST
+from lego.apps.users.constants import PUBLIC_GROUPS
 from lego.apps.users.filters import MembershipHistoryFilterSet
 from lego.apps.users.models import Membership, MembershipHistory
 from lego.apps.users.serializers.membership_history import MembershipHistorySerializer
@@ -25,8 +25,6 @@ class MembershipHistoryViewSet(
         ).select_related("user", "abakus_group")
 
         if not self.request.user.has_perm(EDIT, Membership):
-            return queryset.filter(
-                abakus_group__type__in=(GROUP_COMMITTEE, GROUP_INTEREST)
-            )
+            return queryset.filter(abakus_group__type__in=PUBLIC_GROUPS)
 
         return queryset


### PR DESCRIPTION
Comittees and interest groups had hard coded behavior in a lot of places, which makes it hard to add new public groups. This will enable all users to view the membership of public groups, as intended.