### PR TITLE
Kontaktperson not part of normal event serializer

### DIFF
--- a/lego/apps/events/serializers/events.py
+++ b/lego/apps/events/serializers/events.py
@@ -85,12 +85,6 @@ class EventReadSerializer(
     registration_count = RegistrationCountField()
     total_capacity = TotalCapacityField()
     user_reg = serializers.SerializerMethodField()
-    responsible_users = PublicUserField(
-        queryset=User.objects.all(),
-        allow_null=False,
-        required=True,
-        many=True,
-    )
 
     class Meta:
         model = Event
@@ -115,7 +109,6 @@ class EventReadSerializer(
             "is_admitted",
             "survey",
             "is_priced",
-            "responsible_users",
             "is_foreign_language",
             "user_reg",
             "show_company_description",
@@ -145,12 +138,6 @@ class EventReadDetailedSerializer(
     created_by = PublicUserSerializer()
     registration_close_time = serializers.DateTimeField(read_only=True)
     unregistration_close_time = serializers.DateTimeField(read_only=True)
-    responsible_users = PublicUserField(
-        queryset=User.objects.all(),
-        allow_null=False,
-        required=True,
-        many=True,
-    )
 
     class Meta:
         model = Event
@@ -196,7 +183,6 @@ class EventReadDetailedSerializer(
             "use_consent",
             "youtube_url",
             "mazemap_poi",
-            "responsible_users",
             "is_foreign_language",
             "show_company_description",
         )
@@ -307,9 +293,16 @@ class EventReadAuthUserDetailedSerializer(EventReadUserDetailedSerializer):
     pools = PoolReadAuthSerializer(many=True)
     waiting_registrations = RegistrationReadSerializer(many=True)
     unanswered_surveys = serializers.SerializerMethodField()
+    responsible_users = PublicUserField(
+        queryset=User.objects.all(),
+        allow_null=False,
+        required=True,
+        many=True,
+    )
 
     class Meta(EventReadUserDetailedSerializer.Meta):
         fields = EventReadUserDetailedSerializer.Meta.fields + (  # type: ignore
+            "responsible_users",
             "waiting_registrations",
             "unanswered_surveys",
         )

--- a/lego/apps/events/serializers/events.py
+++ b/lego/apps/events/serializers/events.py
@@ -135,7 +135,6 @@ class EventReadDetailedSerializer(
     pools = PoolReadSerializer(many=True)
     active_capacity = serializers.ReadOnlyField()
     text = ContentSerializerField()
-    created_by = PublicUserSerializer()
     registration_close_time = serializers.DateTimeField(read_only=True)
     unregistration_close_time = serializers.DateTimeField(read_only=True)
 
@@ -177,7 +176,6 @@ class EventReadDetailedSerializer(
             "tags",
             "is_merged",
             "heed_penalties",
-            "created_by",
             "legacy_registration_count",
             "survey",
             "use_consent",
@@ -293,6 +291,7 @@ class EventReadAuthUserDetailedSerializer(EventReadUserDetailedSerializer):
     pools = PoolReadAuthSerializer(many=True)
     waiting_registrations = RegistrationReadSerializer(many=True)
     unanswered_surveys = serializers.SerializerMethodField()
+    created_by = PublicUserSerializer()
     responsible_users = PublicUserField(
         queryset=User.objects.all(),
         allow_null=False,
@@ -302,6 +301,7 @@ class EventReadAuthUserDetailedSerializer(EventReadUserDetailedSerializer):
 
     class Meta(EventReadUserDetailedSerializer.Meta):
         fields = EventReadUserDetailedSerializer.Meta.fields + (  # type: ignore
+            "created_by",
             "responsible_users",
             "waiting_registrations",
             "unanswered_surveys",


### PR DESCRIPTION
# Description

**bug-fix** User will get less personal information if not logged in about events.

Before:
<img width="374" height="189" alt="image" src="https://github.com/user-attachments/assets/8fbcbe7d-f4d8-422f-aae9-ee2b70ee96ae" />

After:
<img width="361" height="238" alt="Screenshot from 2025-09-20 13-49-54" src="https://github.com/user-attachments/assets/10b2e50d-06ee-4f2d-aa4b-bda076b99aa3" />

Don't mind that there are 2 differents events.

# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x ] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

Ran test suite for lego.apps.events

Resolves ABA-1515
