### PR TITLE
Lock pools as well as event when bumping

### DIFF
--- a/lego/apps/events/fixtures/test_events.yaml
+++ b/lego/apps/events/fixtures/test_events.yaml
@@ -264,7 +264,7 @@
     name: Abakusmember
     capacity: 2
     event: 10
-    counter: 2
+    counter: 1
     activation_date: "2019-09-01T13:20:30+03:00"
     permission_groups:
       - - Abakus


### PR DESCRIPTION
Previously, only the event itself was locked. When a registration is registered to an event, we only lock the pool, since we don't actually care about the event unless it's merged. This means that we can see race conditions when we lock the _event_ when bumping (e.g. in `unregister()`), and a single _pool_ in `register()` while actually modifying the reg count of that same _pool_ in `unregister()`.

By locking the pools in all of these places, as well as the event while bumping, we make sure that only one of these happens at a time.





OOPS: 
I plan to try making a test to try to repro this. But not today...
Awesome if someone wants to look over and see if this makes sense in the mean time though :)