### PR TITLE
Prevent admins from searching meetings

### DIFF
--- a/lego/apps/meetings/permissions.py
+++ b/lego/apps/meetings/permissions.py
@@ -28,8 +28,15 @@ class MeetingPermissionHandler(PermissionHandler):
         if not user.is_authenticated:
             return False
 
-        # Check object permissions before keywork perms
+        # Check object permissions before keyword perms
         if obj is not None:
+            # Disable permission checking if the user is not a creator or invited to the meeting
+            # Supplying self.filter_queryset() functionality for individual objects as well
+            if not (
+                obj.created_by == user or obj.invited_users.filter(id=user.id).exists()
+            ):
+                return False
+
             if self.has_object_permissions(user, perm, obj):
                 return True
 


### PR DESCRIPTION
It's been bugging a little that admins can search all meetings (even though we can't actually see the meetings - which is an annoying bug/feature caused by the view filtering the queryset instead of using the permissions)

Anyways, this change ensures that no users have permissions to meetings that they are not a part of, resulting in them being excluded from searches. It might seem like searching was the only place where meetings was accessed not through the meetings view, so that's why that is the only place it was noticeable.

Works just fine locally (the creator can still view and edit the meeting, and the superadmin cannot view it, nor search for it)