### PR TITLE
Rename studies back to uppercase

### DIFF
--- a/lego/apps/users/constants.py
+++ b/lego/apps/users/constants.py
@@ -80,10 +80,10 @@ class FSGroup(Enum):
     def values(cls) -> list[str]:
         return [e.value for e in cls]
 
-    MTDT = "fc:fs:fs:prg:ntnu.no:mtdt"
-    MTKOM = "fc:fs:fs:prg:ntnu.no:mtkom"
-    MIDT = "fc:fs:fs:prg:ntnu.no:midt"
-    MSTCNNS = "fc:fs:fs:prg:ntnu.no:mstcnns"
+    MTDT = "fc:fs:fs:prg:ntnu.no:MTDT"
+    MTKOM = "fc:fs:fs:prg:ntnu.no:MTKOM"
+    MIDT = "fc:fs:fs:prg:ntnu.no:MIDT"
+    MSTCNNS = "fc:fs:fs:prg:ntnu.no:MSTCNNS"
 
 
 AbakusGradeFSMapping = {

--- a/lego/apps/users/models.py
+++ b/lego/apps/users/models.py
@@ -451,7 +451,7 @@ class User(
             return True
 
         for group in feide_groups:
-            if group["id"].lower() in constants.FSGroup.values():
+            if group["id"] in constants.FSGroup.values():
                 grade_group = AbakusGroup.objects.get(
                     name=constants.AbakusGradeFSMapping[constants.FSGroup(group["id"])]
                 )

--- a/lego/apps/users/tests/test_student_confirmation_api.py
+++ b/lego/apps/users/tests/test_student_confirmation_api.py
@@ -44,7 +44,7 @@ def _token(token):
 
 data_resp = [
     {
-        "id": "fc:fs:fs:prg:ntnu.no:mtdt",
+        "id": "fc:fs:fs:prg:ntnu.no:MTDT",
         "type": "fc:fs:prg",
         "displayName": "Computer Science",
         "membership": {
@@ -60,7 +60,7 @@ data_resp = [
 
 komtek_resp = [
     {
-        "id": "fc:fs:fs:prg:ntnu.no:mtkom",
+        "id": "fc:fs:fs:prg:ntnu.no:MTKOM",
         "type": "fc:fs:prg",
         "displayName": "Communication Technology",
         "membership": {
@@ -76,7 +76,7 @@ komtek_resp = [
 
 data_master_resp = [
     {
-        "id": "fc:fs:fs:prg:ntnu.no:midt",
+        "id": "fc:fs:fs:prg:ntnu.no:MIDT",
         "type": "fc:fs:prg",
         "displayName": "Computer Science",
     }
@@ -84,7 +84,7 @@ data_master_resp = [
 
 komtek_master_resp = [
     {
-        "id": "fc:fs:fs:prg:ntnu.no:mstcnns",
+        "id": "fc:fs:fs:prg:ntnu.no:MSTCNNS",
         "type": "fc:fs:prg",
         "displayName": "Digital Infrastructure and Cyber Security",
     }
@@ -92,12 +92,12 @@ komtek_master_resp = [
 
 multi_other_resp = [
     {
-        "id": "fc:fs:fs:prg:ntnu.no:msit",
+        "id": "fc:fs:fs:prg:ntnu.no:MSIT",
         "type": "fc:fs:prg",
         "displayName": "Informatikk",
     },
     {
-        "id": "fc:fs:fs:prg:ntnu.no:bit",
+        "id": "fc:fs:fs:prg:ntnu.no:BIT",
         "type": "fc:fs:prg",
         "displayName": "Informatikk (Bachelor)",
     },
@@ -105,7 +105,7 @@ multi_other_resp = [
 
 indok_resp = [
     {
-        "id": "fc:fs:fs:prg:ntnu.no:mtiot",
+        "id": "fc:fs:fs:prg:ntnu.no:MTIOT",
         "type": "fc:fs:prg",
         "displayName": "Industriell økonomi og teknologiledelse",
     }


### PR DESCRIPTION
We missed a single .lower(), so instead of having to add that every time you want to do something I think it's better to just keep them as uppercase, especially considering we get them like that from Feide.

![image](https://github.com/webkom/lego/assets/69514187/59d0ee66-3c94-4e98-a91d-dfe8e1ca9069)
