### PR TITLE
Fix docker build with poetry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ENV ENV_CONFIG 1
 ENV RELEASE ${RELEASE}
 
 RUN mkdir /app
-COPY requirements /app/requirements
+COPY pyproject.toml /app/pyproject.toml
 WORKDIR /app
 
 RUN pip install poetry


### PR DESCRIPTION
Changed `COPY requirements /app/requirements` to `COPY pyproject.toml /app/pyproject.toml` in Dockerfile

`requirements` no longer exists, causing the build to fail. `pyproject.toml` now contains the requirements, and is needed to install deps with poetry.