### PR TITLE
Re-include legacy_registration_count to detailed event serializer

### DIFF
--- a/lego/apps/events/serializers/events.py
+++ b/lego/apps/events/serializers/events.py
@@ -190,6 +190,7 @@ class EventReadDetailedSerializer(
             "is_merged",
             "heed_penalties",
             "created_by",
+            "legacy_registration_count",
             "survey",
             "use_consent",
             "youtube_url",


### PR DESCRIPTION
Not sure why this was removed [here](https://github.com/webkom/lego/pull/3673/files) hehe

Tested with webapp