### PR TITLE
Fix bug sending 10+ mails to all users

### DIFF
--- a/lego/apps/email/tasks.py
+++ b/lego/apps/email/tasks.py
@@ -119,8 +119,8 @@ def send_weekly_email(self, logger_context=None):
 
     week_number = timezone.now().isocalendar().week
 
-    # Set to just PR and Webkom for testing purposes
-    all_users = AbakusGroup.objects.get(name="Abakus").restricted_lookup()[0]
+    # Send to all active students
+    all_users = set(AbakusGroup.objects.get(name="Students").restricted_lookup()[0])
     recipients = []
 
     for user in all_users:

--- a/lego/apps/email/tests/test_weekly_email.py
+++ b/lego/apps/email/tests/test_weekly_email.py
@@ -31,6 +31,8 @@ class WeeklyEmailTestCase(BaseTestCase):
         joblisting.save()
         pr = AbakusGroup.objects.get(name="PR")
         pr.add_user(User.objects.get(pk=10))
+        students = AbakusGroup.objects.get(name="Students")
+        students.add_user(User.objects.get(pk=10))
 
     def assertEmailContains(self, send_mass_mail_mock, content):
         message = send_mass_mail_mock.call_args.args[0][0][1]
@@ -78,6 +80,8 @@ class WeeklyEmailTestCaseNoWeekly(WeeklyEmailTestCase):
         joblisting.save()
         pr = AbakusGroup.objects.get(name="PR")
         pr.add_user(User.objects.get(pk=10))
+        students = AbakusGroup.objects.get(name="Students")
+        students.add_user(User.objects.get(pk=10))
 
     def test_generate_weekly(self, send_mail_mock):
         send_weekly_email()
@@ -112,6 +116,8 @@ class WeeklyEmailTestCaseNoEventsOrWeekly(WeeklyEmailTestCase):
         joblisting.save()
         pr = AbakusGroup.objects.get(name="PR")
         pr.add_user(User.objects.get(pk=10))
+        students = AbakusGroup.objects.get(name="Students")
+        students.add_user(User.objects.get(pk=10))
 
     def test_generate_weekly(self, send_mail_mock):
         send_weekly_email()
@@ -141,6 +147,8 @@ class WeeklyEmailTestCaseNothing(BaseTestCase):
     def setUp(self):
         pr = AbakusGroup.objects.get(name="PR")
         pr.add_user(User.objects.get(pk=10))
+        students = AbakusGroup.objects.get(name="Students")
+        students.add_user(User.objects.get(pk=10))
         return
 
     def test_send_mail(self, send_mass_mail_mock):
@@ -169,6 +177,8 @@ class WeeklyEmailTaskTest(BaseTestCase):
         joblisting.save()
         pr = AbakusGroup.objects.get(name="PR")
         pr.add_user(User.objects.get(pk=10))
+        students = AbakusGroup.objects.get(name="Students")
+        students.add_user(User.objects.get(pk=10))
 
     def test_email_sent(self, send_mass_mail_mock):
         send_weekly_email()


### PR DESCRIPTION
The restricted lookup returns a list containing each user multiple times. This results in each user receiving multiple copies of each weekly mail(I think). This sends out the weekly mail to each user just once, and also just does it for students.