### PR TITLE
Auto remove interest group membership for no longer students

### DIFF
--- a/lego/apps/users/tests/test_grade_bump.py
+++ b/lego/apps/users/tests/test_grade_bump.py
@@ -3,7 +3,8 @@ from datetime import timedelta
 from django.core.management import call_command
 from django.utils import timezone
 
-from lego.apps.users.models import AbakusGroup, User
+from lego.apps.users.constants import GROUP_INTEREST
+from lego.apps.users.models import AbakusGroup, Membership, User
 from lego.utils.test_utils import BaseTestCase
 
 
@@ -105,6 +106,22 @@ class AbakusGroupHierarchyTestCase(BaseTestCase):
         bump_users()
         reset_user_bump_date(user)
         self.assertEqual(get_groups(user), [])
+
+    def test_bump_komtek_interest_remove(self):
+        """5th grade interestgroup should not be member afterwards"""
+        user = self.user
+        self.komtek_5.add_user(user)
+        self.assertEqual(get_groups(user), [self.komtek_5])
+        abacraft = AbakusGroup.objects.create(name="AbaCraft", type=GROUP_INTEREST)
+        abacraft.add_user(user)
+        bump_users()
+        reset_user_bump_date(user)
+        self.assertEqual(get_groups(user), [])
+        self.assertFalse(
+            Membership.objects.filter(
+                user=user, abakus_group__type=GROUP_INTEREST
+            ).exists()
+        )
 
     def test_multibump_should_not_bump(self):
         """Bumping multiple times should not bump the same user more than once"""

--- a/lego/utils/management/commands/bump_users.py
+++ b/lego/utils/management/commands/bump_users.py
@@ -5,8 +5,8 @@ from django.db import transaction
 from django.db.models import Count, Q
 from django.utils import timezone
 
-from lego.apps.users.constants import DATA_LONG, KOMTEK_LONG
-from lego.apps.users.models import AbakusGroup, User
+from lego.apps.users.constants import DATA_LONG, GROUP_INTEREST, KOMTEK_LONG
+from lego.apps.users.models import AbakusGroup, Membership, User
 from lego.utils.management_command import BaseCommand
 
 log = logging.getLogger(__name__)
@@ -91,6 +91,11 @@ class Command(BaseCommand):
             from_grade.remove_user(user)
             if to_grade:
                 to_grade.add_user(user)
+            else:
+                for membership in Membership.objects.filter(
+                    user=user, abakus_group__type=GROUP_INTEREST
+                ):
+                    membership.delete()
             User.objects.filter(pk=user.pk).update(date_bumped=timezone.now())
 
     def run(self, *args, **options):


### PR DESCRIPTION
Will work on bump_users, but will not remove already alumni users in interest groups.

Resolves: ABA-982