### PR TITLE
Add plausible source to weekly email links

### DIFF
--- a/lego/apps/email/tasks.py
+++ b/lego/apps/email/tasks.py
@@ -23,6 +23,10 @@ from lego.utils.tasks import AbakusTask
 log = get_logger()
 
 
+def add_source_to_url(url):
+    return f"{url}?utm_source=WeeklyMail&utm_campaign=Email"
+
+
 def create_weekly_mail(user):
     three_days_ago_timestamp = timezone.now() - timedelta(days=3)
     last_sunday_timestamp = timezone.now() - timedelta(days=7)
@@ -80,7 +84,7 @@ def create_weekly_mail(user):
                 "id": event.id,
                 "pools": pools,
                 "start_time": event.start_time.strftime("%d/%m kl %H:%M"),
-                "url": event.get_absolute_url(),
+                "url": add_source_to_url(event.get_absolute_url()),
                 "type": EVENT_TYPE_TRANSLATIONS[event.event_type],
             }
         )
@@ -91,7 +95,7 @@ def create_weekly_mail(user):
             "events": events,
             "todays_weekly": ""
             if todays_weekly is None
-            else todays_weekly.get_absolute_url(),
+            else add_source_to_url(todays_weekly.get_absolute_url()),
             "joblistings": joblistings,
             "frontend_url": settings.FRONTEND_URL,
         },

--- a/lego/apps/email/templates/email/email/weekly_mail.html
+++ b/lego/apps/email/templates/email/email/weekly_mail.html
@@ -50,7 +50,7 @@
     {% for joblisting in joblistings%}
                 <tr>
                     <td style="text-align: left; padding-right: 10px;">
-                        <a href="https://abakus.no/joblistings/{{joblisting.id}}">{{joblisting.title}}</a>
+                        <a href="https://abakus.no/joblistings/{{joblisting.id}}?utm_source=WeeklyMail&utm_campaign=Email">{{joblisting.title}}</a>
                     </td>
                     <td style="text-align: left; padding-right: 10px; min-width: 70px; word-break: break-all;">
                         {{joblisting.company_name}} 


### PR DESCRIPTION
Add some source query params to track if people click the links in our weekly mails. Nice to check if people actually read them, and if the lead to people checking out weekly, events or joblistings.