### PR TITLE
Make not-accepted meetings transparent in calendar

### DIFF
--- a/lego/apps/ical/utils.py
+++ b/lego/apps/ical/utils.py
@@ -16,9 +16,9 @@ def add_events_to_ical_feed(
         add_event_to_ical_feed(feed, event, price, title, ical_starttime, ical_endtime)
 
 
-def add_meetings_to_ical_feed(feed, meetings):
+def add_meetings_to_ical_feed(feed, meetings, user):
     for meeting in meetings:
-        add_meeting_to_ical_feed(feed, meeting)
+        add_meeting_to_ical_feed(feed, meeting, user)
 
 
 def add_event_to_ical_feed(
@@ -40,7 +40,7 @@ def add_event_to_ical_feed(
     )
 
 
-def add_meeting_to_ical_feed(feed, meeting):
+def add_meeting_to_ical_feed(feed, meeting, user):
     desc_context = {
         "title": meeting.title,
         "report": meeting.report,
@@ -59,6 +59,7 @@ def add_meeting_to_ical_feed(feed, meeting):
         start_datetime=meeting.start_time,
         end_datetime=meeting.end_time,
         location=meeting.location,
+        transparency="OPAQUE" if user in meeting.participants else "TRANSPARENT",
     )
 
 

--- a/lego/apps/ical/viewsets.py
+++ b/lego/apps/ical/viewsets.py
@@ -95,7 +95,7 @@ class ICalViewset(viewsets.ViewSet):
         meetings = permission_handler.filter_queryset(request.user, Meeting.objects)
 
         utils.add_events_to_ical_feed(feed, following_events)
-        utils.add_meetings_to_ical_feed(feed, meetings)
+        utils.add_meetings_to_ical_feed(feed, meetings, request.user)
 
         return utils.render_ical_response(feed, calendar_type)
 


### PR DESCRIPTION
Fixes an annoyance of mine, kinda™️    
![bilde](https://user-images.githubusercontent.com/64247965/203409424-c53ec17d-8aa4-4650-8ef1-037f39a108ac.png)
Appears white (test123) and not dashed in google calendar, but this seems to be the proper way to do this