### PR TITLE
Add pagination to joblistings

### DIFF
--- a/lego/apps/joblistings/filters.py
+++ b/lego/apps/joblistings/filters.py
@@ -1,11 +1,20 @@
-from django_filters import DateFilter, FilterSet
+from django.utils import timezone
+from django_filters import BooleanFilter, DateFilter, FilterSet
 
 from lego.apps.joblistings.models import Joblisting
 
 
 class JoblistingFilterSet(FilterSet):
     created_after = DateFilter("created_at", lookup_expr="gte")
+    timeFilter = BooleanFilter(method="filter_time")
 
     class Meta:
         model = Joblisting
         fields = ("company",)
+
+    def filter_time(self, queryset, name, value):
+        if value:
+            return queryset.filter(
+                visible_from__lte=timezone.now(), visible_to__gte=timezone.now()
+            )
+        return queryset

--- a/lego/apps/joblistings/views.py
+++ b/lego/apps/joblistings/views.py
@@ -14,7 +14,6 @@ from lego.apps.permissions.api.views import AllowedPermissionsMixin
 
 
 class JoblistingViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
-    pagination_class = None
     filterset_class = JoblistingFilterSet
     ordering = "-created_at"
 
@@ -49,10 +48,12 @@ class JoblistingViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
     def get_queryset(self):
         queryset = Joblisting.objects.all()
 
-        time_filter = self.request.query_params.get("timeFilter", False)
-        if time_filter:
-            queryset = queryset.filter(
-                visible_from__lte=timezone.now(), visible_to__gte=timezone.now()
-            )
+        params = self.request.query_params
+
+        # Disable pagination if filters are applied
+        if params and any(
+            params.get(key) for key in self.filterset_class.get_filters()
+        ):
+            self.pagination_class = None
 
         return queryset


### PR DESCRIPTION
# Description

Add pagination to joblistings, since now whenever anyone access `api/v1/joblistings` it returns all joblistings ever.
Disable pagination whenever filters are applied, to stay consistent with previous functionality.

This aims to improve speed of health check.

# Testing
- [ ] The code quality is at a minimum required level of quality, readability, and performance.
- [ ] I have thoroughly tested my changes.

Tests work, so i guess... isss good?

Resolves ABA-1366
