### PR TITLE
Roll out weekly mail

### DIFF
--- a/lego/apps/email/tasks.py
+++ b/lego/apps/email/tasks.py
@@ -117,10 +117,7 @@ def send_weekly_email(self, logger_context=None):
     week_number = timezone.now().isocalendar().week
 
     # Set to just PR and Webkom for testing purposes
-    all_users = set(
-        AbakusGroup.objects.get(name="Webkom").restricted_lookup()[0]
-        + AbakusGroup.objects.get(name="PR").restricted_lookup()[0]
-    )
+    all_users = AbakusGroup.objects.get(name="Abakus").restricted_lookup()[0]
     recipients = []
 
     for user in all_users:

--- a/lego/apps/email/tasks.py
+++ b/lego/apps/email/tasks.py
@@ -29,6 +29,8 @@ def add_source_to_url(url):
 
 
 def create_weekly_mail(user):
+    week_number = timezone.now().isocalendar().week
+
     three_days_ago_timestamp = timezone.now() - timedelta(days=3)
     last_sunday_timestamp = timezone.now() - timedelta(days=7)
 
@@ -97,6 +99,7 @@ def create_weekly_mail(user):
     html_body = render_to_string(
         "email/email/weekly_mail.html",
         {
+            "week_number": week_number,
             "events": events,
             "todays_weekly": ""
             if todays_weekly is None

--- a/lego/apps/email/templates/email/email/weekly_mail.html
+++ b/lego/apps/email/templates/email/email/weekly_mail.html
@@ -1,10 +1,15 @@
 {% extends "email/base.html" %}
 
 {% block content %}
+    <tr>
+        <td class="content-block">
+            <h1 style="margin: 20px 0 10px 0;">Ukesmail uke {{week_number}}</h1>
+        </td>
+    </tr>
     {%if events %}
     <tr>
         <td class="content-block">
-            <h3 style="margin: 20px 0 10px 0;">Arrangementer med påmelding neste uke:</h3>
+            <h3 style="margin: 20px 0 10px 0;">Arrangementer med påmelding neste uke</h3>
         </td>
     </tr>
     <tr>
@@ -35,7 +40,7 @@
     {%if joblistings %}
     <tr>
         <td class="content-block">
-            <h3 style="margin: 20px 0 10px 0;" colspan=5>Nye jobbannonser</h3>
+            <h3 style="margin: 35px 0 10px 0;" colspan=5>Nye jobbannonser</h3>
         </td>
     </tr>
     <tr>
@@ -49,13 +54,13 @@
     {% endif %}
     {% for joblisting in joblistings%}
                 <tr>
-                    <td style="text-align: left; padding-right: 10px;">
+                    <td style="padding-top: 5px; text-align: left; padding-right: 10px;">
                         <a href="https://abakus.no/joblistings/{{joblisting.id}}?utm_source=WeeklyMail&utm_campaign=Email">{{joblisting.title}}</a>
                     </td>
-                    <td style="text-align: left; padding-right: 10px; min-width: 120px; word-break: break-word;">
+                    <td style="padding-top: 5px; text-align: left; padding-right: 10px; min-width: 140px; word-break: break-word;">
                         {{joblisting.company_name}} 
                     </td>
-                    <td style="text-align: left; padding-right: 10px; min-width: 120px; word-break: break-word;">
+                    <td style="padding-top: 5px; text-align: left; padding-right: 10px; min-width: 120px; word-break: break-word;">
                      {{joblisting.type}}
                     </td>
                 </tr>


### PR DESCRIPTION
This PR does two things:
 - Send weekly mail to all users in organisation(ie. those in the Abakus group). Not just PR and Webkom
 - Make some minor improvements:
   - Add header with week number
   - Additional padding for joblistings
   - Make company name column wider
 
 **Screenshot**: 
![image](https://user-images.githubusercontent.com/7977650/218824623-323473ef-b17c-40bb-800a-827ffb25a17a.png)
