### PR TITLE
Fix excessive fetching

### DIFF
--- a/lego/apps/surveys/views.py
+++ b/lego/apps/surveys/views.py
@@ -149,9 +149,7 @@ class SurveyTemplateViewSet(
     mixins.RetrieveModelMixin,
 ):
     queryset = (
-        Survey.objects.all()
-        .prefetch_related("questions")
-        .filter(is_template__isnull=False)
+        Survey.objects.all().prefetch_related("questions").filter(is_template=True)
     )
     lookup_field = "id"
     filter_backends = (DjangoFilterBackend,)


### PR DESCRIPTION
# Description

Fixes excessive fetching as most surveys have is_template=False so this check fetched too many and it got filtered frontend.


# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

Resolves ... (either GitHub issue or Linear task)
