### PR TITLE
Add new penalty achievements

### DIFF
--- a/lego/apps/achievements/constants.py
+++ b/lego/apps/achievements/constants.py
@@ -5,9 +5,9 @@ from lego.apps.users.models import User
 
 from lego.apps.achievements.verification import (
     check_event_generic,
+    check_longest_period_without_penalties,
     check_poll_responses,
     check_total_event_payment_over,
-    check_total_penalties,
     check_verified_quote,
 )
 
@@ -27,7 +27,7 @@ EVENT_PRICE_IDENTIFIER = "event_price"
 QUOTE_IDENTIFIER = "quote_count"
 MEETING_IDENTIFIER = "meeting_hidden"
 POLL_IDENTIFIER = "poll_count"
-PENALTY_IDENTIFIER = "penalty_count"
+PENALTY_IDENTIFIER = "penalty_period"
 
 
 EVENT_ACHIEVEMENTS: AchievementCollection = {
@@ -142,18 +142,31 @@ POLL_ACHIEVEMENTS: AchievementCollection = {
 PENALTY_ACHIEVEMENTS: AchievementCollection = {
     "penalty_1": {
         "identifier": PENALTY_IDENTIFIER,
-        "requirement_function": lambda user: check_total_penalties(user=user, count=1),
+        "requirement_function": lambda user: check_longest_period_without_penalties(
+            user=user, years=1
+        ),
         "level": 0,
     },
-    "penalty_5": {
+    "penalty_2": {
         "identifier": PENALTY_IDENTIFIER,
-        "requirement_function": lambda user: check_total_penalties(user=user, count=5),
+        "requirement_function": lambda user: check_longest_period_without_penalties(
+            user=user, years=2
+        ),
         "level": 1,
     },
-    "penalty_10": {
+    "penalty_3": {
         "identifier": PENALTY_IDENTIFIER,
-        "requirement_function": lambda user: check_total_penalties(user=user, count=10),
+        "requirement_function": lambda user: check_longest_period_without_penalties(
+            user=user, years=3
+        ),
         "level": 2,
+    },
+    "penalty_4": {
+        "identifier": PENALTY_IDENTIFIER,
+        "requirement_function": lambda user: check_longest_period_without_penalties(
+            user=user, years=4
+        ),
+        "level": 3,
     },
 }
 

--- a/lego/apps/achievements/constants.py
+++ b/lego/apps/achievements/constants.py
@@ -3,7 +3,7 @@ from typing import Any, TypedDict
 
 from lego.apps.users.models import User
 
-from .verification import (
+from lego.apps.achievements.verification import (
     check_event_generic,
     check_poll_responses,
     check_total_event_payment_over,

--- a/lego/apps/achievements/constants.py
+++ b/lego/apps/achievements/constants.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Dict, TypedDict
+from collections.abc import Callable
+from typing import Any, TypedDict
 
 from lego.apps.users.models import User
 
@@ -6,6 +7,7 @@ from .verification import (
     check_event_generic,
     check_poll_responses,
     check_total_event_payment_over,
+    check_total_penalties,
     check_verified_quote,
 )
 
@@ -16,7 +18,7 @@ class Achievement(TypedDict):
     level: int
 
 
-AchievementCollection = Dict[str, Achievement]
+AchievementCollection = dict[str, Achievement]
 
 
 EVENT_IDENTIFIER = "event_count"
@@ -25,6 +27,8 @@ EVENT_PRICE_IDENTIFIER = "event_price"
 QUOTE_IDENTIFIER = "quote_count"
 MEETING_IDENTIFIER = "meeting_hidden"
 POLL_IDENTIFIER = "poll_count"
+PENALTY_IDENTIFIER = "penalty_count"
+
 
 EVENT_ACHIEVEMENTS: AchievementCollection = {
     "arrangement_10": {
@@ -135,6 +139,24 @@ POLL_ACHIEVEMENTS: AchievementCollection = {
     },
 }
 
+PENALTY_ACHIEVEMENTS: AchievementCollection = {
+    "penalty_1": {
+        "identifier": PENALTY_IDENTIFIER,
+        "requirement_function": lambda user: check_total_penalties(user=user, count=1),
+        "level": 0,
+    },
+    "penalty_5": {
+        "identifier": PENALTY_IDENTIFIER,
+        "requirement_function": lambda user: check_total_penalties(user=user, count=5),
+        "level": 1,
+    },
+    "penalty_10": {
+        "identifier": PENALTY_IDENTIFIER,
+        "requirement_function": lambda user: check_total_penalties(user=user, count=10),
+        "level": 2,
+    },
+}
+
 
 HIDDEN_ACHIEVEMENTS = {**QUOTE_ACHIEVEMENTS, **MEETING_ACHIEVEMENTS}
 
@@ -145,6 +167,7 @@ ACHIEVEMENTS = {
     **EVENT_PRICE_ACHIEVEMENTS,
     **POLL_ACHIEVEMENTS,
     **HIDDEN_ACHIEVEMENTS,
+    **PENALTY_ACHIEVEMENTS,
 }
 
 ACHIEVEMENT_IDENTIFIERS = sorted(

--- a/lego/apps/achievements/migrations/0001_initial.py
+++ b/lego/apps/achievements/migrations/0001_initial.py
@@ -53,6 +53,7 @@ class Migration(migrations.Migration):
                             ("meeting_hidden", "meeting_hidden"),
                             ("poll_count", "poll_count"),
                             ("quote_count", "quote_count"),
+                            ("penalty_count", "penalty_count"),
                         ],
                         max_length=128,
                     ),

--- a/lego/apps/achievements/migrations/0001_initial.py
+++ b/lego/apps/achievements/migrations/0001_initial.py
@@ -53,7 +53,7 @@ class Migration(migrations.Migration):
                             ("meeting_hidden", "meeting_hidden"),
                             ("poll_count", "poll_count"),
                             ("quote_count", "quote_count"),
-                            ("penalty_count", "penalty_count"),
+                            ("penalty_period", "penalty_period"),
                         ],
                         max_length=128,
                     ),

--- a/lego/apps/achievements/promotion.py
+++ b/lego/apps/achievements/promotion.py
@@ -148,7 +148,6 @@ def check_meeting_hidden(owner: User, user: User, meeting: Meeting):
         if not Achievement.objects.filter(
             user=user, identifier=MEETING_ACHIEVEMENTS["meeting_hidden"]["identifier"]
         ).exists():
-
             Achievement.objects.create(
                 identifier=MEETING_ACHIEVEMENTS["meeting_hidden"]["identifier"],
                 user=user,

--- a/lego/apps/achievements/promotion.py
+++ b/lego/apps/achievements/promotion.py
@@ -8,13 +8,15 @@ from lego.apps.events.models import Registration
 from lego.apps.meetings.models import Meeting
 from lego.apps.users.models import User
 
-from .constants import (
+from lego.apps.achievements.constants import (
     EVENT_ACHIEVEMENTS,
     EVENT_IDENTIFIER,
     EVENT_PRICE_ACHIEVEMENTS,
     EVENT_PRICE_IDENTIFIER,
     EVENT_RANK_ACHIEVEMENTS,
     MEETING_ACHIEVEMENTS,
+    PENALTY_ACHIEVEMENTS,
+    PENALTY_IDENTIFIER,
     POLL_ACHIEVEMENTS,
     POLL_IDENTIFIER,
     QUOTE_ACHIEVEMENTS,
@@ -25,7 +27,7 @@ from .constants import (
 
 def check_leveled_promotions(
     user_id: int, identifier: str, input_achievements: AchievementCollection
-):
+) -> None:
     try:
         user = User.objects.get(pk=user_id)
     except User.DoesNotExist:
@@ -156,22 +158,28 @@ def check_meeting_hidden(owner: User, user: User, meeting: Meeting):
     return False
 
 
-def check_event_related_single_user(user_id: int):
-    check_leveled_promotions(user_id, EVENT_IDENTIFIER, EVENT_ACHIEVEMENTS)
-    check_leveled_promotions(user_id, EVENT_PRICE_IDENTIFIER, EVENT_PRICE_ACHIEVEMENTS)
+def check_event_related_single_user(user: User) -> None:
+    check_leveled_promotions(user.id, EVENT_IDENTIFIER, EVENT_ACHIEVEMENTS)
+    check_leveled_promotions(user.id, EVENT_PRICE_IDENTIFIER, EVENT_PRICE_ACHIEVEMENTS)
 
 
-def check_poll_related_single_user(user: User):
+def check_poll_related_single_user(user: User) -> None:
     check_leveled_promotions(user.id, POLL_IDENTIFIER, POLL_ACHIEVEMENTS)
 
 
-def check_quote_related_single_user(user: User):
+def check_quote_related_single_user(user: User) -> None:
     check_leveled_promotions(user.id, QUOTE_IDENTIFIER, QUOTE_ACHIEVEMENTS)
+
+
+def check_penalty_related_single_user(user: User) -> None:
+    check_leveled_promotions(user.id, PENALTY_IDENTIFIER, PENALTY_ACHIEVEMENTS)
 
 
 def check_all_promotions():
     for user in User.objects.all():
         check_quote_related_single_user(user)
-        check_event_related_single_user(user.id)
+        check_event_related_single_user(user)
         check_poll_related_single_user(user)
+        check_penalty_related_single_user(user)
+
     check_rank_promotions()

--- a/lego/apps/achievements/promotion.py
+++ b/lego/apps/achievements/promotion.py
@@ -158,9 +158,9 @@ def check_meeting_hidden(owner: User, user: User, meeting: Meeting):
     return False
 
 
-def check_event_related_single_user(user: User) -> None:
-    check_leveled_promotions(user.id, EVENT_IDENTIFIER, EVENT_ACHIEVEMENTS)
-    check_leveled_promotions(user.id, EVENT_PRICE_IDENTIFIER, EVENT_PRICE_ACHIEVEMENTS)
+def check_event_related_single_user(user_id: int) -> None:
+    check_leveled_promotions(user_id, EVENT_IDENTIFIER, EVENT_ACHIEVEMENTS)
+    check_leveled_promotions(user_id, EVENT_PRICE_IDENTIFIER, EVENT_PRICE_ACHIEVEMENTS)
 
 
 def check_poll_related_single_user(user: User) -> None:
@@ -178,7 +178,7 @@ def check_penalty_related_single_user(user: User) -> None:
 def check_all_promotions():
     for user in User.objects.all():
         check_quote_related_single_user(user)
-        check_event_related_single_user(user)
+        check_event_related_single_user(user.id)
         check_poll_related_single_user(user)
         check_penalty_related_single_user(user)
 

--- a/lego/apps/achievements/verification.py
+++ b/lego/apps/achievements/verification.py
@@ -37,7 +37,7 @@ def check_poll_responses(user: User, count: int):
 def check_longest_period_without_penalties(user: User, years: int) -> bool:
     days = years * 365
 
-    if not (events := Registration.objects.filter(user=user).order_by("end_time")):
+    if not (events := Registration.objects.filter(user=user).order_by("event__end_time")):
         return False
 
     start_time = events.first().event.end_time

--- a/lego/apps/achievements/verification.py
+++ b/lego/apps/achievements/verification.py
@@ -39,7 +39,7 @@ def check_longest_period_without_penalties(user: User, years: int) -> bool:
         return False
     if not (
         events := Registration.objects.filter(
-            user=user, status=SUCCESS_REGISTER
+            user=user, status=SUCCESS_REGISTER, event__end_time__lte=timezone.now()
         ).order_by("event__end_time")
     ):
         return False

--- a/lego/apps/achievements/verification.py
+++ b/lego/apps/achievements/verification.py
@@ -58,7 +58,9 @@ def _generate_penalty_intervals(
 def check_longest_period_without_penalties(user: User, years: int) -> bool:
     if not user.has_grade_group:
         return False
-    if not (registrations := _passed_user_registrations(user).order_by("event__end_time")).exists():
+    if not (
+        registrations := _passed_user_registrations(user).order_by("event__end_time")
+    ).exists():
         return False
 
     days = 365 * years
@@ -79,7 +81,9 @@ def check_longest_period_without_penalties(user: User, years: int) -> bool:
 
             last_registration_in_interval = (
                 _passed_user_registrations(user)
-                .filter(event__end_time__gt=current_end, event__end_time__lte=cutoff_time)
+                .filter(
+                    event__end_time__gt=current_end, event__end_time__lte=cutoff_time
+                )
                 .last()
             )
 
@@ -88,7 +92,9 @@ def check_longest_period_without_penalties(user: User, years: int) -> bool:
                 continue
 
             next_event = (
-                _passed_user_registrations(user).filter(event__end_time__gt=cutoff_time).first()
+                _passed_user_registrations(user)
+                .filter(event__end_time__gt=cutoff_time)
+                .first()
             )
 
             if next_event is None:

--- a/lego/apps/achievements/verification.py
+++ b/lego/apps/achievements/verification.py
@@ -5,7 +5,7 @@ from lego.apps.events.constants import PAYMENT_MANUAL, PAYMENT_SUCCESS, SUCCESS_
 from lego.apps.events.models import Registration
 from lego.apps.polls.models import Poll
 from lego.apps.quotes.models import Quote
-from lego.apps.users.models import User
+from lego.apps.users.models import Penalty, User
 
 
 def check_event_generic(user: User, count: int):
@@ -30,6 +30,10 @@ def check_poll_responses(user: User, count: int):
         ).count()
         >= count
     )
+
+
+def check_total_penalties(user: User, count: int) -> bool:
+    return Penalty.objects.filter(user=user).count() >= count
 
 
 # There is a case where manual payment does not update the payment amount.

--- a/lego/apps/achievements/verification.py
+++ b/lego/apps/achievements/verification.py
@@ -62,7 +62,7 @@ def check_longest_period_without_penalties(user: User, years: int) -> bool:
         return False
 
     days = 365 * years
-    max_registration_interval = timedelta(days=183)  # Once per semester
+    max_registration_interval = timedelta(days=365)  # Once a year
     start_time = registrations.first().event.end_time
     end_time = registrations.last().event.end_time
     intervals = _generate_penalty_intervals(user, start_time, end_time)

--- a/lego/apps/achievements/verification.py
+++ b/lego/apps/achievements/verification.py
@@ -3,11 +3,7 @@ import itertools
 from django.db.models import Sum
 from django.utils import timezone
 
-from lego.apps.events.constants import (
-    PAYMENT_MANUAL,
-    PAYMENT_SUCCESS,
-    SUCCESS_REGISTER,
-)
+from lego.apps.events.constants import PAYMENT_MANUAL, PAYMENT_SUCCESS, SUCCESS_REGISTER
 from lego.apps.events.models import Registration
 from lego.apps.polls.models import Poll
 from lego.apps.quotes.models import Quote
@@ -38,15 +34,13 @@ def check_poll_responses(user: User, count: int):
     )
 
 
-def check_total_penalties(user: User, count: int) -> bool:
-    return Penalty.objects.filter(user=user).count() >= count
+def check_longest_period_without_penalties(user: User, years: int) -> bool:
+    days = years * 365
 
-
-def check_longest_period_without_penalties(user: User, days: int) -> bool:
     if not (events := Registration.objects.filter(user=user).order_by("end_time")):
         return False
 
-    start_time = events.first().event.start_time
+    start_time = events.first().event.end_time
     end_time = events.last().event.end_time
 
     if not (penalties := Penalty.objects.filter(user=user).order_by("created_at")):

--- a/lego/apps/events/apps.py
+++ b/lego/apps/events/apps.py
@@ -14,7 +14,6 @@ class EventsConfig(AppConfig):
         )
 
         if not settings.TESTING:
-
             post_save.connect(event_save_callback, sender=Event)
 
         post_save.connect(

--- a/lego/apps/events/tests/utils.py
+++ b/lego/apps/events/tests/utils.py
@@ -7,7 +7,7 @@ import stripe
 from lego.apps.users.models import AbakusGroup, User
 
 
-def get_dummy_users(n):
+def get_dummy_users(n: int) -> list[User]:
     users = []
 
     for i in range(n):


### PR DESCRIPTION
* Add penalty achievement.
* Will make students in Abakus more likely to avoid penalties.
* Add function to find longest period without receiving a penalty. As per now, the user can go maximum one year between two events in the period for which they receive the achievement.
* Improve `dict` type annotation since the one from `typing` is considered obsolete after 3.10.
* Replace the `Callable`-import to be from `collections.abc`, since the one from `typing` is deprecated.
* Small refactor of `check_event_generic`.
* Dependent on [front-end PR](https://github.com/webkom/lego-webapp/pull/5153).
* 100% not Lego-pin bait...