### PR TITLE
Revert crypt hash generation on login

### DIFF
--- a/lego/api/tests/test_authentication.py
+++ b/lego/api/tests/test_authentication.py
@@ -38,32 +38,6 @@ class JSONWebTokenTestCase(BaseAPITestCase):
         self.assertContains(response, text="token", status_code=status.HTTP_201_CREATED)
         self.assertContains(response, text="user", status_code=status.HTTP_201_CREATED)
 
-    def test_crypt_hash_generated_on_successfull_auth(self):
-        user = User.objects.get(pk=12)
-        self.assertEqual(user.crypt_password_hash, "")
-        user_data = {"username": user.username, "password": "test"}
-        response = self.client.post(reverse("jwt:obtain_jwt_token"), user_data)
-        self.assertContains(response, text="token", status_code=status.HTTP_201_CREATED)
-        self.assertContains(response, text="user", status_code=status.HTTP_201_CREATED)
-        self.assertNotEqual(User.objects.get(pk=12).crypt_password_hash, "")
-
-    def test_crypt_hash_generated_on_successfull_auth_case(self):
-        user = User.objects.get(pk=12)
-        self.assertEqual(user.crypt_password_hash, "")
-        user_data = {"username": "tEsT12", "password": "test"}
-        response = self.client.post(reverse("jwt:obtain_jwt_token"), user_data)
-        self.assertContains(response, text="token", status_code=status.HTTP_201_CREATED)
-        self.assertContains(response, text="user", status_code=status.HTTP_201_CREATED)
-        self.assertNotEqual(User.objects.get(pk=12).crypt_password_hash, "")
-
-    def test_crypt_hash_not_generated_on_failed_auth(self):
-        user = User.objects.get(pk=12)
-        self.assertEqual(user.crypt_password_hash, "")
-        user_data = {"username": user.username, "password": "tes"}
-        response = self.client.post(reverse("jwt:obtain_jwt_token"), user_data)
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(User.objects.get(pk=12).crypt_password_hash, "")
-
     def test_refresh(self):
         token_response = self.client.post(
             reverse("jwt:obtain_jwt_token"), self.user_data

--- a/lego/apps/users/fixtures/test_users.yaml
+++ b/lego/apps/users/fixtures/test_users.yaml
@@ -105,21 +105,8 @@
 - model: users.User
   pk: 12
   fields:
-    username: test12
-    student_username: test12student
-    student_verification_status: true
-    password: pbkdf2_sha256$24000$zowF0cRkFimt$qzeoY9hZ0X3zDhlG0FP8imaGto8S2N6ed1AMp83xcn4= # test
-    gender: female
-    first_name: test
-    last_name: user12
-    email: test12@user.com
-    crypt_password_hash: ''
-
-- model: users.User
-  pk: 13 
-  fields:
     username: abakulingutenklasse
     gender: male
-    first_name: abakuling 
+    first_name: abakuling
     last_name: utenklasse
     email: abakulingutenklasse@abakus.no

--- a/lego/urls.py
+++ b/lego/urls.py
@@ -6,31 +6,13 @@ from django.views.generic import TemplateView
 from rest_framework.documentation import include_docs_urls
 
 from rest_framework_jwt.views import (
-    ObtainJSONWebTokenView,
+    obtain_jwt_token,
     refresh_jwt_token,
     verify_jwt_token,
 )
 
 from lego.api.urls import urlpatterns as api
-from lego.apps.users.models import User
 from lego.utils.types import URLList
-
-
-# START
-# Temporary view to generate crypt_hashes for the users that do not have it
-class TokenAuthView(ObtainJSONWebTokenView):
-    def post(self, request, *args, **kwargs):
-        result = super().post(request, *args, **kwargs)
-        # If the login is invalid it would have raised an exception by this point
-        user = User._default_manager.get_by_natural_key(request.data.get("username"))
-        if user.crypt_password_hash == "":
-            user.set_password(request.data.get("password"))
-            user.save()
-        return result
-
-
-obtain_jwt_token = TokenAuthView.as_view()
-# END
 
 jwt_urlpatterns: URLList = [
     re_path(r"^token-auth/$", obtain_jwt_token, name="obtain_jwt_token"),


### PR DESCRIPTION
We've been generating crypt hashes on login for users missing it due to it not being set on registration until 8 months ago. Now we're down from 487 users with no hash to 78, so I figured it could be time to remove the temporary update.

If any of the remaining 78 users against all odds require the hash they can reset their password.

Originally implemented in https://github.com/webkom/lego/pull/3602 and https://github.com/webkom/lego/pull/3603

Resolves ABA-942