### PR TITLE
Add "sub" field to OAuth2 userdata

### DIFF
--- a/lego/apps/users/serializers/users.py
+++ b/lego/apps/users/serializers/users.py
@@ -142,12 +142,16 @@ class Oauth2UserDataSerializer(serializers.ModelSerializer):
     is_student = serializers.SerializerMethodField()
     is_abakus_member = serializers.BooleanField()
 
+    def get_sub(self):
+        return str(self.instance.id)
+
     def get_email(self):
         return self.instance.email_address
 
     class Meta:
         model = User
         fields = (
+            "sub",
             "id",
             "username",
             "first_name",


### PR DESCRIPTION
OIDC uses "sub" as the id-field. While this is still not really OIDC complient (because we don't use the "openid" scope) it might fix issues with some OAuth2 clients

# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [ ] I have thoroughly tested my changes.

Resolves #3724 (maybe)
