### PR TITLE
Replace `urlparse()` with the faster `urlsplit()` alternative

### DIFF
--- a/lego/apps/ical/utils.py
+++ b/lego/apps/ical/utils.py
@@ -1,4 +1,4 @@
-from urllib.parse import urlparse
+from urllib.parse import urlsplit
 
 from django.conf import settings
 from django.http import HttpResponse
@@ -83,7 +83,7 @@ def render_ical_response(feed, calendar_type):
 
 
 def get_frontend_domain():
-    return urlparse(settings.FRONTEND_URL).netloc
+    return urlsplit(settings.FRONTEND_URL).netloc
 
 
 def get_calendar_name(calendar_type):


### PR DESCRIPTION
[urlparse()](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlparse) allows for “parameters” before the ? in the URL, which we do not use here.

[urlsplit()](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlsplit) supports a later (1998) RFC and does not parse such parameters. It's thus a bit faster.

Anthony Sottile did a [video on the subject](https://www.youtube.com/watch?v=ABJvdsIANds), which taught me about this difference.

---

This change makes a _very_ little difference for us, but I just wanted to try it out for fun.