### PR TITLE
Set password hash for external sync on newly created users

### DIFF
--- a/lego/apps/users/tests/test_password_change.py
+++ b/lego/apps/users/tests/test_password_change.py
@@ -47,6 +47,7 @@ class TestPasswordChange(BaseAPITestCase):
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
     def test_new_password_success(self):
+        old_password_hash = self.user.crypt_password_hash
         self.client.force_authenticate(self.user)
         response = self.client.post(
             self.url,
@@ -60,3 +61,4 @@ class TestPasswordChange(BaseAPITestCase):
         self.assertTrue(
             authenticate(username="test1", password="new_secret_password123")
         )
+        self.assertNotEqual(self.user.crypt_password_hash, old_password_hash)

--- a/lego/apps/users/tests/test_users_api.py
+++ b/lego/apps/users/tests/test_users_api.py
@@ -232,6 +232,7 @@ class CreateUsersAPITestCase(BaseAPITestCase):
         self.assertEqual(new_user.is_superuser, False)
         self.assertEqual(new_user.is_abakus_member, False)
         self.assertEqual(new_user.is_abakom_member, False)
+        self.assertNotEqual(new_user.crypt_password_hash, "")
 
         # Test member groups
         user_group = AbakusGroup.objects.get(name=constants.USER_GROUP)

--- a/lego/apps/users/views/users.py
+++ b/lego/apps/users/views/users.py
@@ -116,6 +116,8 @@ class UsersViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
         serializer.is_valid(raise_exception=True)
 
         user = User.objects.create_user(email=token_email, **serializer.validated_data)
+        user.set_password(serializer.validated_data["password"])
+        user.save()
 
         user_group = AbakusGroup.objects.get(name=constants.USER_GROUP)
         user_group.add_user(user)


### PR DESCRIPTION
The reason GSuite sync only works after changing password, is that the password hash used for external sync was not set correctly when creating users. The logic for setting this hash is implemented in the `set_password()` method which is not called when creating a new user. 

I wasn't able to add any logic with access to the new password in the `PasswordHashUser`-model, so I just added a call to `set_password` right after creating new user.

resolves ABA-578

Although this will fix the problem for new users, there is still probably a lot of users that have never changed their password and thus do not have the saved hash. It might be worth adding some warning whenever we try to sync a user with a missing hash.