### PR TITLE
Retrieve user the same way the token generator does

### DIFF
--- a/lego/api/tests/test_authentication.py
+++ b/lego/api/tests/test_authentication.py
@@ -47,6 +47,15 @@ class JSONWebTokenTestCase(BaseAPITestCase):
         self.assertContains(response, text="user", status_code=status.HTTP_201_CREATED)
         self.assertNotEqual(User.objects.get(pk=12).crypt_password_hash, "")
 
+    def test_crypt_hash_generated_on_successfull_auth_case(self):
+        user = User.objects.get(pk=12)
+        self.assertEqual(user.crypt_password_hash, "")
+        user_data = {"username": "tEsT12", "password": "test"}
+        response = self.client.post(reverse("jwt:obtain_jwt_token"), user_data)
+        self.assertContains(response, text="token", status_code=status.HTTP_201_CREATED)
+        self.assertContains(response, text="user", status_code=status.HTTP_201_CREATED)
+        self.assertNotEqual(User.objects.get(pk=12).crypt_password_hash, "")
+
     def test_crypt_hash_not_generated_on_failed_auth(self):
         user = User.objects.get(pk=12)
         self.assertEqual(user.crypt_password_hash, "")

--- a/lego/urls.py
+++ b/lego/urls.py
@@ -22,7 +22,7 @@ class TokenAuthView(ObtainJSONWebTokenView):
     def post(self, request, *args, **kwargs):
         result = super().post(request, *args, **kwargs)
         # If the login is invalid it would have raised an exception by this point
-        user = User.objects.get(username=request.data.get("username"))
+        user = User._default_manager.get_by_natural_key(request.data.get("username"))
         if user.crypt_password_hash == "":
             user.set_password(request.data.get("password"))
             user.save()


### PR DESCRIPTION
Resolves bug in https://github.com/webkom/lego/pull/3602 where inserting the username in the wrong case would raise errors as the user was not found.