### PR TITLE
Add nestledere group to LDAP sync

### DIFF
--- a/lego/settings/lego.py
+++ b/lego/settings/lego.py
@@ -45,6 +45,7 @@ LDAP_GROUPS = [
     "RevyStyret",
     "xcom-data",
     "xcom-komtek",
+    "Nestledere",
 ]
 
 SMTP_HOST = "0.0.0.0"


### PR DESCRIPTION
Created a "Nestledere" group to be able to sync with confluence to remove the need for us manually giving them access through the admin user.