### PR TITLE
Fix comment reaction notification preventing event update

### DIFF
--- a/lego/apps/comments/serializers.py
+++ b/lego/apps/comments/serializers.py
@@ -33,7 +33,9 @@ class CommentSerializer(BasisModelSerializer):
         )
 
     def get_reactions_grouped(self, obj):
-        user = self.context["request"].user
+        user = None
+        if "request" in self.context:
+            user = self.context["request"].user
         return obj.get_reactions_grouped(user)
 
     def validate(self, attrs):


### PR DESCRIPTION
Small change to ensure that the `user` variable is only set if the "request" key is present in the context, which currently prevents some events from being updated.  

ABA-1106