### PR TITLE
Add responsible group to serializer

### DIFF
--- a/lego/apps/events/serializers/events.py
+++ b/lego/apps/events/serializers/events.py
@@ -71,6 +71,7 @@ class EventReadSerializer(
     TagSerializerMixin, BasisModelSerializer, ObjectPermissionsSerializerMixin
 ):
     company = CompanyField(queryset=Company.objects.all())
+    responsible_group = PublicAbakusGroupSerializer(read_only=True)
     cover = ImageField(required=False, options={"height": 500})
     cover_placeholder = ImageField(
         source="cover", required=False, options={"height": 50, "filters": ["blur(20)"]}
@@ -103,6 +104,7 @@ class EventReadSerializer(
             "thumbnail",
             "total_capacity",
             "company",
+            "responsible_group",
             "registration_count",
             "tags",
             "activation_time",


### PR DESCRIPTION
# Description

EventSerializer now return responsible group, needed to find out what interest group is responsible group for interest events

# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

Resolves #4121 
