### PR TITLE
Fixes a bug where unanswered surveys were bugged

### DIFF
--- a/lego/apps/users/models.py
+++ b/lego/apps/users/models.py
@@ -536,7 +536,7 @@ class User(
             Survey.objects.filter(
                 event__registrations__in=registrations,
                 active_from__lte=timezone.now(),
-                template_type__isnull=True,
+                is_template=False,
             )
             .exclude(submissions__user__in=[self])
             .prefetch_related("event__registrations", "submissions__user")


### PR DESCRIPTION
# Description

New surveys inherit the template_type used from their template, so the new check should check is_template not template_type.
This bug led to unanswered surveys not showing up for users at all thus leading to 0 submissions for some surveys.


# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

Resolves ABA-1312
