### PR TITLE
Prefetch more stuff needed in event detail page

### DIFF
--- a/lego/apps/users/serializers/users.py
+++ b/lego/apps/users/serializers/users.py
@@ -44,23 +44,21 @@ class PublicUserSerializer(serializers.ModelSerializer):
 
 class PublicUserWithAbakusGroupsSerializer(PublicUserSerializer):
     abakus_groups = PublicAbakusGroupSerializer(many=True)
-    achievements = AchievementSerializer(many=True)
 
     class Meta(PublicUserSerializer.Meta):
-        fields = PublicUserSerializer.Meta.fields + (  # type: ignore
-            "abakus_groups",
-            "achievements",
-        )
+        fields = PublicUserSerializer.Meta.fields + ("abakus_groups",)  # type: ignore
 
 
 class PublicUserWithGroupsSerializer(PublicUserWithAbakusGroupsSerializer):
     past_memberships = PastMembershipSerializer(many=True)
     memberships = MembershipSerializer(many=True)
+    achievements = AchievementSerializer(many=True)
 
     class Meta(PublicUserSerializer.Meta):
         fields = PublicUserWithAbakusGroupsSerializer.Meta.fields + (  # type: ignore
             "past_memberships",
             "memberships",
+            "achievements",
         )
 
 


### PR DESCRIPTION
This decreases the number of separate SQL-queries, increasing performance

When testing locally with 11 registered + 10 waiting list users, it decreased number of queries from 114 -> 51

@jonasdeluna I moved `achievements` from `PublicUserWithAbakusGroupsSerializer` to `PublicUserWithGroupsSerializer` to avoid fetching achievements for registrations in events. This shouldn't affect the user detail page, is there any other place we need `achievements`?