### PR TITLE
Disable pagination in TagViewSet

### DIFF
--- a/lego/apps/tags/tests/test_views.py
+++ b/lego/apps/tags/tests/test_views.py
@@ -13,9 +13,7 @@ class TagViewsTestCase(APITestCase):
     def test_fetch_list(self):
         response = self.client.get("/api/v1/tags/")
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        self.assertDictEqual(
-            response.json()["results"][0], {"tag": "ababrygg", "usages": 0}
-        )
+        self.assertDictEqual(response.json()[0], {"tag": "ababrygg", "usages": 0})
 
     def test_fetch_detail(self):
         response = self.client.get("/api/v1/tags/ababrygg/")

--- a/lego/apps/tags/views.py
+++ b/lego/apps/tags/views.py
@@ -12,10 +12,11 @@ class TagViewSet(
     RetrieveModelMixin,
     viewsets.GenericViewSet,
 ):
-    queryset = Tag.objects.all()
+    queryset = Tag.objects.all().order_by("tag")
     ordering = "tag"
     serializer_class = TagListSerializer
     permission_classes = [permissions.AllowAny]
+    pagination_class = None
 
     def get_serializer_class(self):
         if self.action != "list":


### PR DESCRIPTION
We need all the tags at once for the [tag-cloud](https://abakus.no/tags) in frontend. It's better to just send them without pagination than to send a whole bunch of requests from the frontend to get them all.

This is a non-breaking change, as this will behave the same as if there was only one page in the paginated response.

Resolves ABA-884