### PR TITLE
Fix sending announcements to meetings

### DIFF
--- a/lego/apps/notifications/serializers.py
+++ b/lego/apps/notifications/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from lego.apps.events.serializers.events import EventReadSerializer
-from lego.apps.meetings.serializers import MeetingDetailSerializer
+from lego.apps.meetings.serializers import MeetingListSerializer
 from lego.apps.users.serializers.abakus_groups import PublicAbakusGroupSerializer
 from lego.apps.users.serializers.users import PublicUserSerializer
 from lego.utils.serializers import BasisModelSerializer
@@ -30,7 +30,7 @@ class AnnouncementListSerializer(BasisModelSerializer):
     users = PublicUserSerializer(many=True, read_only=True)
     groups = PublicAbakusGroupSerializer(many=True, read_only=True)
     events = EventReadSerializer(many=True, read_only=True)
-    meetings = MeetingDetailSerializer(many=True, read_only=True)
+    meetings = MeetingListSerializer(many=True, read_only=True)
     from_group = PublicAbakusGroupSerializer(read_only=True)
 
     class Meta:


### PR DESCRIPTION
Announcement create with a meeting as recipient failed because the Announcement list serializer used a nested `MeetingDetailSerializer` which includes reactions. These reactions did not serialize well nested, and caused a crash. Fixed by using `MeetingListSerializer` instead, we didn't need any detailed data anyways.

ABA-685

