### PR TITLE
Fix broken link on weekly mail

### DIFF
--- a/lego/apps/email/tasks.py
+++ b/lego/apps/email/tasks.py
@@ -93,6 +93,7 @@ def create_weekly_mail(user):
             if todays_weekly is None
             else todays_weekly.get_absolute_url(),
             "joblistings": joblistings,
+            "frontend_url": settings.FRONTEND_URL,
         },
     )
     if events or joblistings or todays_weekly:


### PR DESCRIPTION
`frontend_url` was undefined, causing a link to be broken.

---

Closes #3127 and closes ABA-189.