### PR TITLE
Remove unused DetailedUserSerializer

### DIFF
--- a/lego/apps/jwt/handlers.py
+++ b/lego/apps/jwt/handlers.py
@@ -1,7 +1,7 @@
 from rest_framework_jwt.settings import api_settings
 
 from lego.apps.stats.utils import track
-from lego.apps.users.serializers.users import MeSerializer
+from lego.apps.users.serializers.users import CurrentUserSerializer
 
 jwt_payload_handler = api_settings.JWT_PAYLOAD_HANDLER
 jwt_encode_handler = api_settings.JWT_ENCODE_HANDLER
@@ -13,7 +13,7 @@ def response_handler(token, user=None, request=None, issued_at=None):
     which includes the serialized representation of the User.
     """
     track(user, "authenticate")
-    return {"token": token, "user": MeSerializer(user).data}
+    return {"token": token, "user": CurrentUserSerializer(user).data}
 
 
 def get_jwt_token(user):

--- a/lego/apps/users/serializers/users.py
+++ b/lego/apps/users/serializers/users.py
@@ -15,47 +15,6 @@ from lego.apps.users.serializers.photo_consents import PhotoConsentSerializer
 from lego.utils.fields import PrimaryKeyRelatedFieldNoPKOpt
 
 
-class DetailedUserSerializer(serializers.ModelSerializer):
-    abakus_groups = PublicAbakusGroupSerializer(many=True)
-    past_memberships = PastMembershipSerializer(many=True)
-    penalties = serializers.SerializerMethodField("get_valid_penalties")
-    profile_picture = ImageField(required=False, options={"height": 200, "width": 200})
-    profile_picture_placeholder = ImageField(
-        source="profile_picture",
-        required=False,
-        options={"height": 20, "width": 20, "filters": ["blur(20)"]},
-    )
-
-    def get_valid_penalties(self, user):
-        qs = Penalty.objects.valid().filter(user=user)
-        serializer = PenaltySerializer(instance=qs, many=True)
-        return serializer.data
-
-    class Meta:
-        model = User
-        fields = (
-            "id",
-            "username",
-            "first_name",
-            "last_name",
-            "full_name",
-            "gender",
-            "email",
-            "email_address",
-            "email_lists_enabled",
-            "profile_picture",
-            "profile_picture_placeholder",
-            "allergies",
-            "is_active",
-            "penalties",
-            "abakus_groups",
-            "past_memberships",
-            "permissions_per_group",
-            "github_username",
-            "linkedin_id",
-        )
-
-
 class PublicUserSerializer(serializers.ModelSerializer):
     profile_picture = ImageField(required=False, options={"height": 200, "width": 200})
     profile_picture_placeholder = ImageField(
@@ -205,7 +164,7 @@ class Oauth2UserDataSerializer(serializers.ModelSerializer):
         return user.is_verified_student()
 
 
-class MeSerializer(serializers.ModelSerializer):
+class CurrentUserSerializer(serializers.ModelSerializer):
     """
     Serializer for the /me, retrieve and update endpoint with EDIT permissions.
     Also used by our JWT handler and returned to the user when a user obtains a JWT token.

--- a/lego/apps/users/views/password_reset.py
+++ b/lego/apps/users/views/password_reset.py
@@ -11,7 +11,7 @@ from lego.apps.users.serializers.password_reset import (
     PasswordResetPerformSerializer,
     PasswordResetRequestSerializer,
 )
-from lego.apps.users.serializers.users import DetailedUserSerializer
+from lego.apps.users.serializers.users import CurrentUserSerializer
 from lego.utils.tasks import send_email
 
 log = get_logger()
@@ -67,4 +67,4 @@ class PasswordResetPerformViewSet(viewsets.GenericViewSet):
 
         user.set_password(password)
         user.save()
-        return Response(DetailedUserSerializer(user).data, status=status.HTTP_200_OK)
+        return Response(CurrentUserSerializer(user).data, status=status.HTTP_200_OK)

--- a/lego/apps/users/views/users.py
+++ b/lego/apps/users/views/users.py
@@ -17,7 +17,7 @@ from lego.apps.users.serializers.photo_consents import PhotoConsentSerializer
 from lego.apps.users.serializers.registration import RegistrationConfirmationSerializer
 from lego.apps.users.serializers.users import (
     ChangeGradeSerializer,
-    MeSerializer,
+    CurrentUserSerializer,
     Oauth2UserDataSerializer,
     PublicUserSerializer,
     PublicUserWithGroupsSerializer,
@@ -39,7 +39,7 @@ class UsersViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
 
     def get_serializer_class(self):
         """
-        Users should receive the DetailedUserSerializer if they tries to get themselves or have the
+        Users should receive the CurrentUserSerializer if they try to get themselves or have the
         EDIT permission.
         """
         if self.action in ["retrieve", "update", "partial_update"]:
@@ -52,7 +52,7 @@ class UsersViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
                 self.request.user.has_perm(EDIT, instance)
                 or self.request.user == instance
             ):
-                return MeSerializer
+                return CurrentUserSerializer
 
             return PublicUserWithGroupsSerializer
 
@@ -89,7 +89,7 @@ class UsersViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
         detail=False,
         methods=["GET"],
         permission_classes=[IsAuthenticated],
-        serializer_class=MeSerializer,
+        serializer_class=CurrentUserSerializer,
     )
     def me(self, request):
         """
@@ -173,7 +173,7 @@ class UsersViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
             if newGrade is not None:
                 newGrade.add_user(user)
 
-        return Response(MeSerializer(user).data)
+        return Response(CurrentUserSerializer(user).data)
 
     def destroy(self, request, *args, **kwargs):
         return Response(status=status.HTTP_405_METHOD_NOT_ALLOWED)
@@ -196,4 +196,4 @@ class UsersViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
 
         serializer.save()
 
-        return Response(MeSerializer(user).data)
+        return Response(CurrentUserSerializer(user).data)


### PR DESCRIPTION
Well, almost unused. Replaced the usage in the response of reset_password with `MeSerializer`. I also renamed `MeSerializer` to `CurrentUserSerializer`, I think this makes more sense and that is also what it's called in frontend.

Seems like `DetailedUserSerializer` was previously used for the current user.