### PR TITLE
Remove galla promotion temporarily

### DIFF
--- a/lego/apps/achievements/promotion.py
+++ b/lego/apps/achievements/promotion.py
@@ -205,7 +205,6 @@ def check_all_promotions() -> None:
         check_poll_related_single_user(user)
         check_penalty_related_single_user(user)
         check_genfors_related_single_user(user)
-        check_gala_related_single_user(user)
         check_complete_user_profile(user)
 
     check_rank_promotions()


### PR DESCRIPTION
# Description

The "jubileum" string is too broad and needs to be fixed.
Probably need to add tags to events first and use that instead.


# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

Resolves ... (either GitHub issue or Linear task)
