### PR TITLE
Allow self-approval, but not self-request changes

### DIFF
--- a/lego/apps/lending/serializers.py
+++ b/lego/apps/lending/serializers.py
@@ -91,7 +91,6 @@ class TimelineEntrySerializer(BasisModelSerializer):
 
 
 class TimelineEntryCreateAndUpdateSerializer(BasisModelSerializer):
-
     class Meta:
         model = TimelineEntry
         fields = (
@@ -214,14 +213,17 @@ class LendingRequestCreateAndUpdateSerializer(BasisModelSerializer):
             if "status" in attrs:
                 new_status = attrs["status"]
 
-                user_in_edit_group = False
+                user_can_edit = False
                 if lendable_object:
                     group_ids = [group.pk for group in user.all_groups]
-                    user_in_edit_group = lendable_object.can_edit_groups.filter(
-                        pk__in=group_ids
-                    ).exists()
+                    user_can_edit = (
+                        lendable_object.can_edit_users.filter(pk=user.pk).exists()
+                        or lendable_object.can_edit_groups.filter(
+                            pk__in=group_ids
+                        ).exists()
+                    )
 
-                if not user_in_edit_group and new_status not in (
+                if not user_can_edit and new_status not in (
                     LENDING_REQUEST_STATUSES["LENDING_CANCELLED"]["value"],
                     LENDING_REQUEST_STATUSES["LENDING_UNAPPROVED"]["value"],
                 ):
@@ -234,20 +236,20 @@ class LendingRequestCreateAndUpdateSerializer(BasisModelSerializer):
                         }
                     )
                 if (
+                    self.instance.created_by == user
+                    and new_status
+                    == LENDING_REQUEST_STATUSES["LENDING_CHANGES_REQUESTED"]["value"]
+                ):
+                    raise serializers.ValidationError(
+                        {"status": ("You cannot request changes for your own request.")}
+                    )
+                if (
                     self.instance.created_by != user
                     and new_status
                     == LENDING_REQUEST_STATUSES["LENDING_CANCELLED"]["value"]
                 ):
                     raise serializers.ValidationError(
                         {"status": ("You cannot cancel someone else's request.. ")}
-                    )
-                if (
-                    self.instance.created_by == user
-                    and new_status
-                    == LENDING_REQUEST_STATUSES["LENDING_APPROVED"]["value"]
-                ):
-                    raise serializers.ValidationError(
-                        {"status": ("You cannot approve your own request.. ")}
                     )
 
         return attrs

--- a/lego/apps/lending/tests/test_lendingrequest_api.py
+++ b/lego/apps/lending/tests/test_lendingrequest_api.py
@@ -661,17 +661,31 @@ class LendingRequestAdditionalPermissionTestCase(BaseAPITestCase):
             "You cannot cancel someone else's request", patch_response.data["status"][0]
         )
 
-    def test_user_cant_approve_own_request(self):
-        """User should not be able to approve own request"""
-        self.client.force_authenticate(user=self.creator_user)
-        patch_data = {"status": "approved"}
+    def test_user_without_edit_permission_cant_approve_own_request(self):
+        """A requester without edit permission should not be able to approve own request."""
+        view_only_user = User.objects.create(
+            username="view_only_user", email="view_only@abakus.no"
+        )
+        self.view_group.add_user(view_only_user)
+
+        self.client.force_authenticate(user=view_only_user)
+        create_data = {
+            "lendable_object": self.lendable_object.pk,
+            "start_date": (now() + timedelta(days=1)).isoformat(),
+            "end_date": (now() + timedelta(days=2)).isoformat(),
+        }
+        create_response = self.client.post(get_lending_request_list_url(), create_data)
+        self.assertEqual(create_response.status_code, status.HTTP_201_CREATED)
+
         patch_response = self.client.patch(
-            get_lending_request_detail_url(self.request_id), patch_data
+            get_lending_request_detail_url(create_response.data["id"]),
+            {"status": "approved"},
         )
         self.assertEqual(patch_response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("status", patch_response.data)
         self.assertIn(
-            "You cannot approve your own request", patch_response.data["status"][0]
+            "You cannot change the status to that value",
+            patch_response.data["status"][0],
         )
 
     def test_creation_creates_system_linelineentry(self):
@@ -784,3 +798,54 @@ class LendingRequestApprovalByDifferentUserTestCase(BaseAPITestCase):
         self.assertEqual(system_timelineentry.is_system, True)
         # Optionally check that the entry was created by the approver.
         self.assertEqual(system_timelineentry.created_by, self.approver_user)
+
+
+class LendingRequestApprovalByResponsibleUserTestCase(BaseAPITestCase):
+    def setUp(self):
+        self.responsible_user = User.objects.create(
+            username="responsible_user", email="responsible@example.com"
+        )
+        self.view_group = AbakusGroup.objects.create(name="responsible_view_group")
+        self.view_group.add_user(self.responsible_user)
+
+        self.lendable_object = LendableObject.objects.create(
+            title="Test Object", description="Testing object"
+        )
+        self.lendable_object.can_view_groups.add(self.view_group)
+        self.lendable_object.can_edit_users.add(self.responsible_user)
+
+        self.client.force_authenticate(user=self.responsible_user)
+        create_data = {
+            "lendable_object": self.lendable_object.pk,
+            "start_date": (now() + timedelta(days=1)).isoformat(),
+            "end_date": (now() + timedelta(days=2)).isoformat(),
+        }
+        create_response = self.client.post(get_lending_request_list_url(), create_data)
+        self.assertEqual(create_response.status_code, status.HTTP_201_CREATED)
+        self.request_id = create_response.data["id"]
+
+    def test_responsible_user_can_approve_own_request(self):
+        patch_response = self.client.patch(
+            get_lending_request_detail_url(self.request_id), {"status": "approved"}
+        )
+
+        self.assertEqual(patch_response.status_code, status.HTTP_200_OK)
+
+        lending_request = LendingRequest.objects.get(pk=self.request_id)
+        self.assertEqual(lending_request.status, "approved")
+
+    def test_responsible_user_cannot_request_changes_on_own_request(self):
+        patch_response = self.client.patch(
+            get_lending_request_detail_url(self.request_id),
+            {"status": "changes_requested"},
+        )
+
+        self.assertEqual(patch_response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("status", patch_response.data)
+        self.assertIn(
+            "You cannot request changes for your own request.",
+            patch_response.data["status"][0],
+        )
+
+        lending_request = LendingRequest.objects.get(pk=self.request_id)
+        self.assertEqual(lending_request.status, "unapproved")


### PR DESCRIPTION
# Description

Make it possible for user who's admin for the object to approve their own request of it.
Disallow request changes when its their lendable object.

@itsisak 😝

# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

Resolves #4107 
