### PR TITLE
Give permission to see Allergies for Event to Responsible Group

### DIFF
--- a/lego/apps/events/fixtures/test_events.yaml
+++ b/lego/apps/events/fixtures/test_events.yaml
@@ -198,6 +198,7 @@
     end_time: "2012-09-01T15:20:30+03:00"
     created_by: 1
     require_auth: False
+    responsible_group: 25
   
 - model: events.Pool
   pk: 1

--- a/lego/apps/events/models.py
+++ b/lego/apps/events/models.py
@@ -32,7 +32,7 @@ from lego.apps.files.models import FileField
 from lego.apps.followers.models import FollowEvent
 from lego.apps.permissions.models import ObjectPermissionsModel
 from lego.apps.users.constants import AUTUMN, SPRING
-from lego.apps.users.models import AbakusGroup, Penalty, User
+from lego.apps.users.models import AbakusGroup, Membership, Penalty, User
 from lego.utils.models import BasisModel
 from lego.utils.youtube_validator import youtube_validator
 
@@ -133,6 +133,15 @@ class Event(Content, BasisModel, ObjectPermissionsModel):
             or user.is_abakom_member
             or (self.created_by is not None and self.created_by.id == user.id)
         )
+
+    def user_should_see_allergies(self, user: User) -> bool:
+        memberships = Membership.objects.filter(user=user)
+        in_responsible_group = self.responsible_group in [
+            mem.abakus_group for mem in memberships
+        ]
+        created_by_self = user == self.created_by
+
+        return created_by_self or in_responsible_group
 
     def admin_register(
         self,

--- a/lego/apps/events/serializers/events.py
+++ b/lego/apps/events/serializers/events.py
@@ -327,6 +327,9 @@ class EventAdministrateSerializer(EventReadSerializer):
     pools = PoolAdministrateSerializer(many=True)
     unregistered = RegistrationReadDetailedSerializer(many=True)
     waiting_registrations = RegistrationReadDetailedSerializer(many=True)
+    responsible_group = AbakusGroupField(
+        queryset=AbakusGroup.objects.all(), required=False, allow_null=True
+    )
 
     class Meta(EventReadSerializer.Meta):
         fields = EventReadSerializer.Meta.fields + (  # type: ignore
@@ -337,6 +340,7 @@ class EventAdministrateSerializer(EventReadSerializer):
             "use_contact_tracing",
             "created_by",
             "feedback_required",
+            "responsible_group",
         )
 
 

--- a/lego/apps/events/serializers/events.py
+++ b/lego/apps/events/serializers/events.py
@@ -322,6 +322,7 @@ class EventReadAuthUserDetailedSerializer(EventReadUserDetailedSerializer):
         request = self.context.get("request", None)
         return request.user.unanswered_surveys()
 
+
 class EventAdministrateSerializer(EventReadSerializer, EventReadDetailedSerializer):
     pools = PoolAdministrateSerializer(many=True)
     unregistered = RegistrationReadDetailedSerializer(many=True)

--- a/lego/apps/events/serializers/events.py
+++ b/lego/apps/events/serializers/events.py
@@ -322,8 +322,7 @@ class EventReadAuthUserDetailedSerializer(EventReadUserDetailedSerializer):
         request = self.context.get("request", None)
         return request.user.unanswered_surveys()
 
-
-class EventAdministrateSerializer(EventReadSerializer):
+class EventAdministrateSerializer(EventReadSerializer, EventReadDetailedSerializer):
     pools = PoolAdministrateSerializer(many=True)
     unregistered = RegistrationReadDetailedSerializer(many=True)
     waiting_registrations = RegistrationReadDetailedSerializer(many=True)

--- a/lego/apps/events/views.py
+++ b/lego/apps/events/views.py
@@ -251,8 +251,7 @@ class EventViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
         event_id = self.kwargs.get("pk", None)
         serializer = EventAdministrateSerializer
         event = Event.objects.get(pk=event_id)
-
-        if request.user == event.created_by:
+        if event.user_should_see_allergies(request.user):
             serializer = EventAdministrateAllergiesSerializer
 
         event_data = serializer(event).data


### PR DESCRIPTION
Backend checks if user is part of responsible group when delegating authorization to view allergies.

The corresponding serializer has also been updated to include the "ResponsibleGroup" field so that frontend also can check if user should be able to see the allergy tab

Resolves: ABA-589