### PR TITLE
Replace dummy HTTPConsumer with a working one

### DIFF
--- a/lego/apps/websockets/routing.py
+++ b/lego/apps/websockets/routing.py
@@ -1,6 +1,8 @@
 from django.conf import settings
 from django.urls import re_path
+from rest_framework import status
 
+from channels.generic.http import AsyncHttpConsumer
 from channels.routing import ProtocolTypeRouter, URLRouter
 from structlog import get_logger
 
@@ -10,18 +12,19 @@ from lego.apps.websockets.consumers import GroupConsumer
 log = get_logger()
 
 
-class HTTPConsumer:
+class HTTPConsumer(AsyncHttpConsumer):
     """
     The HTTPConsumer disables the http protocol when the application is running in production.
     Http is handled by uwsgi in production.
     """
 
-    def __init__(self, *args, **kwargs):
-        pass
-
-    async def __call__(self, scope):
+    async def handle(self, body: bytes) -> None:
         log.warn("http_disabled_daphne")
-        raise ValueError
+        await self.send_response(
+            status.HTTP_405_METHOD_NOT_ALLOWED,
+            b"This server does not accept http",
+            headers=[(b"Content-Type", b"text/plain")],
+        )
 
 
 protocols = {
@@ -31,6 +34,6 @@ protocols = {
 }
 
 if settings.DAPHNE_SERVER:
-    protocols["http"] = HTTPConsumer  # type: ignore
+    protocols["http"] = HTTPConsumer()
 
 application = ProtocolTypeRouter(protocols)


### PR DESCRIPTION
It just responds with 405 method not allowed. IMO this is better than constant warnings when something tries to do an http request at it.


Fixes ABA-457