### PR TITLE
Availability endpoint gives RequestId and Edit boolean

### DIFF
--- a/lego/apps/lending/tests/test_lendableobject_api.py
+++ b/lego/apps/lending/tests/test_lendableobject_api.py
@@ -441,7 +441,7 @@ class LendableObjectAvailabilityTestCase(BaseAPITestCase):
         self.assertEqual(len(response.json()), 1)
 
         unavailable_range = response.json()[0]
-        self.assertEqual(len(unavailable_range), 4)
+        self.assertEqual(len(unavailable_range), 6)
         self.assertEqual(unavailable_range[0], start_date.isoformat())
         self.assertEqual(unavailable_range[1], end_date.isoformat())
 

--- a/lego/apps/lending/views.py
+++ b/lego/apps/lending/views.py
@@ -83,9 +83,13 @@ class LendableObjectViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
         for request in overlapping_requests:
             range_start = max(request.start_date, start_of_month)
             range_end = min(request.end_date, end_of_month)
-            canEditRequest = request._meta.permission_handler.has_perm(user, EDIT, request)
+            canEditRequest = request._meta.permission_handler.has_perm(
+                user, EDIT, request
+            )
 
-            unavailable_ranges.append([range_start, range_end, request.created_by, request.id, canEditRequest])
+            unavailable_ranges.append(
+                [range_start, range_end, request.created_by, request.id, canEditRequest]
+            )
 
         formatted_ranges = []
         for i in range(len(unavailable_ranges)):
@@ -108,7 +112,14 @@ class LendableObjectViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
                 created_by_fullname = None
             created_by_username = None if (created_by is None) else created_by.username
             formatted_ranges.append(
-                [start_date, end_date, id, canEdit, created_by_fullname, created_by_username]
+                [
+                    start_date,
+                    end_date,
+                    id,
+                    canEdit,
+                    created_by_fullname,
+                    created_by_username,
+                ]
             )
 
         return Response(formatted_ranges)

--- a/lego/apps/lending/views.py
+++ b/lego/apps/lending/views.py
@@ -48,6 +48,7 @@ class LendableObjectViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
         for a specified month and year.
         """
         lendable_object = self.get_object()
+        user = request.user
 
         try:
             month = int(request.query_params.get("month", ""))
@@ -82,12 +83,13 @@ class LendableObjectViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
         for request in overlapping_requests:
             range_start = max(request.start_date, start_of_month)
             range_end = min(request.end_date, end_of_month)
+            canEditRequest = request._meta.permission_handler.has_perm(user, EDIT, request)
 
-            unavailable_ranges.append([range_start, range_end, request.created_by])
+            unavailable_ranges.append([range_start, range_end, request.created_by, request.id, canEditRequest])
 
         formatted_ranges = []
         for i in range(len(unavailable_ranges)):
-            start, end, created_by = unavailable_ranges[i]
+            start, end, created_by, id, canEdit = unavailable_ranges[i]
             start_date = start.isoformat()
             end_date = end.isoformat()
             created_by_username = created_by
@@ -106,7 +108,7 @@ class LendableObjectViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
                 created_by_fullname = None
             created_by_username = None if (created_by is None) else created_by.username
             formatted_ranges.append(
-                [start_date, end_date, created_by_fullname, created_by_username]
+                [start_date, end_date, id, canEdit, created_by_fullname, created_by_username]
             )
 
         return Response(formatted_ranges)


### PR DESCRIPTION
# Description

Availability endpoint passes RequestId and CanEdit fields along with old ones. For every unavailable range the corresponding LendingRequestId is passed as well as a permission check for the user making the request if they are allowed to make changes to said request.

Allows lending calender to link unavailable times (approved requests) to the actual request if the user has the permission to do so.

Changed Lending API test to accept answer length 6 to accommodate 2 extra fields being passed.

# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

Ran all lego tests along with code style fixes.

Resolves [webkom x bekk](https://github.com/orgs/webkom/projects/7/views/10?pane=issue&itemId=174112694&issue=webkom|lego-webapp|5930)