### PR TITLE
Resolve typo of "backend"

### DIFF
--- a/lego/apps/search/backend.py
+++ b/lego/apps/search/backend.py
@@ -1,7 +1,7 @@
 from . import registry
 
 
-class SearchBacked:
+class SearchBackend:
     """
     Base class for search backends. A backend needs to implement all methods on this class to work
     like it should.

--- a/lego/apps/search/backends/elasticsearch.py
+++ b/lego/apps/search/backends/elasticsearch.py
@@ -6,10 +6,10 @@ import certifi
 from elasticsearch import Elasticsearch, NotFoundError
 from elasticsearch.helpers import bulk
 
-from lego.apps.search.backend import SearchBacked
+from lego.apps.search.backend import SearchBackend
 
 
-class ElasticsearchBackend(SearchBacked):
+class ElasticsearchBackend(SearchBackend):
     name = "elasticsearch"
 
     connection = None

--- a/lego/apps/search/backends/postgres.py
+++ b/lego/apps/search/backends/postgres.py
@@ -1,9 +1,9 @@
-from lego.apps.search.backend import SearchBacked
+from lego.apps.search.backend import SearchBackend
 
 from .. import registry
 
 
-class PostgresBackend(SearchBacked):
+class PostgresBackend(SearchBackend):
     name = "postgres"
 
     max_results = 10

--- a/lego/apps/users/fixtures/initial_abakus_groups.py
+++ b/lego/apps/users/fixtures/initial_abakus_groups.py
@@ -30,11 +30,12 @@ initial_tree = {
         {
             "description": "Medlemmer av Abakus",
             "permissions": [
-                "/sudo/admin/meetings/create",
-                "/sudo/admin/meetinginvitations/create",
+                "/sudo/admin/meetings/create/",
+                "/sudo/admin/meetinginvitations/create/",
                 "/sudo/admin/registrations/create/",
                 "/sudo/admin/events/payment/",
-                "/sudo/admin/comments/create",
+                "/sudo/admin/comments/create/",
+                "/sudo/admin/meetings/list/",
             ],
         },
         {

--- a/lego/apps/users/fixtures/initial_abakus_groups.yaml
+++ b/lego/apps/users/fixtures/initial_abakus_groups.yaml
@@ -30,8 +30,8 @@
     logo: null
     type: annen
     text: ''
-    permissions: '["/sudo/admin/meetings/create", "/sudo/admin/meetinginvitations/create",
-      "/sudo/admin/registrations/create/", "/sudo/admin/events/payment/", "/sudo/admin/comments/create"]'
+    permissions: '["/sudo/admin/meetings/create/", "/sudo/admin/meetinginvitations/create/",
+      "/sudo/admin/registrations/create/", "/sudo/admin/events/payment/", "/sudo/admin/comments/create/", "/sudo/admin/meetings/list/"]'
     show_badge: true
     active: true
     lft: 1

--- a/lego/apps/users/fixtures/test_abakus_groups.yaml
+++ b/lego/apps/users/fixtures/test_abakus_groups.yaml
@@ -325,7 +325,7 @@
     logo: null
     type: annen
     text: ''
-    permissions: '["/sudo/admin/meetings/create", "/sudo/admin/meetinginvitations/create",
+    permissions: '["/sudo/admin/meetings/create/", "/sudo/admin/meetinginvitations/create/",
       "/sudo/admin/registrations/create/", "/sudo/admin/events/payment/"]'
     show_badge: true
     active: true


### PR DESCRIPTION
Resolve lil typo

Fix incorrect fixtures. The missing slashes made it impossible to add/remove permissions for those groups as the remaining ones did not pass validation. Also added meeting list to Abakus to mirror prod