### PR TITLE
Allow non admins to list surveys and add user filter

### DIFF
--- a/lego/apps/surveys/filters.py
+++ b/lego/apps/surveys/filters.py
@@ -1,14 +1,23 @@
-from django_filters import CharFilter, FilterSet
+from django.db.models import Q
+from django_filters import CharFilter, FilterSet, NumberFilter
 
+from lego.apps.events.constants import PRESENCE_CHOICES
 from lego.apps.surveys.models import Submission, Survey
 
 
 class SurveyFilterSet(FilterSet):
     company = CharFilter("event__company")
+    user = NumberFilter(method="filter_by_attended_user")
 
     class Meta:
         model = Survey
         fields = ("event",)
+
+    def filter_by_attended_user(self, queryset, name, value):
+        return queryset.filter(
+            Q(event__registrations__user=value)
+            & Q(event__registrations__presence=PRESENCE_CHOICES.PRESENT)
+        )
 
 
 class SubmissionFilterSet(FilterSet):

--- a/lego/apps/surveys/tests/test_surveys_api.py
+++ b/lego/apps/surveys/tests/test_surveys_api.py
@@ -218,7 +218,7 @@ class SurveyViewSetTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         results = response.json()["results"]
-        self.assertEqual(len(results), 2) # All test surveys
+        self.assertEqual(len(results), 2)  # All test surveys
 
     def test_list_regular(self):
         """Regular users should have permission to see surveys list view"""
@@ -227,7 +227,7 @@ class SurveyViewSetTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         results = response.json()["results"]
-        self.assertEqual(len(results), 0) # Has no surveys
+        self.assertEqual(len(results), 0)  # Has no surveys
 
     def test_list_attended(self):
         """Users who attended an event should be able to see surveys list view"""
@@ -236,7 +236,7 @@ class SurveyViewSetTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         results = response.json()["results"]
-        self.assertEqual(len(results), 1) # Only one survey
+        self.assertEqual(len(results), 1)  # Only one survey
 
     def test_list_anonymous(self):
         """Anonymous users should not be able to see surveys list view"""
@@ -252,12 +252,12 @@ class SurveyViewSetTestCase(APITestCase):
         response = self.client.get(_get_list_url(), {"user": self.admin_user.id})
         results = response.json()["results"]
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(results), 0) # Has no surveys
+        self.assertEqual(len(results), 0)  # Has no surveys
 
         response = self.client.get(_get_list_url(), {"user": self.attended_user.id})
         results = response.json()["results"]
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(results), 1) # Can view other users surveys
+        self.assertEqual(len(results), 1)  # Can view other users surveys
 
     def test_filter_list_regular(self):
         """Regular users should be able to check if they have surveys"""
@@ -266,12 +266,12 @@ class SurveyViewSetTestCase(APITestCase):
         response = self.client.get(_get_list_url(), {"user": self.regular_user.id})
         results = response.json()["results"]
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(results), 0) # Has no surveys
+        self.assertEqual(len(results), 0)  # Has no surveys
 
         response = self.client.get(_get_list_url(), {"user": self.attended_user.id})
         results = response.json()["results"]
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(results), 0) # Can not view other users surveys
+        self.assertEqual(len(results), 0)  # Can not view other users surveys
 
     def test_filter_list_attended(self):
         """Attended users should be able to see their own surveys"""
@@ -279,7 +279,7 @@ class SurveyViewSetTestCase(APITestCase):
         response = self.client.get(_get_list_url(), {"user": self.attended_user.id})
         results = response.json()["results"]
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(results), 1) # Has one survey
+        self.assertEqual(len(results), 1)  # Has one survey
 
     def test_filter_list_anonymous(self):
         """Anonymous users should not be able to see surveys list view"""

--- a/lego/apps/surveys/tests/test_surveys_api.py
+++ b/lego/apps/surveys/tests/test_surveys_api.py
@@ -218,21 +218,72 @@ class SurveyViewSetTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_list_regular(self):
-        """Regular users should not be able to see surveys list view"""
+        """Regular users should have permission to see surveys list view"""
         self.client.force_authenticate(user=self.regular_user)
         response = self.client.get(_get_list_url())
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Should not have any surveys and so should not be able to see any
+        results = response.json()["results"]
+        self.assertEqual(len(results), 0)
 
     def test_list_attended(self):
-        """Users who attended an event should not be able to see surveys list view"""
+        """Users who attended an event should be able to see surveys list view"""
         self.client.force_authenticate(user=self.attended_user)
         response = self.client.get(_get_list_url())
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_list_anonymous(self):
         """Anonymous users should not be able to see surveys list view"""
         self.client.force_authenticate(user=None)
         response = self.client.get(_get_list_url())
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    # Fetch filtered list
+    def test_filter_list_admin(self):
+        """Admin users should be able to see all surveys"""
+        self.client.force_authenticate(user=self.admin_user)
+
+        # Admin user has no surveys
+        response = self.client.get(_get_list_url(), {"user": self.admin_user.id})
+        results = response.json()["results"]
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(results), 0)
+
+        # Attended user has one survey and admin should be able to see it
+        response = self.client.get(_get_list_url(), {"user": self.attended_user.id})
+        results = response.json()["results"]
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(results), 1)
+
+    def test_filter_list_regular(self):
+        """Regular users should be able to check if they have surveys"""
+        self.client.force_authenticate(user=self.regular_user)
+
+        # Regular user has no surveys
+        response = self.client.get(_get_list_url(), {"user": self.regular_user.id})
+        results = response.json()["results"]
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(results), 0)
+
+        # Regular user should not be able to see other users surveys
+        response = self.client.get(_get_list_url(), {"user": self.attended_user.id})
+        results = response.json()["results"]
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(results), 0)
+
+    def test_filter_list_attended(self):
+        """Attended users should be able to see their own surveys"""
+        self.client.force_authenticate(user=self.attended_user)
+        response = self.client.get(_get_list_url(), {"user": self.attended_user.id})
+        results = response.json()["results"]
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(results), 1)
+
+    def test_filter_list_anonymous(self):
+        """Anonymous users should not be able to see surveys list view"""
+        self.client.force_authenticate(user=None)
+        response = self.client.get(_get_list_url(), {"user": self.admin_user.id})
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     # Edit permissions

--- a/lego/apps/surveys/tests/test_surveys_api.py
+++ b/lego/apps/surveys/tests/test_surveys_api.py
@@ -217,21 +217,26 @@ class SurveyViewSetTestCase(APITestCase):
         response = self.client.get(_get_list_url())
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+        results = response.json()["results"]
+        self.assertEqual(len(results), 2) # All test surveys
+
     def test_list_regular(self):
         """Regular users should have permission to see surveys list view"""
         self.client.force_authenticate(user=self.regular_user)
         response = self.client.get(_get_list_url())
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        # Should not have any surveys and so should not be able to see any
         results = response.json()["results"]
-        self.assertEqual(len(results), 0)
+        self.assertEqual(len(results), 0) # Has no surveys
 
     def test_list_attended(self):
         """Users who attended an event should be able to see surveys list view"""
         self.client.force_authenticate(user=self.attended_user)
         response = self.client.get(_get_list_url())
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        results = response.json()["results"]
+        self.assertEqual(len(results), 1) # Only one survey
 
     def test_list_anonymous(self):
         """Anonymous users should not be able to see surveys list view"""
@@ -244,33 +249,29 @@ class SurveyViewSetTestCase(APITestCase):
         """Admin users should be able to see all surveys"""
         self.client.force_authenticate(user=self.admin_user)
 
-        # Admin user has no surveys
         response = self.client.get(_get_list_url(), {"user": self.admin_user.id})
         results = response.json()["results"]
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(results), 0)
+        self.assertEqual(len(results), 0) # Has no surveys
 
-        # Attended user has one survey and admin should be able to see it
         response = self.client.get(_get_list_url(), {"user": self.attended_user.id})
         results = response.json()["results"]
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results), 1) # Can view other users surveys
 
     def test_filter_list_regular(self):
         """Regular users should be able to check if they have surveys"""
         self.client.force_authenticate(user=self.regular_user)
 
-        # Regular user has no surveys
         response = self.client.get(_get_list_url(), {"user": self.regular_user.id})
         results = response.json()["results"]
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(results), 0)
+        self.assertEqual(len(results), 0) # Has no surveys
 
-        # Regular user should not be able to see other users surveys
         response = self.client.get(_get_list_url(), {"user": self.attended_user.id})
         results = response.json()["results"]
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(results), 0)
+        self.assertEqual(len(results), 0) # Can not view other users surveys
 
     def test_filter_list_attended(self):
         """Attended users should be able to see their own surveys"""
@@ -278,7 +279,7 @@ class SurveyViewSetTestCase(APITestCase):
         response = self.client.get(_get_list_url(), {"user": self.attended_user.id})
         results = response.json()["results"]
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results), 1) # Has one survey
 
     def test_filter_list_anonymous(self):
         """Anonymous users should not be able to see surveys list view"""

--- a/lego/apps/surveys/views.py
+++ b/lego/apps/surveys/views.py
@@ -52,7 +52,7 @@ class SurveyViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
         permission_handler = get_permission_handler(Survey)
         return permission_handler.filter_queryset(
             user,
-            Survey.objects.prefetch_related("questions", "submissions"),
+            queryset=Survey.objects.prefetch_related("questions", "submissions"),
         )
 
     def get_serializer_class(self):

--- a/lego/apps/users/fixtures/test_abakus_groups.py
+++ b/lego/apps/users/fixtures/test_abakus_groups.py
@@ -128,6 +128,7 @@ test_tree = {
                 "/sudo/admin/registrations/create/",
                 "/sudo/admin/events/payment/",
                 "/sudo/admin/submissions/create/",
+                "/sudo/admin/surveys/list/",
             ],
         },
         {

--- a/lego/apps/users/fixtures/test_abakus_groups.yaml
+++ b/lego/apps/users/fixtures/test_abakus_groups.yaml
@@ -326,7 +326,8 @@
     type: annen
     text: ''
     permissions: '["/sudo/admin/meetings/create/", "/sudo/admin/meetinginvitations/create/",
-      "/sudo/admin/registrations/create/", "/sudo/admin/events/payment/", "/sudo/admin/submissions/create/"]'
+      "/sudo/admin/registrations/create/", "/sudo/admin/events/payment/", "/sudo/admin/submissions/create/",
+      "/sudo/admin/surveys/list/"]'
     show_badge: true
     active: true
     lft: 1


### PR DESCRIPTION
# Description

Allow users with `/sudo/admin/surveys/list/` to list surveys. (This permission should be added to `Abakus` group. This way all users should be able to list surveys. Filtering ensures they still only can list surveys they should have access to. 

# Testing
- [X] The code quality is at a minimum required level of quality, readability, and performance.
- [X] I have thoroughly tested my changes.


Resolves ABA-1358


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced survey filtering that allows users to refine survey views based on attendance.
  - Updated survey access so that authenticated users—including regular and attended users—can now view their own surveys, while admin users retain full access.
  - Added a new permission path for the `Abakus` group, enabling access to a new endpoint for listing surveys.

These improvements streamline the survey experience while expanding access for authorized users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->