### PR TITLE
Fix: none template in surveys

### DIFF
--- a/lego/apps/surveys/tasks.py
+++ b/lego/apps/surveys/tasks.py
@@ -16,7 +16,10 @@ def send_survey_mail(self, logger_context=None):
     self.setup_logger(logger_context)
 
     surveys = Survey.objects.filter(
-        active_from__lte=timezone.now(), sent=False, template_type=None
+        active_from__lte=timezone.now(),
+        sent=False,
+        is_template=False,
+        event__isnull=False,
     )
     for survey in surveys.all():
         for registration in survey.event.registrations.filter(


### PR DESCRIPTION
# Description

After many sentry error notifications:

Migration-13 introduced that new templates can be created. Therefore the old `templete_type=None` filter no longer works. New templates can be created with `templete_type=None` and `templete_type=True`


# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

Resolves #4158 
