### PR TITLE
Feat add mazemap to recurring meetings & remove while loop

### DIFF
--- a/lego/apps/meetings/models.py
+++ b/lego/apps/meetings/models.py
@@ -56,10 +56,11 @@ class Meeting(BasisModel):
         if not self.is_recurring:
             return None
 
-        next_occurrence = self.start_time + timedelta(days=7)
+        now = timezone.now()
+        days_since_start = (now - self.start_time).days
+        weeks_since_start = days_since_start // 7
 
-        while next_occurrence < timezone.now():
-            next_occurrence += timedelta(days=7)
+        next_occurrence = self.start_time + timedelta(weeks=weeks_since_start + 1)
 
         return next_occurrence
 

--- a/lego/apps/meetings/tasks.py
+++ b/lego/apps/meetings/tasks.py
@@ -90,6 +90,7 @@ def generate_weekly_recurring_meetings(self, logger_context=None):
         new_meeting = Meeting.objects.create(
             title=new_title,
             location=meeting.location,
+            mazemap_poi=meeting.mazemap_poi,
             start_time=next_start_time,
             end_time=next_end_time,
             description=meeting.description,


### PR DESCRIPTION
# Description

Add mazemap POI to recurring meeting and update calculation of next occurence to avoid while loop


# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [ish] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

Resolves ABA-1355
