### PR TITLE
Fix type checking import needed in code

### DIFF
--- a/lego/apps/events/websockets.py
+++ b/lego/apps/events/websockets.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
+from lego.apps.events.models import Event
 from lego.apps.events.serializers.sockets import (
     EventReadDetailedSocketSerializer,
     RegistrationPaymentInitiateSocketSerializer,
@@ -19,7 +20,7 @@ from lego.apps.websockets.notifiers import notify_group
 if TYPE_CHECKING:
     from django.db.models.query import QuerySet
 
-    from lego.apps.events.models import Event, Registration
+    from lego.apps.events.models import Registration
     from lego.apps.users.models import User
 
 


### PR DESCRIPTION
# Description

I made a mistake when linting #3825 , and placed an import that was used in code in the `if TYPE_CHECKING:` block. I have no idea how this passed the tests...

# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

Resolves [LEGO-119](https://abakus.sentry.io/issues/6539431189/events/7eb52d155cdd4c4f9029ae14ab4dea6b/)
