### PR TITLE
Make email lowercase when saving model and validating

### DIFF
--- a/lego/apps/users/models.py
+++ b/lego/apps/users/models.py
@@ -420,7 +420,9 @@ class User(
 
     def save(self, *args, **kwargs):
         self.email = self.email.lower()
-        self.student_username = self.student_username.lower() if self.student_username else None
+        self.student_username = (
+            self.student_username.lower() if self.student_username else None
+        )
         if self.pk:
             from lego.apps.achievements.utils.calculation_utils import (
                 calculate_user_rank,

--- a/lego/apps/users/models.py
+++ b/lego/apps/users/models.py
@@ -391,10 +391,6 @@ class User(
     class Meta:
         permission_handler = UserPermissionHandler()
 
-    def clean(self):
-        self.student_username = self.student_username.lower()
-        super(User, self).clean()
-
     def get_full_name(self):
         return f"{self.first_name} {self.last_name}".strip()
 
@@ -423,6 +419,8 @@ class User(
         super(User, self).delete(using=using, force=force)
 
     def save(self, *args, **kwargs):
+        self.email = self.email.lower()
+        self.student_username = self.student_username.lower() if self.student_username else None
         if self.pk:
             from lego.apps.achievements.utils.calculation_utils import (
                 calculate_user_rank,

--- a/lego/apps/users/tests/test_student_confirmation_api.py
+++ b/lego/apps/users/tests/test_student_confirmation_api.py
@@ -394,7 +394,8 @@ class ValidateOIDCAPITestCase(BaseAPITestCase):
         json = response.json()
         self.assertEqual(json.get("status"), "success")
         self.assertEqual(
-            self.user_with_student_confirmation.student_username, f"{Token.DATA}"
+            self.user_with_student_confirmation.student_username,
+            f"{str(Token.DATA).lower()}",
         )
 
         self.client.force_authenticate(self.user_without_student_confirmation)


### PR DESCRIPTION
# Description

Makes all emails lowercase when saving.
All current emails have been set to lower using shell.
There was one guy with duplicate email but he was deleted.

# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

Resolves ABA-374
