### PR TITLE
Stop privilege escalation by group leaders

### DIFF
--- a/lego/apps/users/permissions.py
+++ b/lego/apps/users/permissions.py
@@ -71,7 +71,18 @@ class PreventPermissionElevation(LegoPermissions):
     def has_permission(self, request, view):
         if request.method in ["CREATE", "PUT", "PATCH"]:
             user = request.user
-            requested_permissions = request.data.get("permissions", [])
+            requested_permissions = list(request.data.get("permissions", []))
+
+            parent_id = request.data.get("parent")
+            if parent_id:
+                from lego.apps.users.models import AbakusGroup
+
+                try:
+                    parent = AbakusGroup.objects.get(id=parent_id)
+                except (AbakusGroup.DoesNotExist, ValueError, TypeError):
+                    return False
+                for group in parent.get_ancestors(include_self=True):
+                    requested_permissions += list(group.permissions)
 
             if not user.has_perms(requested_permissions):
                 return False


### PR DESCRIPTION
Kjære webkom,

Jeg ønsker å meddele at dere har blitt pwnet 🥰


<img width="400" height="310" alt="image" src="https://github.com/user-attachments/assets/3bc973d7-a61a-4efc-b1f0-4a4f9b2ea8de" /><br>

Jeg (og claude code) har funnet et sikkerhetshull som tillatter en hvilken som helst gruppeleder, inkludert ledere av interessegrupper kan få sudottilgang på LEGO ved å endre parent gruppen til egen gruppe til f.eks webkom

På tross av fristelsen til å stifte interessegruppen for pils og sprit og utnytte feilen, har jeg bestemt meg for å være snill som medlem av deres søskenkomite, og gjøre responsible disclosure 🙏

PR'en her sørger for at når du endrer parent gruppe så sjekker den att du ikke får noen nye permissions, men dere kan jo vurdere om man skal kunne endre parent gruppe i det hele tatt.

Vennlig hilsen Jo fra Dotkom, den beste kodekomiteen på NTNU ❤️