### PR TITLE
Fix event-following bug by adding current user following status to event serializer

### DIFF
--- a/lego/apps/events/fields.py
+++ b/lego/apps/events/fields.py
@@ -79,6 +79,17 @@ class IsAdmittedField(serializers.Field):
         return value.is_admitted(request.user)
 
 
+class FollowingField(serializers.Field):
+    def get_attribute(self, instance):
+        return instance
+
+    def to_representation(self, value):
+        request = self.context.get("request", None)
+        if not request or not request.user.is_authenticated:
+            return False
+        return value.following(request.user)
+
+
 class ActivationTimeField(serializers.Field):
     def get_attribute(self, instance):
         return instance

--- a/lego/apps/events/models.py
+++ b/lego/apps/events/models.py
@@ -646,6 +646,12 @@ class Event(Content, BasisModel, ObjectPermissionsModel):
             return self.user_reg[0].pool is not None
         return self.registrations.filter(user=user).exclude(pool=None).exists()
 
+    def following(self, user: User) -> int | False:
+        try:
+            return FollowEvent.objects.get(follower=user, target=self).pk
+        except FollowEvent.DoesNotExist:
+            return False
+
     def is_on_waiting_list(self, user: User) -> bool:
         return self.registrations.filter(
             user=user, pool=None, status=constants.SUCCESS_REGISTER

--- a/lego/apps/events/serializers/events.py
+++ b/lego/apps/events/serializers/events.py
@@ -10,7 +10,12 @@ from lego.apps.companies.models import Company
 from lego.apps.content.fields import ContentSerializerField
 from lego.apps.events import constants
 from lego.apps.events.constants import PRESENCE_CHOICES
-from lego.apps.events.fields import ActivationTimeField, IsAdmittedField, SpotsLeftField
+from lego.apps.events.fields import (
+    ActivationTimeField,
+    FollowingField,
+    IsAdmittedField,
+    SpotsLeftField,
+)
 from lego.apps.events.models import Event, Pool, Registration
 from lego.apps.events.serializers.pools import (
     PoolAdministrateExportSerializer,
@@ -205,6 +210,7 @@ class EventReadUserDetailedSerializer(EventReadDetailedSerializer):
 
     activation_time = ActivationTimeField()
     is_admitted = IsAdmittedField()
+    following = FollowingField()
     spots_left = SpotsLeftField()
     pending_registration = serializers.SerializerMethodField()
     price = serializers.SerializerMethodField()
@@ -215,6 +221,7 @@ class EventReadUserDetailedSerializer(EventReadDetailedSerializer):
             "price",
             "activation_time",
             "is_admitted",
+            "following",
             "spots_left",
             "pending_registration",
             "photo_consents",


### PR DESCRIPTION
There is a bug where the webapp does not correctly load the following status of the current user, if an event has a large number of followers. It is caused by pagination on the event follower endpoint, but I figured this was a better solution than loading all pages in the webapp.

This adds a field "following" on `EventReadUserDetailedSerializer` that is `false` when the current user is not following the event, and the id of the relevant `EventFollow` object if the user is following the event.

https://github.com/webkom/lego-webapp/pull/3541 implements the needed front-end changes