### PR TITLE
Fix weekly mail when email is empty

### DIFF
--- a/lego/apps/email/tasks.py
+++ b/lego/apps/email/tasks.py
@@ -125,7 +125,7 @@ def send_weekly_email(self, logger_context=None):
     datatuple = (
         (
             f"Ukesmail uke {week_number}",
-            transform(create_weekly_mail(user)),
+            transform(html) if (html := create_weekly_mail(user)) is not None else None,
             settings.DEFAULT_FROM_EMAIL,
             [user.email],
         )

--- a/lego/apps/email/tests/test_weekly_email.py
+++ b/lego/apps/email/tests/test_weekly_email.py
@@ -139,6 +139,8 @@ class WeeklyEmailTestCaseNothing(BaseTestCase):
     ]
 
     def setUp(self):
+        pr = AbakusGroup.objects.get(name="PR")
+        pr.add_user(User.objects.get(pk=10))
         return
 
     def test_send_mail(self, send_mass_mail_mock):


### PR DESCRIPTION
The behavior for not sending an email when there is nothing to put in the weekly mail was broken. Unfortunately the tast was also broken, so this error was not discovered. This fixes both the behavior and the test.