### PR TITLE
Non-authenticated PPI access

### DIFF
--- a/lego/apps/events/tests/test_events_api.py
+++ b/lego/apps/events/tests/test_events_api.py
@@ -1512,6 +1512,28 @@ class AllergiesTestCase(BaseAPITestCase):
             .get("allergies")
         )
 
+    def test_allergies_endpoint_without_permission_returns_403(self):
+        user = User.objects.get(pk=2)
+        AbakusGroup.objects.get(name="Abakom").add_user(user)
+        self.client.force_authenticate(user)
+
+        event_response = self.client.get(f"{_get_detail_url(self.event.id)}allergies/")
+
+        self.assertEqual(event_response.status_code, status.HTTP_403_FORBIDDEN)
+        body = event_response.json()
+        for leaked_field in (
+            "pools",
+            "waiting_registrations",
+            "unregistered",
+            "responsible_users",
+        ):
+            self.assertNotIn(leaked_field, body)
+
+    def test_allergies_endpoint_unauthenticated_returns_401(self):
+        event_response = self.client.get(f"{_get_detail_url(self.event.id)}allergies/")
+
+        self.assertEqual(event_response.status_code, status.HTTP_401_UNAUTHORIZED)
+
 
 class CreateAdminRegistrationTestCase(BaseAPITestCase):
     fixtures = [

--- a/lego/apps/events/views.py
+++ b/lego/apps/events/views.py
@@ -243,13 +243,10 @@ class EventViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
 
     @decorators.action(detail=True, methods=["GET"])
     def allergies(self, request, *args, **kwargs):
-        event_id = self.kwargs.get("pk", None)
-        serializer = EventAdministrateSerializer
-        event = Event.objects.get(pk=event_id)
-        if event.user_should_see_allergies(request.user):
-            serializer = EventAdministrateAllergiesSerializer
-
-        event_data = serializer(event).data
+        event = self.get_object()
+        if not event.user_should_see_allergies(request.user):
+            raise PermissionDenied()
+        event_data = EventAdministrateAllergiesSerializer(event).data
         return Response(event_data)
 
     @decorators.action(detail=True, methods=["GET"])


### PR DESCRIPTION
# Description

`GET /api/v1/events/{id}/allergies/` endpoint returned PPI for people attending the event. Also allowed non-logged in and logged in members to view that information.

The fix only allows event administrators to access allergies. Corresponding [frontend PR](https://github.com/webkom/lego-webapp/compare/fix-ppi-leak-allergies?expand=1)


# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

Resolves #4156 
