### PR TITLE
Enable filtering memberships by multiple roles

### DIFF
--- a/lego/apps/users/filters.py
+++ b/lego/apps/users/filters.py
@@ -1,11 +1,16 @@
 from django.db.models import F, Value
 from django.db.models.functions import Concat
-from django_filters.rest_framework import CharFilter, FilterSet
+from django_filters.rest_framework import BaseInFilter, CharFilter, FilterSet
 
 from lego.apps.users.models import AbakusGroup, Membership, MembershipHistory, Penalty
 
 
+class CharInFilter(BaseInFilter, CharFilter):
+    pass
+
+
 class MembershipFilterSet(FilterSet):
+    role = CharInFilter(field_name="role", lookup_expr="in")
     userUsername = CharFilter(field_name="user__username", lookup_expr="icontains")
     userFullname = CharFilter(field_name="userFullname", method="user__fullname")
     abakusGroupName = CharFilter(


### PR DESCRIPTION
Memberships can now be filtered by multiple roles - which makes it possible to do the same in the frontend.

Frontend PR: https://github.com/webkom/lego-webapp/pull/4257

The filtering still works the old way, so this should be good to merge regardless of the frontend PR

ABA-366