### PR TITLE
Make statistics support slugs

### DIFF
--- a/lego/apps/articles/views.py
+++ b/lego/apps/articles/views.py
@@ -58,8 +58,9 @@ class ArticlesViewSet(AllowedPermissionsMixin, ModelViewSet):
         return obj
 
     @action(detail=True, methods=["GET"])
-    def statistics(self, request, pk=None, *args, **kwargs) -> Response:
-        article = Article.objects.get(id=pk)
+    def statistics(self, request, *args, **kwargs) -> Response:
+        article_id = self.kwargs.get("pk", None)
+        article = Article.objects.get(id=article_id)
         user = request.user
 
         if not user or not user.is_authenticated:

--- a/lego/apps/articles/views.py
+++ b/lego/apps/articles/views.py
@@ -58,9 +58,8 @@ class ArticlesViewSet(AllowedPermissionsMixin, ModelViewSet):
         return obj
 
     @action(detail=True, methods=["GET"])
-    def statistics(self, request, *args, **kwargs) -> Response:
-        article_id = self.kwargs.get("pk", None)
-        article = Article.objects.get(id=article_id)
+    def statistics(self, request, pk=None, *args, **kwargs) -> Response:
+        article = Article.objects.get(id=pk)
         user = request.user
 
         if not user or not user.is_authenticated:

--- a/lego/utils/functions.py
+++ b/lego/utils/functions.py
@@ -60,7 +60,7 @@ def request_plausible_statistics(obj: BasisModel, **kwargs) -> Response:
     if not (model_name or url_root):
         raise ValueError("Valid obj or url_root must be provided")
 
-    url_path = f"/{url_root or model_name + 's'}/{obj.id}"
+    url_path = f"/{url_root or model_name + 's'}/{obj.id}*"
     filters = f"event:page=={quote(url_path)}"
 
     api_url = (


### PR DESCRIPTION
# Description

Since events and articles use slugs, we need to use a wildcard `*` to group all pages matching `articles/<id>-<slug>`, not only `articles/<id>`. Pretty sure it works fine!

# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.


Resolves ABA-1396