### PR TITLE
Change penalty ignore period to start at this years last event

### DIFF
--- a/lego/settings/lego.py
+++ b/lego/settings/lego.py
@@ -20,7 +20,7 @@ MANAGERS = ADMINS
 PENALTY_DURATION = timedelta(days=20)
 # Tuples for ignored (month, day) intervals
 PENALTY_IGNORE_SUMMER = ((6, 1), (8, 15))
-PENALTY_IGNORE_WINTER = ((12, 1), (1, 10))
+PENALTY_IGNORE_WINTER = ((11, 18), (1, 10))
 
 BEDKOM_BOOKING_PERIOD = ((10, 2), (10, 19))
 


### PR DESCRIPTION
As per this years slightly revised arrangement rules the penalty ignore/freeze period starts after the last event with registration. This year this is the Christmas Party at 11. Nov.