### PR TITLE
Add strikethrough tag to allowed in html sanitizer

### DIFF
--- a/lego/apps/content/utils.py
+++ b/lego/apps/content/utils.py
@@ -10,6 +10,7 @@ def sanitize_html(value, allow_images=True):
         "b",
         "i",
         "u",
+        "s",
         "h1",
         "h2",
         "h3",


### PR DESCRIPTION
Strikethrough is supported in `lego-editor`, but gets removed by lego's html sanitizer. This allows \<s>-tags to pass through the sanitizer.