### PR TITLE
fix: allow change of event type when registrations exist

### DIFF
--- a/lego/apps/events/serializers/events.py
+++ b/lego/apps/events/serializers/events.py
@@ -495,6 +495,10 @@ class EventCreateAndUpdateSerializer(
                     pool_serializer.is_valid(raise_exception=True)
                     pool_serializer.save()
                 if existing_ids:
+                    if event_status_type in (constants.TBA, constants.OPEN):
+                        Registration.objects.filter(pool_id__in=existing_ids).update(
+                            pool=None
+                        )
                     for pool_obj in Pool.objects.filter(
                         event=instance, id__in=existing_ids
                     ).iterator():


### PR DESCRIPTION
# Description
This change fixes the issue of not being able to update the event type to OPEN or TBA after registrations exist. 
When registrations are referencing the pools they cannot be deleted, and the update failed for event types not using pools.

# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

Tested locally by updating events with existing registrations to OPEN and TBA.
Resolves #4096 
