### PR TITLE
Unauthed users should not see various registration counts

### DIFF
--- a/lego/apps/events/fields.py
+++ b/lego/apps/events/fields.py
@@ -217,3 +217,28 @@ class PublicEventListField(serializers.ManyRelatedField):
 
         kwargs["child_relation"] = PublicEventField(**field_kwargs)
         super().__init__(**kwargs)
+
+
+# Unauthenticated users shouldn't be able to see registration count or total capacity
+
+
+class RegistrationCountField(serializers.Field):
+    def get_attribute(self, instance):
+        return instance
+
+    def to_representation(self, value):
+        request = self.context.get("request", None)
+        if request and request.user.is_authenticated:
+            return value.registration_count
+        return None
+
+
+class TotalCapacityField(serializers.Field):
+    def get_attribute(self, instance):
+        return instance
+
+    def to_representation(self, value):
+        request = self.context.get("request", None)
+        if request and request.user.is_authenticated:
+            return value.total_capacity
+        return None

--- a/lego/apps/events/serializers/pools.py
+++ b/lego/apps/events/serializers/pools.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 
+from lego.apps.events.fields import RegistrationCountField
 from lego.apps.events.models import Event, Pool
 from lego.apps.events.serializers.registrations import (
     RegistrationPaymentReadSerializer,
@@ -14,6 +15,7 @@ from lego.utils.serializers import BasisModelSerializer
 
 class PoolReadSerializer(BasisModelSerializer):
     permission_groups = PublicAbakusGroupSerializer(many=True)
+    registration_count = RegistrationCountField()
 
     class Meta:
         model = Pool


### PR DESCRIPTION
Requested by Bedkom at KLF

<table>
    <tr>
		<td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>	
		<td>Unauthenticated</td>
        <td>
			<img src="https://github.com/user-attachments/assets/6f431bfe-7b85-44f9-8e80-377fefb3ccff" />
        </td>
        <td>
			<img src="https://github.com/user-attachments/assets/e7011d62-ce5c-4f95-97ad-3ca86487e5cc" />
        </td>
	</tr>
    <tr>
		<td>Authenticated (same as before)</td>
        <td>
			<img src="https://github.com/user-attachments/assets/eeca7820-27c9-4e88-86b5-485716f7c9b1" />
        </td>
        <td>
			<img src="https://github.com/user-attachments/assets/c02eef2b-80d4-4391-8c97-12ac2a1cd696" />
        </td>
	</tr>
</table>