### PR TITLE
Fix: Restrict pool updates to pools with registrations

### DIFF
--- a/lego/apps/events/models.py
+++ b/lego/apps/events/models.py
@@ -849,6 +849,9 @@ class Pool(BasisModel):
         self.save(update_fields=["counter"])
         return self
 
+    def permission_group_ids(self) -> set[int]:
+        return set(self.permission_groups.values_list("id", flat=True))
+
     @abakus_cached_property
     def all_permission_groups(self):
         groups = self.permission_groups.all()

--- a/lego/apps/events/tests/test_events_api.py
+++ b/lego/apps/events/tests/test_events_api.py
@@ -1000,6 +1000,31 @@ class PoolsTestCase(BaseAPITestCase):
         pool_response = self.client.delete(_get_pools_detail_url(1, pool.id))
         self.assertEqual(pool_response.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_patch_permission_groups_in_pool_with_registrations(self):
+        """Test that change of permission group is not possible in pool with registrations"""
+        AbakusGroup.objects.get(name="Bedkom").add_user(self.abakus_user)
+        self.client.force_authenticate(self.abakus_user)
+        new_group = AbakusGroup.objects.get(name="Webkom")
+        pool_response = self.client.patch(
+            _get_pools_detail_url(1, 1),
+            {"permissionGroups": [new_group.id]},
+            format="json",
+        )
+        self.assertEqual(pool_response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("permissionGroups", pool_response.json())
+
+    def test_patch_activation_date_in_pool_with_registrations(self):
+        """Test that change of activation date is not possible in pool with registrations"""
+        AbakusGroup.objects.get(name="Bedkom").add_user(self.abakus_user)
+        self.client.force_authenticate(self.abakus_user)
+        pool_response = self.client.patch(
+            _get_pools_detail_url(1, 1),
+            {"activationDate": timezone.now().isoformat()},
+            format="json",
+        )
+        self.assertEqual(pool_response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("activationDate", pool_response.json())
+
 
 @mock.patch("lego.apps.events.views.verify_captcha", return_value=True)
 class RegistrationsTransactionTestCase(BaseAPITransactionTestCase):

--- a/lego/apps/events/views.py
+++ b/lego/apps/events/views.py
@@ -346,10 +346,17 @@ class PoolViewSet(
     serializer_class = PoolCreateAndUpdateSerializer
 
     def get_queryset(self):
-        event_id = self.kwargs.get("event_pk", None)
+        event_id = self.kwargs.get("event_pk")
         return Pool.objects.filter(event=event_id).prefetch_related(
             "permission_groups", "registrations"
         )
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        event_id = self.kwargs.get("event_pk")
+        if event_id:
+            context["event"] = get_object_or_404(Event, pk=event_id)
+        return context
 
     def destroy(self, request, *args, **kwargs):
         try:


### PR DESCRIPTION
# Description

Blocks edits to permission groups and activation date in pools with registrations. Validation is added in the pool serializer, and event updates now delegates to it. Added tests and removed unused create method in the pool read-only serializer. It is only used for event read so it feels safe to clean up.

# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

