### PR TITLE
Add HS-rep group to LDAP sync groups

### DIFF
--- a/lego/settings/lego.py
+++ b/lego/settings/lego.py
@@ -46,6 +46,7 @@ LDAP_GROUPS = [
     "xcom-data",
     "xcom-komtek",
     "Nestledere",
+    "HS-representant",
 ]
 
 SMTP_HOST = "0.0.0.0"


### PR DESCRIPTION
# Description
Created a new group for HS-rep in shell, and added it to the `LDAP_GROUPS` (the hardcoded list of groups that is synced to ldap, aka wiki), so that the HS-rep can have access to wiki without being showed as a HS-group member and getting extra permissions etc.

Resolves ABA-1439
