### PR TITLE
No reminder for meeting templates 

### DIFF
--- a/lego/apps/meetings/tasks.py
+++ b/lego/apps/meetings/tasks.py
@@ -30,7 +30,7 @@ def notify_user_of_unanswered_meeting_invitation(self, logger_context=None):
         if (
             datetime.combine(meeting.start_time, time(0))
             - datetime.combine(timezone.now(), time(0))
-        ).days not in [7, 5, 3, 1]:
+        ).days not in [7, 5, 3, 1] or meeting.is_template:
             continue
 
         meeting_invitations: list[MeetingInvitation] = meeting.invitations.filter(


### PR DESCRIPTION
# Description

Edgecase that should not really happen as templates are supposed to be in the past but not yet enforced, so may occur as of now.
Removes reminder for meeting templates.


# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

Resolves ... (either GitHub issue or Linear task)
