### PR TITLE
Remove user field from survey submission read serializer

### DIFF
--- a/lego/apps/surveys/serializers.py
+++ b/lego/apps/surveys/serializers.py
@@ -6,7 +6,6 @@ from rest_framework import exceptions, serializers
 from lego.apps.events.serializers.events import EventForSurveySerializer
 from lego.apps.surveys.constants import DISPLAY_TYPES, QUESTION_TYPES
 from lego.apps.surveys.models import Answer, Option, Question, Submission, Survey
-from lego.apps.users.serializers.users import PublicUserSerializer
 from lego.utils.serializers import BasisModelSerializer
 
 
@@ -93,11 +92,14 @@ class SurveyReadSerializer(BasisModelSerializer):
 
 class SubmissionReadSerializer(BasisModelSerializer):
     answers = AnswerSerializer(many=True)
-    user = PublicUserSerializer()
+    is_owner = serializers.SerializerMethodField()
 
     class Meta:
         model = Submission
-        fields = ("id", "user", "survey", "answers")
+        fields = ("id", "is_owner", "survey", "answers")
+
+    def get_is_owner(self, submission):
+        return submission.user == self.context["request"].user
 
 
 class SubmissionAdminReadSerializer(SubmissionReadSerializer):

--- a/lego/apps/surveys/tests/test_submissions_api.py
+++ b/lego/apps/surveys/tests/test_submissions_api.py
@@ -198,7 +198,8 @@ class SubmissionViewSetTestCase(APITestCase):
 
         expected = submission_data(self.admin_user, 1)
         result = response.json()
-        self.assertEqual(expected["user"], result["user"].get("id", None))
+        self.assertEqual(expected["survey"], result["survey"])
+        self.assertTrue(result["isOwner"])
 
         self.assertEqual(len(result["answers"]), 3)
         for i, answer in enumerate(result["answers"]):

--- a/lego/apps/surveys/views.py
+++ b/lego/apps/surveys/views.py
@@ -171,7 +171,9 @@ class SubmissionViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
         serializer.is_valid(raise_exception=True)
         self.perform_create(serializer)
         return Response(
-            SubmissionReadSerializer(serializer.instance).data,
+            SubmissionReadSerializer(
+                serializer.instance, context={"request": request}
+            ).data,
             status=status.HTTP_201_CREATED,
         )
 
@@ -198,7 +200,9 @@ class SubmissionViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
         submission, answer = self.validate_answer(request, **kwargs)
         answer.hide()
         return Response(
-            data=SubmissionAdminReadSerializer(submission).data,
+            data=SubmissionAdminReadSerializer(
+                submission, context={"request": request}
+            ).data,
             status=status.HTTP_202_ACCEPTED,
         )
 
@@ -212,7 +216,9 @@ class SubmissionViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
         submission, answer = self.validate_answer(request, **kwargs)
         answer.show()
         return Response(
-            data=SubmissionAdminReadSerializer(submission).data,
+            data=SubmissionAdminReadSerializer(
+                submission, context={"request": request}
+            ).data,
             status=status.HTTP_202_ACCEPTED,
         )
 


### PR DESCRIPTION
The surveys are supposedly anonymous, they are not when the user field is sent with the submission

Related frontend PR: https://github.com/webkom/lego-webapp/pull/4988

TODO:
- [x] Double-check that nothing breaks in lego-webapp, especially for non-admin users

Resolves ABA-273