### PR TITLE
Fix incorrect waiting list sorting

### DIFF
--- a/lego/apps/events/views.py
+++ b/lego/apps/events/views.py
@@ -118,7 +118,9 @@ class EventViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
                     "can_edit_users",
                     "can_edit_groups",
                     Prefetch("pools__registrations", queryset=reg_queryset),
-                    Prefetch("registrations", queryset=reg_queryset),
+                    Prefetch(
+                        "registrations", queryset=Registration.objects.filter(pool=None)
+                    ),
                 )
         else:
             queryset = Event.objects.all()


### PR DESCRIPTION
On some events, usually with many users in the waiting list, the waiting
list is consistently wrong for all users (i.e. the sorting is the same,
incorrect for all users) when admitted to the event.

I'm not 100% sure why this works, but changing the query for the
prefetching on the event retrieve endpoint consistently gives the
correct sorting.
