### PR TITLE
Add info for calculating waiting list position within pools

### DIFF
--- a/lego/apps/events/serializers/registrations.py
+++ b/lego/apps/events/serializers/registrations.py
@@ -18,7 +18,7 @@ from lego.apps.users.serializers.users import (
     AdministrateUserAllergiesSerializer,
     AdministrateUserExportSerializer,
     AdministrateUserSerializer,
-    PublicUserSerializer,
+    PublicUserWithAbakusGroupsSerializer,
 )
 from lego.utils.fields import PrimaryKeyRelatedFieldNoPKOpt
 from lego.utils.serializers import BasisModelSerializer
@@ -80,7 +80,7 @@ class RegistrationAnonymizedReadSerializer(BasisModelSerializer):
 
 
 class RegistrationPublicReadSerializer(BasisModelSerializer):
-    user = PublicUserSerializer()
+    user = PublicUserWithAbakusGroupsSerializer()
 
     class Meta:
         model = Registration

--- a/lego/apps/users/serializers/users.py
+++ b/lego/apps/users/serializers/users.py
@@ -84,19 +84,24 @@ class PublicUserSerializer(serializers.ModelSerializer):
 
 class PublicUserWithAbakusGroupsSerializer(PublicUserSerializer):
     abakus_groups = PublicAbakusGroupSerializer(many=True)
-
-    class Meta(PublicUserSerializer.Meta):
-        fields = PublicUserSerializer.Meta.fields + ("abakus_groups",)  # type: ignore
-
-
-class PublicUserWithGroupsSerializer(PublicUserSerializer):
-    abakus_groups = PublicAbakusGroupSerializer(many=True)
-    past_memberships = PastMembershipSerializer(many=True)
-    memberships = MembershipSerializer(many=True)
+    all_abakus_group_ids = serializers.SerializerMethodField()
 
     class Meta(PublicUserSerializer.Meta):
         fields = PublicUserSerializer.Meta.fields + (  # type: ignore
             "abakus_groups",
+            "all_abakus_group_ids",
+        )
+
+    def get_all_abakus_group_ids(self, user):
+        return [group.id for group in user.all_groups]
+
+
+class PublicUserWithGroupsSerializer(PublicUserWithAbakusGroupsSerializer):
+    past_memberships = PastMembershipSerializer(many=True)
+    memberships = MembershipSerializer(many=True)
+
+    class Meta(PublicUserSerializer.Meta):
+        fields = PublicUserWithAbakusGroupsSerializer.Meta.fields + (  # type: ignore
             "past_memberships",
             "memberships",
         )


### PR DESCRIPTION
When calculating the waiting list position per pool, we need to know what users from the waiting list are applicable for each one. By sending all groups (including inherited) each user in the waiting list are a member of, we can check who can is applicable for each pool, and thus calculate how many will be bumped to that pool before you.

Related frontend PR: https://github.com/webkom/lego-webapp/pull/4983

ABA-1070