### PR TITLE
Prevent error when anonymous user requests allergies

### DIFF
--- a/lego/apps/events/models.py
+++ b/lego/apps/events/models.py
@@ -134,6 +134,8 @@ class Event(Content, BasisModel, ObjectPermissionsModel):
         )
 
     def user_should_see_allergies(self, user: User) -> bool:
+        if user.is_anonymous:
+            return False
         memberships = Membership.objects.filter(user=user)
         in_responsible_group = self.responsible_group in [
             mem.abakus_group for mem in memberships


### PR DESCRIPTION
Should fix this error in [sentry](https://abakus.sentry.io/issues/5265702117/?referrer=slack&notification_uuid=96546d5e-aa8b-44ce-8679-aaf95fb0fdf7&alert_rule_id=1071606&alert_type=issue)

Difficult to test since anonymous users do not have access to the administrate pages, but this does not break correct functionality at least. 