### PR TITLE
Add availability endpoint to lendable objects

### DIFF
--- a/lego/apps/lending/tests/test_lendableobject_api.py
+++ b/lego/apps/lending/tests/test_lendableobject_api.py
@@ -1,7 +1,11 @@
+from datetime import datetime, timedelta
+
 from django.urls import reverse
+from django.utils import timezone
 from rest_framework import status
 
-from lego.apps.lending.models import LendableObject
+from lego.apps.lending.constants import LENDING_REQUEST_STATUSES
+from lego.apps.lending.models import LendableObject, LendingRequest
 from lego.apps.lending.serializers import (
     LendableObjectAdminSerializer,
     LendableObjectSerializer,
@@ -18,6 +22,11 @@ def get_detail_url(pk):
     return reverse("api:v1:lendable-object-detail", kwargs={"pk": pk})
 
 
+def get_availability_url(pk, month, year):
+    base_url = reverse("api:v1:lendable-object-availability", kwargs={"pk": pk})
+    return f"{base_url}?month={month}&year={year}"
+
+
 def create_user(username="testuser", **kwargs):
     return User.objects.create(
         username=username, email=username + "@abakus.no", **kwargs
@@ -27,6 +36,19 @@ def create_user(username="testuser", **kwargs):
 def create_lendable_object(**kwargs):
     return LendableObject.objects.create(
         title="Test objekt", description="Denne kan lånes!", **kwargs
+    )
+
+
+def create_lending_request(lendable_object, user, start_date, end_date, status=None):
+    if status is None:
+        status = LENDING_REQUEST_STATUSES["LENDING_APPROVED"]["value"]
+
+    return LendingRequest.objects.create(
+        lendable_object=lendable_object,
+        created_by=user,
+        start_date=start_date,
+        end_date=end_date,
+        status=status,
     )
 
 
@@ -251,3 +273,93 @@ class CreateLendableObjectTestCase(BaseAPITestCase):
 
         lendable_object = LendableObject.objects.get(title="New title")
         self.assertEqual(lendable_object.title, "New title")
+
+
+class LendableObjectAvailabilityTestCase(BaseAPITestCase):
+    def setUp(self):
+        self.user = create_user()
+        self.group = create_group()
+        self.group.add_user(self.user)
+        self.lendable_object = create_lendable_object()
+
+        self.now = timezone.now()
+        self.year = self.now.year
+        self.month = self.now.month
+
+        self.start_of_month = timezone.make_aware(datetime(self.year, self.month, 1))
+
+        self.borrower = create_user(username="borrower")
+
+        self.lendable_object.can_view_groups.add(self.group)
+        self.lendable_object.can_edit_groups.add(self.group)
+
+        self.user.is_superuser = True
+        self.user.save()
+
+    def test_unauthenticated(self):
+        url = get_availability_url(self.lendable_object.pk, self.month, self.year)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_authenticated_without_permissions(self):
+        # Create a regular user without permissions
+        user_without_perms = create_user(username="nopermuser")
+        self.client.force_authenticate(user=user_without_perms)
+
+        url = get_availability_url(self.lendable_object.pk, self.month, self.year)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_invalid_month_parameter(self):
+        self.client.force_authenticate(user=self.user)
+        # Test with month=13 (invalid)
+        url = get_availability_url(self.lendable_object.pk, 13, self.year)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json(), {"detail": "Month must be between 1 and 12."})
+
+    def test_single_lending_request(self):
+        self.client.force_authenticate(user=self.user)
+
+        start_date = self.start_of_month
+        end_date = start_date + timedelta(days=10)
+
+        create_lending_request(
+            lendable_object=self.lendable_object,
+            user=self.borrower,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        url = get_availability_url(self.lendable_object.pk, self.month, self.year)
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.json()), 1)
+
+        unavailable_range = response.json()[0]
+        self.assertEqual(len(unavailable_range), 2)
+        self.assertEqual(unavailable_range[0], start_date.isoformat())
+        self.assertEqual(unavailable_range[1], end_date.isoformat())
+
+    def test_non_approved_request_not_included(self):
+        self.client.force_authenticate(user=self.user)
+
+        start_date = self.start_of_month
+        end_date = start_date + timedelta(days=10)
+
+        non_approved_status = LENDING_REQUEST_STATUSES["LENDING_DENIED"]["value"]
+
+        create_lending_request(
+            lendable_object=self.lendable_object,
+            user=self.borrower,
+            start_date=start_date,
+            end_date=end_date,
+            status=non_approved_status,
+        )
+
+        url = get_availability_url(self.lendable_object.pk, self.month, self.year)
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), [])


### PR DESCRIPTION
# Description

Adds a calendar to show unavailable time slots given a lendable object, as well the time slots chosen for the current lending request. The calendar is added to both the new lending request and lending request detail pages. 

Next step will be to make the calendar function as the date and time picker for new lending requests.

[Frontend PR](https://github.com/webkom/lego-webapp/pull/5586)

# Result

- [x] Changes look good on both light and dark theme.
- [ ] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

https://github.com/user-attachments/assets/9dd8f7ed-3d3a-45b8-bf9c-d5eca973b277

# Testing

- [x] I have thoroughly tested my changes.

Create and approve a lending request. Verify that the calendar displays unavailable and selected time slots correctly.

Resolves [ABA-1438](https://linear.app/abakus-webkom/issue/ABA-1438)
