### PR TITLE
Automatically give penalty when payment is overdue

### DIFF
--- a/lego/apps/events/templates/events/email/payment_overdue_penalty.html
+++ b/lego/apps/events/templates/events/email/payment_overdue_penalty.html
@@ -1,0 +1,47 @@
+{% extends "email/base.html" %}
+
+{% block alert %}
+
+    <tr>
+        <td class="alert alert-bad">
+            Du har ikke betalt påmelding til et arrangement. Du har derfor mottatt en prikk og blitt avmeldt arrangementet.
+        </td>
+    </tr>
+
+{% endblock %}
+
+{% block content %}
+
+    <tr>
+        <td class="content-block">
+            Hei, {{ first_name }}!
+        </td>
+    </tr>
+
+    <tr>
+        <td class="content-block">
+            Du har ikke betalt for {{ event }} og fristen for betaling har gått ut. 
+            Dermed har du blitt avregistrert fra arrangementet og mottatt en prikk med vekt {{ weight }}.
+            Du har også blitt avregistrert fra arrangementet.
+        </td>
+    </tr>
+
+    <tr>
+        <td class="button">
+          <div>
+            <!--[if mso]>
+            <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{ frontend_url }}/events/{{ id }}" style="height:45px;v-text-anchor:middle;width:155px;" arcsize="15%" strokecolor="#ffffff" fillcolor="#c0392b">
+                <w:anchorlock/>
+                <center style="color:#ffffff;font-family:Helvetica, Arial, sans-serif;font-size:14px;font-weight:regular;">Betal her</center>
+            </v:roundrect>
+            <![endif]-->
+            <a class="btn-primary" href="{{ frontend_url }}/events/{{ id }}"
+                style="background-color:#c0392b;border-radius:5px;color:#ffffff;display:inline-block;font-family:'Cabin', Helvetica, Arial, sans-serif;font-size:14px;font-weight:regular;line-height:45px;text-align:center;text-decoration:none;width:155px;-webkit-text-size-adjust:none;mso-hide:all;">
+                Betal her
+            </a>
+          </div>
+        </td>
+    </tr>
+
+
+{% endblock %}

--- a/lego/apps/events/templates/events/email/payment_overdue_penalty.txt
+++ b/lego/apps/events/templates/events/email/payment_overdue_penalty.txt
@@ -1,0 +1,13 @@
+{% extends "email/base.txt" %}
+
+{% block content %}
+
+Hei, {{ first_name }}!
+
+Du har ikke betalt for {{ event }} og fristen for betaling har gått ut. 
+
+Dermed har du blitt avregistrert fra arrangementet og mottatt en prikk med vekt {{ weight }}.
+
+Du kan se alle prikkene dine på {{ frontend_url }}/users/me/
+
+{% endblock %}

--- a/lego/apps/events/tests/test_async_tasks.py
+++ b/lego/apps/events/tests/test_async_tasks.py
@@ -10,6 +10,7 @@ from lego.apps.events.exceptions import PoolCounterNotEqualToRegistrationCount
 from lego.apps.events.models import Event, Registration
 from lego.apps.events.tasks import (
     AsyncRegister,
+    assign_penalties_and_unregister_when_payment_overdue,
     async_register,
     async_retrieve_payment,
     bump_waiting_users_to_new_pool,
@@ -20,6 +21,7 @@ from lego.apps.events.tasks import (
     set_all_events_ready_and_bump,
 )
 from lego.apps.events.tests.utils import get_dummy_users, make_penalty_expire
+from lego.apps.users.constants import PENALTY_WEIGHTS
 from lego.apps.users.models import AbakusGroup, Penalty
 from lego.utils.test_utils import BaseAPITestCase, BaseTestCase
 
@@ -779,4 +781,70 @@ class PaymentDueTestCase(BaseTestCase):
         self.event.save()
 
         notify_event_creator_when_payment_overdue.delay()
+        mock_notification.assert_not_called()
+
+    @mock.patch("lego.apps.events.tasks.EventPaymentOverduePenaltyNotification")
+    def test_user_is_given_penalty_is_unregistered_and_notified(
+        self, mock_notification
+    ):
+        """Test that user is given a penalty, is unregistered and notified when payment is overdue"""
+
+        self.event.payment_due_date = timezone.now() - timedelta(days=2)
+        self.event.save()
+
+        user = get_dummy_users(1)[0]
+        AbakusGroup.objects.get(name="Abakus").add_user(user)
+        registration_two = Registration.objects.get_or_create(
+            event=self.event, user=user
+        )[0]
+        registration_two.payment_status = constants.PAYMENT_PENDING
+        self.event.register(registration_two)
+
+        number_of_registrations_before = self.event.number_of_registrations
+        number_of_penalties_before = registration_two.user.number_of_penalties()
+
+        assign_penalties_and_unregister_when_payment_overdue.delay()
+        registration_two.refresh_from_db()
+
+        self.assertLess(
+            self.event.number_of_registrations, number_of_registrations_before
+        )
+        self.assertEqual(registration_two.status, constants.SUCCESS_UNREGISTER)
+        self.assertEqual(
+            registration_two.user.number_of_penalties(),
+            number_of_penalties_before + int(PENALTY_WEIGHTS.PAYMENT_OVERDUE),
+        )
+        mock_notification.assert_called()
+        call = mock_notification.mock_calls[2]
+        self.assertEqual(call[2]["user"], user)
+
+    @mock.patch("lego.apps.events.tasks.EventPaymentOverduePenaltyNotification")
+    def test_user_is_not_given_penalty_is_not_unregistered_and_not_notified(
+        self, mock_notification
+    ):
+        """Test that user is NOT given a penalty, is unregistered and notified when payment is overdue"""
+        self.event.payment_due_date = timezone.now() + timedelta(days=2)
+        self.event.save()
+
+        user = get_dummy_users(1)[0]
+        AbakusGroup.objects.get(name="Abakus").add_user(user)
+        registration_two = Registration.objects.get_or_create(
+            event=self.event, user=user
+        )[0]
+        registration_two.payment_status = constants.PAYMENT_PENDING
+        self.event.register(registration_two)
+
+        number_of_registrations_before = self.event.number_of_registrations
+        number_of_penalties_before = registration_two.user.number_of_penalties()
+
+        assign_penalties_and_unregister_when_payment_overdue.delay()
+        registration_two.refresh_from_db()
+
+        self.assertEqual(
+            self.event.number_of_registrations, number_of_registrations_before
+        )
+        self.assertEqual(registration_two.status, constants.SUCCESS_REGISTER)
+        self.assertEqual(
+            registration_two.user.number_of_penalties(), number_of_penalties_before
+        )
         mock_notification.assert_not_called()

--- a/lego/apps/notifications/constants.py
+++ b/lego/apps/notifications/constants.py
@@ -14,6 +14,7 @@ EVENT_ADMIN_REGISTRATION = "event_admin_registration"
 EVENT_ADMIN_UNREGISTRATION = "event_admin_unregistration"
 EVENT_PAYMENT_OVERDUE = "event_payment_overdue"
 EVENT_PAYMENT_OVERDUE_CREATOR = "event_payment_overdue_creator"
+EVENT_PAYMENT_OVERDUE_PENALTY = "event_payment_overdue_penalty"
 
 # Meeting
 MEETING_INVITE = "meeting_invite"

--- a/lego/apps/users/constants.py
+++ b/lego/apps/users/constants.py
@@ -151,6 +151,7 @@ LATE_PRESENCE_PENALTY_WEIGHT = 1
 
 class PENALTY_WEIGHTS(models.TextChoices):
     LATE_PRESENCE = 1
+    PAYMENT_OVERDUE = 2
 
 
 class PENALTY_TYPES(models.TextChoices):

--- a/lego/settings/celery.py
+++ b/lego/settings/celery.py
@@ -54,6 +54,10 @@ schedule = {
     },
     "notify_event_creator_when_payment_overdue": {
         "task": "lego.apps.events.tasks.notify_event_creator_when_payment_overdue",
+        "schedule": crontab(hour=21, minute=0),
+    },
+    "assign_penalties_and_unregister_when_payment_overdue": {
+        "task": "lego.apps.events.tasks.assign_penalties_and_unregister_when_payment_overdue",
         "schedule": crontab(hour=9, minute=0),
     },
     "sync-external-systems": {


### PR DESCRIPTION
Currently this checks every day at 0900 if there is any events with overdue payments. If so it gives penalty to the users who have not paid, unregisters them from the event and sends notification. 

There is still some things that I need to fix:

- Check if a user paid after the payment deadline and not just at 0900. As this effectively moves the deadline to 0900 the day after the given payment deadline. But then maybe not unregister them if they actually has paid, only give penalty?
- Test it more.
- Some clean up and better function description