### PR TITLE
Update deprecated tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands =
 [testenv:tests]
 deps =
     -r{toxinidir}/requirements/dev.txt
-whitelist_externals =
+allowlist_externals =
     /usr/bin/make
 setenv =
     DJANGO_SETTINGS_MODULE=lego.settings


### PR DESCRIPTION
The whitelist_externals option has been deprecated and must be replaced with allowlist_externals. This will allow us to run the tests in drone again