### PR TITLE
Add validation for mail-list-recipients

### DIFF
--- a/lego/apps/email/tests/test_views.py
+++ b/lego/apps/email/tests/test_views.py
@@ -116,6 +116,21 @@ class EmailListTestCase(BaseAPITestCase):
         )
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
+    def test_create_list_no_recipients(self):
+        """Bad request when user tries to create list with no recipients"""
+        response = self.client.post(
+            self.url,
+            {
+                "name": "Webkom",
+                "email": "webbers",
+                "users": [],
+                "groups": [self.admin_group.id],
+                "group_roles": ["recruiting"],
+                "additional_emails": [],
+            },
+        )
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
+
     def test_edit_additional_email(self):
         """Test ability to remove an additional email"""
         response = self.client.patch(
@@ -138,7 +153,9 @@ class EmailListTestCase(BaseAPITestCase):
     def test_delete_additional_email(self):
         """Test ability to set additional emails to an empty array"""
 
-        response = self.client.patch(f"{self.url}1/", {"additional_emails": []})
+        response = self.client.patch(
+            f"{self.url}1/", {"additional_emails": [], "users": [1]}
+        )
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual([], EmailList.objects.get(id=1).additional_emails)
 
@@ -148,6 +165,29 @@ class EmailListTestCase(BaseAPITestCase):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
 
         self.assertEqual("address", EmailList.objects.get(id=1).email_id)
+
+    def test_edit_list_no_recipients(self):
+        """Bad request when user tries to edit list with no recipients"""
+        response = self.client.patch(
+            f"{self.url}1/",
+            {
+                "users": [],
+                "groups": [self.admin_group.id],
+                "group_roles": ["recruiting"],
+                "additional_emails": [],
+            },
+        )
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
+
+    def test_edit_list_no_recipients_partial(self):
+        """Bad request when user tries to edit list with no recipients"""
+        response = self.client.patch(
+            f"{self.url}1/",
+            {
+                "additional_emails": [],
+            },
+        )
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
     def test_delete_endpoint_not_available(self):
         """The delete endpoint is'nt available."""


### PR DESCRIPTION
Mail-lists with no recipients is not cool - and should thus not be allowed

Resolves ABA-897