### PR TITLE
Fix error with registering or unregistering in local development

### DIFF
--- a/lego/apps/feeds/models.py
+++ b/lego/apps/feeds/models.py
@@ -149,7 +149,7 @@ class TimelineStorage(models.Model):
         """
         for aggregated_id in aggregated_ids:
             try:
-                cls.objects.create(
+                cls.objects.update_or_create(
                     activity_id=str(activity_id),
                     feed=feed._meta.model_name,
                     aggregated_id=aggregated_id,


### PR DESCRIPTION
This works in prod because the feed stuff runs in a separate thread i think. The problem is related to the atomic transactions when registering/unregistering and that they fail when this try/catch block executes an invalid database query.

I don't think this will break anything else, but honestly I don't understand very well how feeds work so I'm not sure.

Imo. we should rip out all the feed code and replace it with a simple notification object type, feeds are wayy to complicated for what they do