### PR TITLE
Add admissions oauth fixture

### DIFF
--- a/lego/apps/oauth/fixtures/development_applications.yaml
+++ b/lego/apps/oauth/fixtures/development_applications.yaml
@@ -10,3 +10,18 @@
     skip_authorization: true
     created: '2016-01-1T10:00:00+00:00'
     updated: '2016-01-1T10:00:00+00:00'
+- model: oauth.APIApplication
+  pk: 2
+  fields:
+    client_id: sC6GkHr8GS2OSRpFzKL2aASnz2eTPLYqK8TAGihF
+    user: 3
+    redirect_uris: http://127.0.0.1:5000/complete/lego/
+    client_type: public
+    authorization_grant_type: authorization-code
+    client_secret: fBySp20wgSEcxGmFFHB8BHEqjGu0oU0e1QmDyQ7bU8GZLFsa3GIPAbXyYlbOxnwslZLKGEQJr96i9u50bL4Iq1wWQrmDPoUc8P7nJHAENbrw1l5HblOgDkoKvxPKHnk2
+    name: Opptak
+    skip_authorization: false
+    created: 2023-08-22 07:03:43.167045+00:00
+    updated: 2023-08-22 07:03:43.167059+00:00
+    algorithm: ''
+    description: Testopptak


### PR DESCRIPTION
Makes it so that you don't have to create your own oauth application when devving in admissions - you can just load the fixtures and voilá

![image](https://github.com/webkom/lego/assets/13599770/b4263041-a5d3-4dd1-8afb-62c486484df9)

you can log in with your local LEGO instance