### PR TITLE
Add revue to the permitted groups for the contact form

### DIFF
--- a/lego/apps/contact/serializers.py
+++ b/lego/apps/contact/serializers.py
@@ -1,6 +1,7 @@
+from django.db.models import Q
 from rest_framework import exceptions, serializers
 
-from lego.apps.users.constants import GROUP_COMMITTEE
+from lego.apps.users.constants import GROUP_COMMITTEE, GROUP_REVUE
 from lego.apps.users.models import AbakusGroup
 from lego.utils.fields import PrimaryKeyRelatedFieldNoPKOpt
 from lego.utils.functions import verify_captcha
@@ -12,7 +13,10 @@ class ContactFormSerializer(serializers.Serializer):
     anonymous = serializers.BooleanField()
     captcha_response = serializers.CharField()
     recipient_group = PrimaryKeyRelatedFieldNoPKOpt(
-        allow_null=True, queryset=AbakusGroup.objects.all().filter(type=GROUP_COMMITTEE)
+        allow_null=True,
+        queryset=AbakusGroup.objects.all().filter(
+            Q(type=GROUP_COMMITTEE) | Q(type=GROUP_REVUE)
+        ),
     )
 
     def validate_captcha_response(self, captcha_response):


### PR DESCRIPTION
Initially, I wanted to add support for only contacting the revue board. However, the only way to achieve that would be to hardcode in the group id (or handle RevyStyret as a special group like we do Hovedstyret). I decided to just add support for all revue groups, because that was a lot easier. 

Related to [this PR](https://github.com/webkom/lego-webapp/pull/4221).