### PR TITLE
Disable logging if analytics key is not set

### DIFF
--- a/lego/apps/stats/analytics_client.py
+++ b/lego/apps/stats/analytics_client.py
@@ -20,6 +20,9 @@ def setup_analytics():
     write_key = getattr(settings, "ANALYTICS_WRITE_KEY", "")
     host = getattr(settings, "ANALYTICS_HOST", "https://api.segment.io")
 
+    if write_key == "":
+        return
+
     production = getattr(settings, "ENVIRONMENT_NAME", None) == "production"
     send = not (development or getattr(settings, "TESTING", False)) or production
 
@@ -35,6 +38,9 @@ def setup_analytics():
 
 def _proxy(method, user, *args, **kwargs):
     global default_client, development
+
+    if default_client is None:
+        return
 
     fn = getattr(default_client, method)
 


### PR DESCRIPTION
The logging errors do be kinda annoying, and as far as I understand it there should be no need to try to log errors if the key is not present.

We could always disable the sentry errors for slack, but that would still entail a shit ton of unnecessary network traffic..