### PR TITLE
Individual reactions

### DIFF
--- a/lego/apps/meetings/serializers.py
+++ b/lego/apps/meetings/serializers.py
@@ -1,4 +1,3 @@
-from lego.apps.reactions.models import Reaction
 from rest_framework import serializers
 from rest_framework.fields import CharField
 
@@ -6,6 +5,7 @@ from lego.apps.comments.serializers import CommentSerializer
 from lego.apps.content.fields import ContentSerializerField
 from lego.apps.meetings import constants
 from lego.apps.meetings.models import Meeting, MeetingInvitation
+from lego.apps.reactions.models import Reaction
 from lego.apps.users.fields import PublicUserField
 from lego.apps.users.models import AbakusGroup, User
 from lego.apps.users.serializers.users import PublicUserSerializer
@@ -39,6 +39,7 @@ class MeetingInvitationUpdateSerializer(BasisModelSerializer):
 
 class ReactionsSerializer(serializers.ModelSerializer):
     author = PublicUserSerializer(read_only=True, source="created_by")
+
     class Meta:
         model = Reaction
         fields = ("id", "emoji", "author")

--- a/lego/apps/meetings/serializers.py
+++ b/lego/apps/meetings/serializers.py
@@ -1,3 +1,4 @@
+from lego.apps.reactions.models import Reaction
 from rest_framework import serializers
 from rest_framework.fields import CharField
 
@@ -36,6 +37,16 @@ class MeetingInvitationUpdateSerializer(BasisModelSerializer):
         fields = ("status",)
 
 
+class ReactionsSerializer(serializers.ModelSerializer):
+
+
+    author = PublicUserSerializer(read_only=True, source="created_by")
+    class Meta:
+        model = Reaction
+        fields = ("emoji", "created_by", "created_at", "author")
+        read_only = True
+
+
 class MeetingGroupInvite(serializers.Serializer):
     group = PrimaryKeyRelatedFieldNoPKOpt(queryset=AbakusGroup.objects.all())
 
@@ -63,6 +74,7 @@ class MeetingDetailSerializer(BasisModelSerializer):
     comments = CommentSerializer(read_only=True, many=True)
     content_target = CharField(read_only=True)
     reactions_grouped = serializers.SerializerMethodField()
+    reactions = ReactionsSerializer(many=True, read_only=True)
 
     def get_reactions_grouped(self, obj):
         user = self.context["request"].user
@@ -85,6 +97,7 @@ class MeetingDetailSerializer(BasisModelSerializer):
             "content_target",
             "mazemap_poi",
             "reactions_grouped",
+            "reactions",
         )
         read_only = True
 

--- a/lego/apps/meetings/serializers.py
+++ b/lego/apps/meetings/serializers.py
@@ -43,7 +43,7 @@ class ReactionsSerializer(serializers.ModelSerializer):
     author = PublicUserSerializer(read_only=True, source="created_by")
     class Meta:
         model = Reaction
-        fields = ("emoji", "created_by", "created_at", "author")
+        fields = ("id", "emoji", "created_by", "created_at", "author")
         read_only = True
 
 

--- a/lego/apps/meetings/serializers.py
+++ b/lego/apps/meetings/serializers.py
@@ -38,12 +38,10 @@ class MeetingInvitationUpdateSerializer(BasisModelSerializer):
 
 
 class ReactionsSerializer(serializers.ModelSerializer):
-
-
     author = PublicUserSerializer(read_only=True, source="created_by")
     class Meta:
         model = Reaction
-        fields = ("id", "emoji", "created_by", "created_at", "author")
+        fields = ("id", "emoji", "author")
         read_only = True
 
 


### PR DESCRIPTION
Adds a new field, `reactions` for the meeting serializer. This is used to show who reacted on the meeting on the frontend.

[Frontend PR](https://github.com/webkom/lego-webapp/pull/4271).

[Screencast from 08. nov. 2023 kl. 15.37 +0100.webm](https://github.com/webkom/lego/assets/33326578/c90c3893-d3ae-4dae-aee9-22c3086ff518)
