### PR TITLE
Include `is_priced` in the event read serializer

### DIFF
--- a/lego/apps/events/serializers/events.py
+++ b/lego/apps/events/serializers/events.py
@@ -96,6 +96,7 @@ class EventReadSerializer(
             "activation_time",
             "is_admitted",
             "survey",
+            "is_priced",
         ) + ObjectPermissionsSerializerMixin.Meta.fields
         read_only = True
 


### PR DESCRIPTION
Used by the webapp on /events/{id}/administrate/attendees. If you do a hard refresh here, `is_priced` will become undefined and the column of who's paid will vanish.

We have so many event serializers, and it can get confusing, so I might be missing something as to why stuff like this isn't included in the serializer from beforehand?