### PR TITLE
Fix DAPHNE_SERVER setting check

### DIFF
--- a/lego/settings/__init__.py
+++ b/lego/settings/__init__.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 TESTING = "test" in sys.argv[:2]
-DAPHNE_SERVER = "daphne" in sys.argv
+DAPHNE_SERVER = "daphne" in sys.argv[0]
 
 from .base import *  # noqa
 from .lego import *  # noqa


### PR DESCRIPTION
The first arg could be "/usr/local/daphne" f.ex. This should not break
anything as the first arg would always be the path to the daphne
executable.
