### PR TITLE
Add optional capacity to open events with registration

### DIFF
--- a/lego/apps/events/constants.py
+++ b/lego/apps/events/constants.py
@@ -49,7 +49,9 @@ This even status type should be used for most events.
 """
 NORMAL = "NORMAL"
 """
-Events marked as INFINITE should have exactly 1 pool, with capacity set to 0.
+Events marked as INFINITE should have exactly 1 pool. Capacity 0 (the
+default) means unlimited; a capacity can be set to limit the number of spots,
+with the waiting list handling the overflow.
 A user _should_ be able to sign up to the event.
 There are no permissions (except Abakom).
 This even status type should be used for events such as Abakom Works, etc.

--- a/lego/apps/events/serializers/events.py
+++ b/lego/apps/events/serializers/events.py
@@ -433,7 +433,7 @@ class EventCreateAndUpdateSerializer(
             pools = []
         elif event_status_type == constants.INFINITE:
             pools = [pools[0]]
-            pools[0]["capacity"] = 0
+            pools[0].setdefault("capacity", 0)
         with transaction.atomic():
             event = super().create(validated_data)
             for pool in pools:
@@ -464,7 +464,7 @@ class EventCreateAndUpdateSerializer(
             pools = []
         elif event_status_type == constants.INFINITE and pools:
             pools = [pools[0]]
-            pools[0]["capacity"] = 0
+            pools[0].setdefault("capacity", 0)
         with transaction.atomic():
             if pools is not None:
                 existing_ids = set(instance.pools.values_list("id", flat=True))

--- a/lego/apps/events/tests/test_events_api.py
+++ b/lego/apps/events/tests/test_events_api.py
@@ -616,6 +616,15 @@ class CreateEventsTestCase(BaseAPITestCase):
         created_event = Event.objects.get(id=self.event_id)
         self.assertEqual(created_event.event_status_type, "INFINITE")
         self.assertEqual(len(created_event.pools.all()), 1)
+        self.assertEqual(created_event.pools.first().capacity, 10)
+
+    def test_event_creation_infinite_default_unlimited(self):
+        """Test that INFINITE events without a capacity default to unlimited"""
+        event_data = deepcopy(_test_event_data[4])
+        del event_data["pools"][0]["capacity"]
+        event_response = self.client.post(_get_list_url(), event_data)
+        self.assertEqual(event_response.status_code, status.HTTP_201_CREATED)
+        created_event = Event.objects.get(id=event_response.json()["id"])
         self.assertEqual(created_event.pools.first().capacity, 0)
 
     def test_event_create_no_event_status_type(self):

--- a/lego/apps/events/tests/test_events_api.py
+++ b/lego/apps/events/tests/test_events_api.py
@@ -750,6 +750,43 @@ class CreateEventsTestCase(BaseAPITestCase):
         event = Event.objects.get(id=event_id)
         self.assertEqual(event.pools.count(), 1)
 
+    def test_event_partial_update_infinite_with_pools_keeps_capacity(self):
+        """Test patching INFINITE events with pools keeps the provided capacity."""
+        event_response = self.client.post(
+            _get_list_url(), deepcopy(_test_event_data[4])
+        )
+        self.assertEqual(event_response.status_code, status.HTTP_201_CREATED)
+        event_id = event_response.json()["id"]
+        pool = event_response.json()["pools"][0]
+
+        event_update_response = self.client.patch(
+            _get_detail_url(event_id), {"pools": [{**pool, "capacity": 5}]}
+        )
+        self.assertEqual(event_update_response.status_code, status.HTTP_200_OK)
+
+        event = Event.objects.get(id=event_id)
+        self.assertEqual(event.pools.count(), 1)
+        self.assertEqual(event.pools.first().capacity, 5)
+
+    def test_event_partial_update_infinite_pools_without_capacity_unlimited(self):
+        """Test patching INFINITE events with a pool without capacity defaults to unlimited."""
+        event_response = self.client.post(
+            _get_list_url(), deepcopy(_test_event_data[4])
+        )
+        self.assertEqual(event_response.status_code, status.HTTP_201_CREATED)
+        event_id = event_response.json()["id"]
+        pool = event_response.json()["pools"][0]
+        del pool["capacity"]
+
+        event_update_response = self.client.patch(
+            _get_detail_url(event_id), {"pools": [pool]}
+        )
+        self.assertEqual(event_update_response.status_code, status.HTTP_200_OK)
+
+        event = Event.objects.get(id=event_id)
+        self.assertEqual(event.pools.count(), 1)
+        self.assertEqual(event.pools.first().capacity, 0)
+
     def test_event_pinned_only_one(self):
         """Test that there is only one pinned event at a time"""
         self.client.patch(_get_detail_url(self.event_id), {"pinned": True})

--- a/lego/apps/events/tests/test_registrations.py
+++ b/lego/apps/events/tests/test_registrations.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 from django.utils import timezone
 
+from lego.apps.events.constants import INFINITE
 from lego.apps.events.exceptions import EventNotReady
 from lego.apps.events.models import Event, Pool, Registration
 from lego.apps.followers.models import FollowEvent
@@ -1046,3 +1047,73 @@ class RegistrationTestCase(BaseTestCase):
         registration = Registration.objects.get_or_create(event=event, user=user)[0]
         with self.assertRaises(EventNotReady):
             event.register(registration)
+
+
+class InfiniteEventCapacityTestCase(BaseTestCase):
+    fixtures = [
+        "test_abakus_groups.yaml",
+        "test_users.yaml",
+        "test_companies.yaml",
+        "test_events.yaml",
+    ]
+
+    def setUp(self):
+        Event.objects.all().update(
+            start_time=timezone.now() + timedelta(hours=3),
+            merge_time=timezone.now() + timedelta(hours=12),
+        )
+        self.event = Event.objects.get(title="POOLS_NO_REGISTRATIONS")
+        self.event.event_status_type = INFINITE
+        self.event.save()
+
+        self.pool = self.event.pools.first()
+        for pool in self.event.pools.exclude(id=self.pool.id):
+            pool.delete()
+        self.pool.capacity = 2
+        self.pool.save()
+
+    def test_full_capped_event_waitlists(self):
+        """Registrations beyond a capped INFINITE pool go to the waiting list"""
+        users = get_dummy_users(3)
+        for user in users:
+            AbakusGroup.objects.get(name="Abakus").add_user(user)
+            registration = Registration.objects.get_or_create(
+                event=self.event, user=user
+            )[0]
+            self.event.register(registration)
+
+        self.assertEqual(self.pool.registrations.count(), 2)
+        self.assertEqual(self.event.waiting_registrations.count(), 1)
+
+    def test_unregistration_bumps_waiting_list(self):
+        """Leaving a full capped INFINITE event bumps the first in line"""
+        users = get_dummy_users(3)
+        registrations = []
+        for user in users:
+            AbakusGroup.objects.get(name="Abakus").add_user(user)
+            registration = Registration.objects.get_or_create(
+                event=self.event, user=user
+            )[0]
+            registrations.append(self.event.register(registration))
+
+        self.event.unregister(registrations[0])
+
+        self.assertEqual(self.pool.registrations.count(), 2)
+        self.assertEqual(self.event.waiting_registrations.count(), 0)
+        self.assertEqual(self.event.number_of_registrations, 2)
+
+    def test_uncapped_pool_never_waitlists(self):
+        """Capacity 0 still means unlimited"""
+        self.pool.capacity = 0
+        self.pool.save()
+
+        users = get_dummy_users(5)
+        for user in users:
+            AbakusGroup.objects.get(name="Abakus").add_user(user)
+            registration = Registration.objects.get_or_create(
+                event=self.event, user=user
+            )[0]
+            self.event.register(registration)
+
+        self.assertEqual(self.pool.registrations.count(), 5)
+        self.assertEqual(self.event.waiting_registrations.count(), 0)


### PR DESCRIPTION
# Description

Add the possibility for open events with registration to have capacity limit

Frontend PR: Add optional capacity to open events with registration
#6007


# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

Resolves #4176 
