### PR TITLE
Remove report from search serializer

### DIFF
--- a/lego/apps/meetings/search_indexes.py
+++ b/lego/apps/meetings/search_indexes.py
@@ -10,13 +10,12 @@ class MeetingModelIndex(SearchIndex):
     result_fields = (
         "title",
         "description",
-        "report",
         "start_time",
     )
     autocomplete_result_fields = ("title", "start_time")
 
     autocomplete_fields = ("title", "description")
-    search_fields = ("title", "description", "report")
+    search_fields = ("title", "description")
 
     def get_autocomplete(self, instance):
         return instance.title

--- a/lego/apps/meetings/serializers.py
+++ b/lego/apps/meetings/serializers.py
@@ -124,7 +124,6 @@ class MeetingSearchSerializer(serializers.ModelSerializer):
             "id",
             "title",
             "description",
-            "report",
             "start_time",
         )
         read_only = True


### PR DESCRIPTION
In the future we may want to allow searching for meeting reports you are a part of but this is a quick fix for the security issue.

Resolves: ABA-563