### PR TITLE
Add external mail user sofaktura@abakus.no

### DIFF
--- a/lego/settings/lego.py
+++ b/lego/settings/lego.py
@@ -62,4 +62,4 @@ GSUITE_DOMAIN = "abakus.no"
 GSUITE_GROUPS = []
 
 #  External users in GSuite not managed by lego. (Don't suspend these.)
-GSUITE_EXTERNAL_USERS = ["admin@abakus.no", "noreply@abakus.no"]
+GSUITE_EXTERNAL_USERS = ["admin@abakus.no", "noreply@abakus.no", "sofaktura@abakus.no"]


### PR DESCRIPTION
This is for all the invoice mails from SnackOverflow. It doesn't need an Abakus-user, hence why it is added to external users.