### PR TITLE
Add "Revy" group to LDAP sync

### DIFF
--- a/lego/settings/lego.py
+++ b/lego/settings/lego.py
@@ -42,6 +42,7 @@ LDAP_GROUPS = [
     "Kasserere",
     "Ordenen",
     "PR-ansvarlige",
+    "Revy",
     "RevyStyret",
     "xcom-data",
     "xcom-komtek",


### PR DESCRIPTION
There was a request to add edit-permissions for some wiki-pages to revue members. For this the revue group must be synced with the LDAP server.