### PR TITLE
Enforce Python 3.11 🚄 

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ trigger:
 
 steps:
   - name: setup
-    image: abakus/lego-testbase:python3.9
+    image: abakus/lego-testbase:python3.11
     when:
       event: push
     environment:
@@ -19,7 +19,7 @@ steps:
       - make ci_settings
 
   - name: missing-migrations
-    image: abakus/lego-testbase:python3.9
+    image: abakus/lego-testbase:python3.11
     when:
       event: push
     environment:
@@ -32,7 +32,7 @@ steps:
       - tox -e missing-migrations
 
   - name: tests
-    image: abakus/lego-testbase:python3.9
+    image: abakus/lego-testbase:python3.11
     when:
       event: push
     environment:
@@ -45,7 +45,7 @@ steps:
       - tox -e tests -- --parallel
 
   - name: isort
-    image: abakus/lego-testbase:python3.9
+    image: abakus/lego-testbase:python3.11
     when:
       event: push
     environment:
@@ -56,7 +56,7 @@ steps:
       - tox -e isort
 
   - name: flake8
-    image: abakus/lego-testbase:python3.9
+    image: abakus/lego-testbase:python3.11
     when:
       event: push
     environment:
@@ -67,7 +67,7 @@ steps:
       - tox -e flake8
 
   - name: black
-    image: abakus/lego-testbase:python3.9
+    image: abakus/lego-testbase:python3.11
     pull: true
     when:
       event: push
@@ -79,7 +79,7 @@ steps:
       - tox -e black
 
   - name: mypy
-    image: abakus/lego-testbase:python3.9
+    image: abakus/lego-testbase:python3.11
     pull: true
     when:
       event: push
@@ -91,7 +91,7 @@ steps:
       - tox -e mypy
 
   - name: docs
-    image: abakus/lego-testbase:python3.9
+    image: abakus/lego-testbase:python3.11
     when:
       event: push
     environment:
@@ -102,7 +102,7 @@ steps:
       - tox -e docs
 
   - name: coverage
-    image: abakus/lego-testbase:python3.9
+    image: abakus/lego-testbase:python3.11
     when:
       event: push
     environment:
@@ -187,4 +187,4 @@ services:
 
 ---
 kind: signature
-hmac: d24fc7701282f352982ca8f2568b40d10700e600895e57d6efa47d8b6bfcc674
+hmac: 2b32f45fb6e5972e0ac2aa407b21d5f1be7ed3acb02fb08cc44e37a390efc747

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN sentry-cli releases finalize ${RELEASE}
 RUN sentry-cli releases deploys ${RELEASE} new -e "staging"
 RUN sentry-cli releases deploys ${RELEASE} new -e "production"
 
-FROM python:3.9
+FROM python:3.11
 MAINTAINER Abakus Webkom <webkom@abakus.no>
 
 ARG RELEASE

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,9 @@ ci_settings:
 	echo "from .test import *" > lego/settings/local.py
 
 fixme:
-	docker run --rm -v "${PWD}:/code" -it python:3.9 "bash" "-c" "cd /code && pip install -r requirements/black.txt -r requirements/isort.txt && isort lego && black lego"
+	docker run --rm -v "${PWD}:/code" -it python:3.11 "bash" "-c" "cd /code && pip install -r requirements/black.txt -r requirements/isort.txt && isort lego && black lego"
 
 devenv:
-	docker run --net=host --rm -v "${PWD}:/code" -it python:3.9 "bash" "-c" "cd /code && pip install -r requirements/dev.txt && exec bash"
+	docker run --net=host --rm -v "${PWD}:/code" -it python:3.11 "bash" "-c" "cd /code && pip install -r requirements/dev.txt && exec bash"
 
 .PHONY: help docs ci_settings fixme devenv

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Getting started
 
-LEGO requires `python3.9`, `python3.9-venv`, `docker` and `docker-compose`. Services like Postgres, Redis, Thumbor and Minio run inside docker.
+LEGO requires `python3.11`, `python3.11-venv`, `docker` and `docker-compose`. Services like Postgres, Redis, Thumbor and Minio run inside docker.
 
 ```bash
 # Initial setup (only need to once)

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ sections = FUTURE, STDLIB, DJANGO, THIRDPARTY, FIRSTPARTY, LOCALFOLDER
 combine_as_imports = true
 
 [mypy]
-python_version = 3.9
+python_version = 3.11
 plugins = mypy_django_plugin.main,mypy_drf_plugin.main
 ignore_missing_imports = True
 allow_untyped_globals = True
@@ -24,5 +24,5 @@ allow_untyped_globals = True
 django_settings_module = "lego.settings"
 
 [black]
-target-version = ['py39']
+target-version = ['py311']
 line-length = 100

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = tests, docs, missing-migrations, isort, flake8, coverage, black, mypy
 skipsdist = True
 
 [testenv]
-basepython = python3.9
+basepython = python3.11
 deps =
     black: -r{toxinidir}/requirements/black.txt
     isort: -r{toxinidir}/requirements/isort.txt
@@ -51,7 +51,7 @@ commands =
     python manage.py missing_migrations
 
 [testenv:coverage]
-basepython = python3.9
+basepython = python3.11
 deps = -r{toxinidir}/requirements/coverage.txt
 commands =
     coverage combine
@@ -60,7 +60,7 @@ commands =
 
 [testenv:docs]
 basepython =
-    python3.9
+    python3.11
 changedir =
     docs
 setenv =


### PR DESCRIPTION
Okay, let's be agile here and give Python 3.11 a chance. Crossing fingers. 

`lego-testbase` is upgraded [here](https://github.com/webkom/lego-testbase/pull/6).