### PR TITLE
add name and username returns for the lendingobject availability request

### DIFF
--- a/lego/apps/lending/tests/test_lendableobject_api.py
+++ b/lego/apps/lending/tests/test_lendableobject_api.py
@@ -371,7 +371,18 @@ class LendableObjectAvailabilityTestCase(BaseAPITestCase):
         self.assertEqual(len(unavailable_range), 4)
         self.assertEqual(unavailable_range[0], start_date.isoformat())
         self.assertEqual(unavailable_range[1], end_date.isoformat())
-        self.assertEqual(unavailable_range[2], ("" if (self.borrower is None or self.borrower.first_name is None or self.borrower.last_name is None) else self.borrower.get_full_name()).strip())
+        self.assertEqual(
+            unavailable_range[2],
+            (
+                ""
+                if (
+                    self.borrower is None
+                    or self.borrower.first_name is None
+                    or self.borrower.last_name is None
+                )
+                else self.borrower.get_full_name()
+            ).strip(),
+        )
 
     def test_non_approved_request_not_included(self):
         self.client.force_authenticate(user=self.user)

--- a/lego/apps/lending/views.py
+++ b/lego/apps/lending/views.py
@@ -88,7 +88,11 @@ class LendableObjectViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
             [
                 start.isoformat(),
                 end.isoformat(),
-                "" if (created_by is None or created_by.full_name() is None) else created_by.get_full_name(),
+                (
+                    ""
+                    if (created_by is None or created_by.full_name() is None)
+                    else created_by.get_full_name()
+                ),
                 "" if (created_by is None) else created_by.username,
             ]
             for start, end, created_by in unavailable_ranges


### PR DESCRIPTION
# Description

lending request availability now also returns name and username. The issue was supposed to only be a frontend issue (@ch0rizo) This is an antempt fix the issue. 
I don't think I will have time before Tuesday, so if anyone wants to they can fix any bugs



ABA-1589