### PR TITLE
**bug-fix** changed permission from abakom to abakus member

### DIFF
--- a/lego/apps/events/models.py
+++ b/lego/apps/events/models.py
@@ -136,7 +136,7 @@ class Event(Content, BasisModel, ObjectPermissionsModel):
     def user_should_see_regs(self, user: User) -> bool:
         return (
             self.get_possible_pools(user, future=True, is_admitted=False).exists()
-            or user.is_abakom_member
+            or user.is_abakus_member
             or (self.created_by is not None and self.created_by.id == user.id)
         )
 


### PR DESCRIPTION
# Description

Bug where users not part of pools tied to event could not see pools or registrations (same as if not logged in). 
Changed check from is_abakom to is_abakus allowing all abakus members (this seems reasonable)

Still need to clarify frontend message as to why user cannot register for event.

Before:
![image](https://github.com/user-attachments/assets/e1dd603e-bf8c-4dcd-987b-65c3c6327758)

After:
![image](https://github.com/user-attachments/assets/be016cb9-c7a5-4566-8381-c50b5ee1c622)


# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

I ran all(?) tests for LEGO as described in docs.

Resolves ABA-1404
