### PR TITLE
Save missing password hash on login

### DIFF
--- a/lego/api/tests/test_authentication.py
+++ b/lego/api/tests/test_authentication.py
@@ -38,6 +38,23 @@ class JSONWebTokenTestCase(BaseAPITestCase):
         self.assertContains(response, text="token", status_code=status.HTTP_201_CREATED)
         self.assertContains(response, text="user", status_code=status.HTTP_201_CREATED)
 
+    def test_crypt_hash_generated_on_successfull_auth(self):
+        user = User.objects.get(pk=12)
+        self.assertEqual(user.crypt_password_hash, "")
+        user_data = {"username": user.username, "password": "test"}
+        response = self.client.post(reverse("jwt:obtain_jwt_token"), user_data)
+        self.assertContains(response, text="token", status_code=status.HTTP_201_CREATED)
+        self.assertContains(response, text="user", status_code=status.HTTP_201_CREATED)
+        self.assertNotEqual(User.objects.get(pk=12).crypt_password_hash, "")
+
+    def test_crypt_hash_not_generated_on_failed_auth(self):
+        user = User.objects.get(pk=12)
+        self.assertEqual(user.crypt_password_hash, "")
+        user_data = {"username": user.username, "password": "tes"}
+        response = self.client.post(reverse("jwt:obtain_jwt_token"), user_data)
+        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(User.objects.get(pk=12).crypt_password_hash, "")
+
     def test_refresh(self):
         token_response = self.client.post(
             reverse("jwt:obtain_jwt_token"), self.user_data

--- a/lego/apps/users/fixtures/test_users.yaml
+++ b/lego/apps/users/fixtures/test_users.yaml
@@ -101,3 +101,16 @@
     last_name: medlem
     email: allergies@abakus.no
     allergies: "Vegetar"
+
+- model: users.User
+  pk: 12
+  fields:
+    username: test12
+    student_username: test12student
+    student_verification_status: true
+    password: pbkdf2_sha256$24000$zowF0cRkFimt$qzeoY9hZ0X3zDhlG0FP8imaGto8S2N6ed1AMp83xcn4= # test
+    gender: female
+    first_name: test
+    last_name: user12
+    email: test12@user.com
+    crypt_password_hash: ''

--- a/lego/urls.py
+++ b/lego/urls.py
@@ -6,13 +6,31 @@ from django.views.generic import TemplateView
 from rest_framework.documentation import include_docs_urls
 
 from rest_framework_jwt.views import (
-    obtain_jwt_token,
+    ObtainJSONWebTokenView,
     refresh_jwt_token,
     verify_jwt_token,
 )
 
 from lego.api.urls import urlpatterns as api
+from lego.apps.users.models import User
 from lego.utils.types import URLList
+
+
+# START
+# Temporary view to generate crypt_hashes for the users that do not have it
+class TokenAuthView(ObtainJSONWebTokenView):
+    def post(self, request, *args, **kwargs):
+        result = super().post(request, *args, **kwargs)
+        # If the login is invalid it would have raised an exception by this point
+        user = User.objects.get(username=request.data.get("username"))
+        if user.crypt_password_hash == "":
+            user.set_password(request.data.get("password"))
+            user.save()
+        return result
+
+
+obtain_jwt_token = TokenAuthView.as_view()
+# END
 
 jwt_urlpatterns: URLList = [
     re_path(r"^token-auth/$", obtain_jwt_token, name="obtain_jwt_token"),


### PR DESCRIPTION
Not the cleanest code out there but for something that has to piggybank on the token generation to be able to generate the hash properly it felt like one of the most reliable ways of doing it as all the important logic is still performed by the rest_framework_jwt.

Open to other suggestions if anyone has any

Will need to be tested in staging to feel better about it, but works just fine for me locally.

The idea is to leave this in prod for a while to generate some hashes, and when the number of missing hashes is low enough we revert the PR.

Resolves ABA-920