### PR TITLE
Fix weekly mail

### DIFF
--- a/lego/apps/email/tasks.py
+++ b/lego/apps/email/tasks.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 
 from django.conf import settings
-from django.core.mail import send_mass_mail
 from django.template.loader import render_to_string
 from django.utils import timezone
 
@@ -16,6 +15,7 @@ from lego.apps.joblistings.models import Joblisting
 from lego.apps.notifications.constants import EMAIL, WEEKLY_MAIL
 from lego.apps.notifications.models import NotificationSetting
 from lego.apps.permissions.utils import get_permission_handler
+from lego.apps.restricted.message_processor import MessageProcessor
 from lego.apps.tags.models import Tag
 from lego.apps.users.models import AbakusGroup
 from lego.utils.tasks import AbakusTask
@@ -132,4 +132,4 @@ def send_weekly_email(self, logger_context=None):
         for user in recipients
     )
     datatuple = tuple(tuppel for tuppel in datatuple if tuppel[1] is not None)
-    send_mass_mail(datatuple, fail_silently=False)
+    MessageProcessor.send_mass_mail_html(datatuple)

--- a/lego/apps/email/tasks.py
+++ b/lego/apps/email/tasks.py
@@ -132,4 +132,5 @@ def send_weekly_email(self, logger_context=None):
         for user in recipients
     )
     datatuple = tuple(tuppel for tuppel in datatuple if tuppel[1] is not None)
-    MessageProcessor.send_mass_mail_html(datatuple)
+    if datatuple:
+        MessageProcessor.send_mass_mail_html(datatuple)

--- a/lego/apps/email/tests/test_weekly_email.py
+++ b/lego/apps/email/tests/test_weekly_email.py
@@ -11,7 +11,7 @@ from lego.apps.users.models import AbakusGroup, User
 from lego.utils.test_utils import BaseTestCase
 
 
-@patch("lego.apps.email.tasks.send_mass_mail")
+@patch("lego.apps.restricted.message_processor.MessageProcessor.send_mass_mail_html")
 class WeeklyEmailTestCase(BaseTestCase):
     fixtures = [
         "test_users.yaml",
@@ -59,7 +59,7 @@ class WeeklyEmailTestCase(BaseTestCase):
         self.assertTrue(send_mail_mock.called)
 
 
-@patch("lego.apps.email.tasks.send_mass_mail")
+@patch("lego.apps.restricted.message_processor.MessageProcessor.send_mass_mail_html")
 class WeeklyEmailTestCaseNoWeekly(WeeklyEmailTestCase):
     fixtures = [
         "test_users.yaml",
@@ -97,7 +97,7 @@ class WeeklyEmailTestCaseNoWeekly(WeeklyEmailTestCase):
         self.assertEmailContains(send_mail_mock, "Gutta Consulting")
 
 
-@patch("lego.apps.email.tasks.send_mass_mail")
+@patch("lego.apps.restricted.message_processor.MessageProcessor.send_mass_mail_html")
 class WeeklyEmailTestCaseNoEventsOrWeekly(WeeklyEmailTestCase):
     fixtures = [
         "test_users.yaml",
@@ -131,7 +131,7 @@ class WeeklyEmailTestCaseNoEventsOrWeekly(WeeklyEmailTestCase):
         self.assertEmailContains(send_mail_mock, "Gutta Consulting")
 
 
-@patch("lego.apps.email.tasks.send_mass_mail")
+@patch("lego.apps.restricted.message_processor.MessageProcessor.send_mass_mail_html")
 class WeeklyEmailTestCaseNothing(BaseTestCase):
     fixtures = [
         "test_users.yaml",
@@ -143,10 +143,10 @@ class WeeklyEmailTestCaseNothing(BaseTestCase):
 
     def test_send_mail(self, send_mass_mail_mock):
         send_weekly_email()
-        self.assertEquals(len(send_mass_mail_mock.call_args.args[0]), 0)
+        self.assertFalse(send_mass_mail_mock.called)
 
 
-@patch("lego.apps.email.tasks.send_mass_mail")
+@patch("lego.apps.restricted.message_processor.MessageProcessor.send_mass_mail_html")
 class WeeklyEmailTaskTest(BaseTestCase):
     fixtures = [
         "test_users.yaml",
@@ -178,4 +178,4 @@ class WeeklyEmailTaskTest(BaseTestCase):
             notification_setting.save()
 
         send_weekly_email()
-        self.assertEquals(len(send_mass_mail_mock.call_args.args[0]), 0)
+        self.assertFalse(send_mass_mail_mock.called)

--- a/lego/apps/restricted/message_processor.py
+++ b/lego/apps/restricted/message_processor.py
@@ -3,7 +3,7 @@ from email.message import Message
 from email.mime.text import MIMEText
 
 from django.conf import settings
-from django.core.mail import get_connection
+from django.core.mail import EmailMultiAlternatives, get_connection
 
 from channels.db import database_sync_to_async
 from structlog import get_logger
@@ -131,6 +131,19 @@ class MessageProcessor:
         log.info(
             "restricted_mail_process_messages", sender=sender, recipients=len(messages)
         )
+        return connection.send_messages(messages)
+
+    @staticmethod
+    def send_mass_mail_html(datatuple):
+
+        messages = []
+        for subject, html, from_email, recipients in datatuple:
+            message = EmailMultiAlternatives(subject, html, from_email, recipients)
+            message.content_subtype = "html"
+            messages.append(message)
+
+        connection = get_connection(fail_silently=False)
+        log.info("restricted_mail_mass_html_message", recipients=len(messages))
         return connection.send_messages(messages)
 
     @staticmethod

--- a/lego/apps/restricted/message_processor.py
+++ b/lego/apps/restricted/message_processor.py
@@ -134,11 +134,13 @@ class MessageProcessor:
         return connection.send_messages(messages)
 
     @staticmethod
-    def send_mass_mail_html(datatuple):
+    def send_mass_mail_html(datatuple: tuple[tuple[str, str, str, list[str]]]):
 
         messages = []
         for subject, html, from_email, recipients in datatuple:
-            message = EmailMultiAlternatives(subject, html, from_email, recipients)
+            message: EmailMultiAlternatives = EmailMultiAlternatives(
+                subject, html, from_email, recipients
+            )
             message.content_subtype = "html"
             messages.append(message)
 

--- a/lego/apps/restricted/tests/test_processor.py
+++ b/lego/apps/restricted/tests/test_processor.py
@@ -113,6 +113,43 @@ class MessageProcessorTestCase(BaseTestCase):
             first_message.keys(),
         )
 
+    def test_send_mass_html(self):
+        """Test the outbox and make sure we have correct headers in the messages."""
+
+        messages = self.processor.send_mass_mail_html(
+            (
+                (
+                    "test",
+                    "<h1>test</h1>",
+                    "test@test.com",
+                    ["test1@test.com", "test2@test.com"],
+                ),
+                (
+                    "test",
+                    "<h1>test2</h1>",
+                    "test@test.com",
+                    ["test1@test.com", "test2@test.com"],
+                ),
+            ),
+        )
+        self.assertEqual(2, messages)
+
+        outbox = mail.outbox
+        first_message = outbox[0].message()
+        self.assertSequenceEqual(
+            [
+                "Content-Type",
+                "MIME-Version",
+                "Content-Transfer-Encoding",
+                "Subject",
+                "From",
+                "To",
+                "Date",
+                "Message-ID",
+            ],
+            first_message.keys(),
+        )
+
     @async_test
     async def test_send_wrong_addr(self):
         """Sending from wrong addr shouldn't crash and burn"""


### PR DESCRIPTION
This is a small PR to fix weekly mail. The gist of the PR is sending the html mail with "text/html" content. To do this I had to implement a version of send_mass_mail that supported html_messages. I have tested that this is displayed correctly in thunderbird