### PR TITLE
Sort contact form recipients for a deterministic order

### DIFF
--- a/lego/apps/contact/send.py
+++ b/lego/apps/contact/send.py
@@ -44,4 +44,5 @@ def get_recipients(recipient_group):
             role=LEADER
         ).select_related("user")
     ]
-    return [leader.email_address for leader in recipient_leaders]
+    # Sort for a deterministic recipient order (the query has no inherent ordering).
+    return sorted(leader.email_address for leader in recipient_leaders)

--- a/lego/apps/contact/tests/test_send.py
+++ b/lego/apps/contact/tests/test_send.py
@@ -98,7 +98,9 @@ class SendTestCase(BaseTestCase):
 
         send_message("title", "message", logged_in_user, self.webkom_group)
         mock_send_email.assert_called_with(
-            to_email=[self.webkom_leader.email_address, logged_in_user.email_address],
+            to_email=sorted(
+                [self.webkom_leader.email_address, logged_in_user.email_address]
+            ),
             context={
                 "title": "title",
                 "message": "message",


### PR DESCRIPTION
get_recipients returned leader emails in the database's arbitrary order, so with several leaders the recipient list (and assertion in test_send_to_group_with_several_leaders) was order-dependent and flaky. Sort the emails so the order is stable; mirror the sort in the test.


# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

Resolves #4164 
