### PR TITLE
Fix datetime test for events

### DIFF
--- a/lego/apps/events/websockets.py
+++ b/lego/apps/events/websockets.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import TYPE_CHECKING
+
+from django.utils import timezone
 
 from lego.apps.events.models import Event
 from lego.apps.events.serializers.sockets import (
@@ -33,7 +35,7 @@ def find_event_groups(user: User) -> list[str]:
     that has not started and that started less than two days ago.
     """
     queryset: QuerySet[Event] = Event.objects.filter(
-        start_time__gt=datetime.now() - timedelta(days=2)
+        start_time__gt=timezone.now() - timedelta(days=2)
     )
     if not user.has_perm(LIST, queryset):
         permission_handler = get_permission_handler(queryset.model)


### PR DESCRIPTION
# Description

Problem:

datetime.now() (Python stdlib) gives a naive datetime by default (no timezone info).
timezone.now() (Django) respects your Django setting USE_TZ.

In project, USE_TZ = True, so Django expects timezone-aware datetimes for DateTimeFields like Event.start_time.
When code used naive time (datetime.now()), Django emitted:

RuntimeWarning: DateTimeField Event.start_time received a naive datetime... while time zone support is active.


# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

Resolves #3906 
