### PR TITLE
ABA-114: Always use default profile pictures in staging

### DIFF
--- a/lego/apps/users/models.py
+++ b/lego/apps/users/models.py
@@ -413,6 +413,9 @@ class User(
 
     @property
     def profile_picture(self):
+        if settings.ENVIRONMENT_NAME == "staging":
+            return self.get_default_picture()
+
         return self.picture_id or self.get_default_picture()
 
     @property

--- a/lego/settings/test.py
+++ b/lego/settings/test.py
@@ -21,6 +21,7 @@ DEBUG = False
 SERVER_URL = "http://127.0.0.1:8000"
 FRONTEND_URL = "http://127.0.0.1:8000"
 SERVER_EMAIL = "Abakus <no-reply@abakus.no>"
+ENVIRONMENT_NAME = "testing"
 
 SECRET_KEY = "secret"
 stripe.api_key = os.environ.get("STRIPE_TEST_KEY")


### PR DESCRIPTION
Currently in staging, all users with a profile picture is displayed with a broken / missing image. With this change, all users have placeholder profile pictures in staging.