### PR TITLE
Seed interest groups and add interest event dev fixtures

### DIFF
--- a/lego/apps/events/fixtures/development_events.yaml
+++ b/lego/apps/events/fixtures/development_events.yaml
@@ -1463,7 +1463,10 @@
     description: Brettspill og pizza med interessegruppen.
     end_time: '2026-06-10T20:00:00+00:00'
     event_type: interest_event
-    event_status_type: NORMAL
+    use_captcha: false
+    registration_deadline_hours: 0
+    heed_penalties: false
+    event_status_type: INFINITE
     location: Abakus-kontoret
     start_time: '2026-06-10T16:00:00+00:00'
     text: '<p>En koselig kveld med brettspill og pizza.</p>'
@@ -1478,7 +1481,10 @@
     description: Bli med på klatring i Trondheim!
     end_time: '2026-06-13T20:00:00+00:00'
     event_type: interest_event
-    event_status_type: NORMAL
+    use_captcha: false
+    registration_deadline_hours: 0
+    heed_penalties: false
+    event_status_type: INFINITE
     location: Trondheim klatresenter
     start_time: '2026-06-13T17:00:00+00:00'
     text: '<p>Vi møtes for en kveld med klatring og sosialt samvær.</p>'
@@ -1493,7 +1499,10 @@
     description: LAN-kveld for alle gamere.
     end_time: '2026-06-25T23:00:00+00:00'
     event_type: interest_event
-    event_status_type: NORMAL
+    use_captcha: false
+    registration_deadline_hours: 0
+    heed_penalties: false
+    event_status_type: INFINITE
     location: Realfagbygget
     start_time: '2026-06-25T17:00:00+00:00'
     text: '<p>Ta med deg PC-en og bli med på LAN!</p>'
@@ -1508,7 +1517,10 @@
     description: Bli med på fototur langs Nidelva med Fotogjengen.
     end_time: '2026-07-02T20:00:00+00:00'
     event_type: interest_event
-    event_status_type: NORMAL
+    use_captcha: false
+    registration_deadline_hours: 0
+    heed_penalties: false
+    event_status_type: INFINITE
     location: Nidelva
     start_time: '2026-07-02T16:00:00+00:00'
     text: '<p>Lær deg grunnleggende fotografering på en sosial fototur.</p>'
@@ -1523,7 +1535,10 @@
     description: Filmkveld med popcorn og god stemning.
     end_time: '2026-06-08T22:00:00+00:00'
     event_type: interest_event
-    event_status_type: NORMAL
+    use_captcha: false
+    registration_deadline_hours: 0
+    heed_penalties: false
+    event_status_type: INFINITE
     location: Abakus-kontoret
     start_time: '2026-06-08T19:00:00+00:00'
     text: '<p>Vi ser film og koser oss sammen.</p>'
@@ -1538,7 +1553,10 @@
     description: Rolig yogaøkt for alle nivåer.
     end_time: '2026-06-13T16:00:00+00:00'
     event_type: interest_event
-    event_status_type: NORMAL
+    use_captcha: false
+    registration_deadline_hours: 0
+    heed_penalties: false
+    event_status_type: INFINITE
     location: Idrettsbygget
     start_time: '2026-06-13T14:00:00+00:00'
     text: '<p>Ta med matte og godt humør.</p>'
@@ -1553,7 +1571,10 @@
     description: Sosial volleyballtrening for alle.
     end_time: '2026-07-10T20:00:00+00:00'
     event_type: interest_event
-    event_status_type: NORMAL
+    use_captcha: false
+    registration_deadline_hours: 0
+    heed_penalties: false
+    event_status_type: INFINITE
     location: Gløshaugen
     start_time: '2026-07-10T18:00:00+00:00'
     text: '<p>Alle nivåer er velkomne.</p>'
@@ -1568,7 +1589,10 @@
     description: Vennlig sjakkturnering for alle nivåer.
     end_time: '2026-06-12T20:00:00+00:00'
     event_type: interest_event
-    event_status_type: NORMAL
+    use_captcha: false
+    registration_deadline_hours: 0
+    heed_penalties: false
+    event_status_type: INFINITE
     location: Abakus-kontoret
     start_time: '2026-06-12T18:00:00+00:00'
     text: '<p>Ta med deg konkurranseinstinktet.</p>'
@@ -1583,7 +1607,10 @@
     description: Sosial boulderingøkt for alle.
     end_time: '2026-06-09T21:00:00+00:00'
     event_type: interest_event
-    event_status_type: NORMAL
+    use_captcha: false
+    registration_deadline_hours: 0
+    heed_penalties: false
+    event_status_type: INFINITE
     location: Trondheim klatresenter
     start_time: '2026-06-09T19:00:00+00:00'
     text: '<p>Klatring og pizza etterpå.</p>'
@@ -1598,7 +1625,10 @@
     description: Ta med strikketøy og kos deg.
     end_time: '2026-06-04T19:00:00+00:00'
     event_type: interest_event
-    event_status_type: NORMAL
+    use_captcha: false
+    registration_deadline_hours: 0
+    heed_penalties: false
+    event_status_type: INFINITE
     location: Abakus-kontoret
     start_time: '2026-06-04T17:00:00+00:00'
     text: '<p>Strikk, prat og kaffe.</p>'
@@ -1613,7 +1643,10 @@
     description: Rolig fellesløp for alle nivåer.
     end_time: '2026-05-28T19:00:00+00:00'
     event_type: interest_event
-    event_status_type: NORMAL
+    use_captcha: false
+    registration_deadline_hours: 0
+    heed_penalties: false
+    event_status_type: INFINITE
     location: Nidelva
     start_time: '2026-05-28T18:00:00+00:00'
     text: '<p>Vi løper en rolig runde sammen.</p>'
@@ -1628,7 +1661,10 @@
     description: Flere brettspill og snacks.
     end_time: '2026-05-15T21:00:00+00:00'
     event_type: interest_event
-    event_status_type: NORMAL
+    use_captcha: false
+    registration_deadline_hours: 0
+    heed_penalties: false
+    event_status_type: INFINITE
     location: Abakus-kontoret
     start_time: '2026-05-15T19:00:00+00:00'
     text: '<p>Andre runde med brettspill.</p>'
@@ -1643,7 +1679,10 @@
     description: Lær redigering i Lightroom.
     end_time: '2026-04-30T20:00:00+00:00'
     event_type: interest_event
-    event_status_type: NORMAL
+    use_captcha: false
+    registration_deadline_hours: 0
+    heed_penalties: false
+    event_status_type: INFINITE
     location: Realfagbygget
     start_time: '2026-04-30T18:00:00+00:00'
     text: '<p>Praktisk fotokurs for nybegynnere.</p>'
@@ -1654,3 +1693,184 @@
     require_auth: False
   model: events.Event
   pk: 67
+- fields:
+    description: Turnering i Counter-Strike 2 for alle nivåer.
+    end_time: '2026-08-05T21:00:00+00:00'
+    event_type: interest_event
+    use_captcha: false
+    registration_deadline_hours: 0
+    heed_penalties: false
+    event_status_type: INFINITE
+    location: P15
+    start_time: '2026-08-05T18:00:00+00:00'
+    text: '<p>Vi setter opp lag på stedet, og alle nivåer er velkomne.</p>'
+    title: CS2-turnering med Abalan
+    cover: test_event_cover.png
+    created_by: 3
+    responsible_group: 66
+    require_auth: False
+  model: events.Event
+  pk: 68
+- fields:
+    description: Smaking av høstens viner med god stemning.
+    end_time: '2026-08-07T21:00:00+00:00'
+    event_type: interest_event
+    use_captcha: false
+    registration_deadline_hours: 0
+    heed_penalties: false
+    event_status_type: INFINITE
+    location: Kjelleren
+    start_time: '2026-08-07T19:00:00+00:00'
+    text: '<p>Fem viner, litt ost og en veldig entusiastisk quiz.</p>'
+    title: 'Vinsmaking: Høstens viner'
+    cover: test_event_cover.png
+    created_by: 3
+    responsible_group: 67
+    require_auth: False
+  model: events.Event
+  pk: 69
+- fields:
+    description: Vi bygger videre på Gløshaugen i Minecraft.
+    end_time: '2026-08-07T23:00:00+00:00'
+    event_type: interest_event
+    use_captcha: false
+    registration_deadline_hours: 0
+    heed_penalties: false
+    event_status_type: INFINITE
+    location: Abakus-kontoret
+    start_time: '2026-08-07T20:00:00+00:00'
+    text: '<p>Bli med på byggekveld på serveren, alle kan bidra.</p>'
+    title: Byggekveld på Abacraft-serveren
+    cover: test_event_cover.png
+    created_by: 3
+    responsible_group: 68
+    require_auth: False
+  model: events.Event
+  pk: 70
+- fields:
+    description: Intervalltrening for alle som vil bli raskere.
+    end_time: '2026-08-10T19:30:00+00:00'
+    event_type: interest_event
+    use_captcha: false
+    registration_deadline_hours: 0
+    heed_penalties: false
+    event_status_type: INFINITE
+    location: Lade idrettspark
+    start_time: '2026-08-10T18:00:00+00:00'
+    text: '<p>Vi løper intervaller sammen, og deler oss inn etter tempo.</p>'
+    title: Intervalltrening med Abarun
+    cover: test_event_cover.png
+    created_by: 3
+    responsible_group: 69
+    require_auth: False
+  model: events.Event
+  pk: 71
+- fields:
+    description: Mario Kart-turnering med premier til vinneren.
+    end_time: '2026-08-12T22:00:00+00:00'
+    event_type: interest_event
+    use_captcha: false
+    registration_deadline_hours: 0
+    heed_penalties: false
+    event_status_type: INFINITE
+    location: P15
+    start_time: '2026-08-12T19:00:00+00:00'
+    text: '<p>Blå skall, tårer og en veldig fortjent vinner.</p>'
+    title: Mario Kart-kveld
+    cover: test_event_cover.png
+    created_by: 3
+    responsible_group: 66
+    require_auth: False
+  model: events.Event
+  pk: 72
+- fields:
+    description: Ost og vin i hyggelige omgivelser.
+    end_time: '2026-08-14T22:00:00+00:00'
+    event_type: interest_event
+    use_captcha: false
+    registration_deadline_hours: 0
+    heed_penalties: false
+    event_status_type: INFINITE
+    location: Kjelleren
+    start_time: '2026-08-14T19:00:00+00:00'
+    text: '<p>Vi smaker oss gjennom et utvalg oster med passende viner.</p>'
+    title: Ost og vin-kveld
+    cover: test_event_cover.png
+    created_by: 3
+    responsible_group: 67
+    require_auth: False
+  model: events.Event
+  pk: 73
+- fields:
+    description: Lær deg redstone fra bunnen av.
+    end_time: '2026-08-18T21:00:00+00:00'
+    event_type: interest_event
+    use_captcha: false
+    registration_deadline_hours: 0
+    heed_penalties: false
+    event_status_type: INFINITE
+    location: Realfagbygget
+    start_time: '2026-08-18T18:00:00+00:00'
+    text: '<p>Workshop for deg som vil lære redstone, fra enkle dører til
+      kalkulatorer.</p>'
+    title: Redstone-workshop
+    cover: test_event_cover.png
+    created_by: 3
+    responsible_group: 68
+    require_auth: False
+  model: events.Event
+  pk: 74
+- fields:
+    description: Rolig løpetur til Estenstadhytta med kaffepause på toppen.
+    end_time: '2026-08-22T13:00:00+00:00'
+    event_type: interest_event
+    use_captcha: false
+    registration_deadline_hours: 0
+    heed_penalties: false
+    event_status_type: INFINITE
+    location: Moholt
+    start_time: '2026-08-22T10:00:00+00:00'
+    text: '<p>Vi løper i praterunde-tempo, og ingen løper alene.</p>'
+    title: Løpetur til Estenstadhytta
+    cover: test_event_cover.png
+    created_by: 3
+    responsible_group: 69
+    require_auth: False
+  model: events.Event
+  pk: 75
+- fields:
+    description: LAN-helg for deg som vil game, se turneringer eller bare henge.
+    end_time: '2026-08-29T00:00:00+00:00'
+    event_type: interest_event
+    use_captcha: false
+    registration_deadline_hours: 0
+    heed_penalties: false
+    event_status_type: INFINITE
+    location: P15
+    start_time: '2026-08-28T16:00:00+00:00'
+    text: '<p>Ta med egen rigg eller lån konsollkroken. Kiosk og pizza.</p>'
+    title: 'LAN-helg: Høstutgaven'
+    cover: test_event_cover.png
+    created_by: 3
+    responsible_group: 66
+    require_auth: False
+  model: events.Event
+  pk: 76
+- fields:
+    description: Cava og quiz med lag satt sammen på stedet.
+    end_time: '2026-09-04T22:00:00+00:00'
+    event_type: interest_event
+    use_captcha: false
+    registration_deadline_hours: 0
+    heed_penalties: false
+    event_status_type: INFINITE
+    location: Abakus-kontoret
+    start_time: '2026-09-04T19:00:00+00:00'
+    text: '<p>Quizmaster stiller med spørsmålene, vi stiller med cavaen.</p>'
+    title: Cava- og quizkveld
+    cover: test_event_cover.png
+    created_by: 3
+    responsible_group: 67
+    require_auth: False
+  model: events.Event
+  pk: 77

--- a/lego/apps/events/fixtures/development_pools.yaml
+++ b/lego/apps/events/fixtures/development_pools.yaml
@@ -736,3 +736,210 @@
       - - Abakus
   model: events.Pool
   pk: 82
+- fields:
+    activation_date: '2016-01-01T17:00:00+00:00'
+    capacity: 0
+    event: 55
+    name: Abakus
+    permission_groups:
+      - - Abakus
+  model: events.Pool
+  pk: 83
+- fields:
+    activation_date: '2016-01-01T17:00:00+00:00'
+    capacity: 0
+    event: 56
+    name: Abakus
+    permission_groups:
+      - - Abakus
+  model: events.Pool
+  pk: 84
+- fields:
+    activation_date: '2016-01-01T17:00:00+00:00'
+    capacity: 0
+    event: 57
+    name: Abakus
+    permission_groups:
+      - - Abakus
+  model: events.Pool
+  pk: 85
+- fields:
+    activation_date: '2016-01-01T17:00:00+00:00'
+    capacity: 0
+    event: 58
+    name: Abakus
+    permission_groups:
+      - - Abakus
+  model: events.Pool
+  pk: 86
+- fields:
+    activation_date: '2016-01-01T17:00:00+00:00'
+    capacity: 12
+    event: 59
+    name: Abakus
+    permission_groups:
+      - - Abakus
+  model: events.Pool
+  pk: 87
+- fields:
+    activation_date: '2016-01-01T17:00:00+00:00'
+    capacity: 0
+    event: 60
+    name: Abakus
+    permission_groups:
+      - - Abakus
+  model: events.Pool
+  pk: 88
+- fields:
+    activation_date: '2016-01-01T17:00:00+00:00'
+    capacity: 0
+    event: 61
+    name: Abakus
+    permission_groups:
+      - - Abakus
+  model: events.Pool
+  pk: 89
+- fields:
+    activation_date: '2016-01-01T17:00:00+00:00'
+    capacity: 0
+    event: 62
+    name: Abakus
+    permission_groups:
+      - - Abakus
+  model: events.Pool
+  pk: 90
+- fields:
+    activation_date: '2016-01-01T17:00:00+00:00'
+    capacity: 0
+    event: 63
+    name: Abakus
+    permission_groups:
+      - - Abakus
+  model: events.Pool
+  pk: 91
+- fields:
+    activation_date: '2016-01-01T17:00:00+00:00'
+    capacity: 0
+    event: 64
+    name: Abakus
+    permission_groups:
+      - - Abakus
+  model: events.Pool
+  pk: 92
+- fields:
+    activation_date: '2016-01-01T17:00:00+00:00'
+    capacity: 0
+    event: 65
+    name: Abakus
+    permission_groups:
+      - - Abakus
+  model: events.Pool
+  pk: 93
+- fields:
+    activation_date: '2016-01-01T17:00:00+00:00'
+    capacity: 0
+    event: 66
+    name: Abakus
+    permission_groups:
+      - - Abakus
+  model: events.Pool
+  pk: 94
+- fields:
+    activation_date: '2016-01-01T17:00:00+00:00'
+    capacity: 0
+    event: 67
+    name: Abakus
+    permission_groups:
+      - - Abakus
+  model: events.Pool
+  pk: 95
+- fields:
+    activation_date: '2016-01-01T17:00:00+00:00'
+    capacity: 30
+    event: 68
+    name: Abakus
+    permission_groups:
+      - - Abakus
+  model: events.Pool
+  pk: 96
+- fields:
+    activation_date: '2016-01-01T17:00:00+00:00'
+    capacity: 0
+    event: 69
+    name: Abakus
+    permission_groups:
+      - - Abakus
+  model: events.Pool
+  pk: 97
+- fields:
+    activation_date: '2016-01-01T17:00:00+00:00'
+    capacity: 0
+    event: 70
+    name: Abakus
+    permission_groups:
+      - - Abakus
+  model: events.Pool
+  pk: 98
+- fields:
+    activation_date: '2016-01-01T17:00:00+00:00'
+    capacity: 0
+    event: 71
+    name: Abakus
+    permission_groups:
+      - - Abakus
+  model: events.Pool
+  pk: 99
+- fields:
+    activation_date: '2016-01-01T17:00:00+00:00'
+    capacity: 0
+    event: 72
+    name: Abakus
+    permission_groups:
+      - - Abakus
+  model: events.Pool
+  pk: 100
+- fields:
+    activation_date: '2016-01-01T17:00:00+00:00'
+    capacity: 0
+    event: 73
+    name: Abakus
+    permission_groups:
+      - - Abakus
+  model: events.Pool
+  pk: 101
+- fields:
+    activation_date: '2016-01-01T17:00:00+00:00'
+    capacity: 8
+    event: 74
+    name: Abakus
+    permission_groups:
+      - - Abakus
+  model: events.Pool
+  pk: 102
+- fields:
+    activation_date: '2016-01-01T17:00:00+00:00'
+    capacity: 0
+    event: 75
+    name: Abakus
+    permission_groups:
+      - - Abakus
+  model: events.Pool
+  pk: 103
+- fields:
+    activation_date: '2016-01-01T17:00:00+00:00'
+    capacity: 0
+    event: 76
+    name: Abakus
+    permission_groups:
+      - - Abakus
+  model: events.Pool
+  pk: 104
+- fields:
+    activation_date: '2016-01-01T17:00:00+00:00'
+    capacity: 0
+    event: 77
+    name: Abakus
+    permission_groups:
+      - - Abakus
+  model: events.Pool
+  pk: 105

--- a/lego/apps/events/fixtures/development_registrations.yaml
+++ b/lego/apps/events/fixtures/development_registrations.yaml
@@ -6766,3 +6766,1794 @@
     status: 'SUCCESS_REGISTER'
   model: events.Registration
   pk: 750
+- fields:
+    event: 55
+    pool: 83
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 2
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1001
+- fields:
+    event: 55
+    pool: 83
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 3
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1002
+- fields:
+    event: 55
+    pool: 83
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 4
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1003
+- fields:
+    event: 57
+    pool: 85
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 5
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1004
+- fields:
+    event: 57
+    pool: 85
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 6
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1005
+- fields:
+    event: 57
+    pool: 85
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 7
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1006
+- fields:
+    event: 57
+    pool: 85
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 8
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1007
+- fields:
+    event: 57
+    pool: 85
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 9
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1008
+- fields:
+    event: 57
+    pool: 85
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 10
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1009
+- fields:
+    event: 57
+    pool: 85
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 11
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1010
+- fields:
+    event: 58
+    pool: 86
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 12
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1011
+- fields:
+    event: 59
+    pool: 87
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 13
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1012
+- fields:
+    event: 59
+    pool: 87
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 14
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1013
+- fields:
+    event: 59
+    pool: 87
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 15
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1014
+- fields:
+    event: 59
+    pool: 87
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 16
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1015
+- fields:
+    event: 59
+    pool: 87
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 17
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1016
+- fields:
+    event: 59
+    pool: 87
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 18
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1017
+- fields:
+    event: 59
+    pool: 87
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 19
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1018
+- fields:
+    event: 59
+    pool: 87
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 20
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1019
+- fields:
+    event: 59
+    pool: 87
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 21
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1020
+- fields:
+    event: 59
+    pool: 87
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 22
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1021
+- fields:
+    event: 59
+    pool: 87
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 23
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1022
+- fields:
+    event: 59
+    pool: 87
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 24
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1023
+- fields:
+    event: 60
+    pool: 88
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 25
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1024
+- fields:
+    event: 60
+    pool: 88
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 26
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1025
+- fields:
+    event: 60
+    pool: 88
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 27
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1026
+- fields:
+    event: 60
+    pool: 88
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 28
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1027
+- fields:
+    event: 60
+    pool: 88
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 29
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1028
+- fields:
+    event: 61
+    pool: 89
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 30
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1029
+- fields:
+    event: 61
+    pool: 89
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 31
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1030
+- fields:
+    event: 62
+    pool: 90
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 32
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1031
+- fields:
+    event: 62
+    pool: 90
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 33
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1032
+- fields:
+    event: 62
+    pool: 90
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 34
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1033
+- fields:
+    event: 62
+    pool: 90
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 35
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1034
+- fields:
+    event: 62
+    pool: 90
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 36
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1035
+- fields:
+    event: 62
+    pool: 90
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 37
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1036
+- fields:
+    event: 62
+    pool: 90
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 38
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1037
+- fields:
+    event: 62
+    pool: 90
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 39
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1038
+- fields:
+    event: 62
+    pool: 90
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 40
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1039
+- fields:
+    event: 64
+    pool: 92
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 41
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1040
+- fields:
+    event: 64
+    pool: 92
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 42
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1041
+- fields:
+    event: 64
+    pool: 92
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 43
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1042
+- fields:
+    event: 64
+    pool: 92
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 44
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1043
+- fields:
+    event: 64
+    pool: 92
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 45
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1044
+- fields:
+    event: 64
+    pool: 92
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 46
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1045
+- fields:
+    event: 64
+    pool: 92
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 47
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1046
+- fields:
+    event: 64
+    pool: 92
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 48
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1047
+- fields:
+    event: 64
+    pool: 92
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 49
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1048
+- fields:
+    event: 64
+    pool: 92
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 50
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1049
+- fields:
+    event: 64
+    pool: 92
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 51
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1050
+- fields:
+    event: 64
+    pool: 92
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 52
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1051
+- fields:
+    event: 64
+    pool: 92
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 53
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1052
+- fields:
+    event: 64
+    pool: 92
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 54
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1053
+- fields:
+    event: 64
+    pool: 92
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 55
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1054
+- fields:
+    event: 64
+    pool: 92
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 56
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1055
+- fields:
+    event: 64
+    pool: 92
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 57
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1056
+- fields:
+    event: 64
+    pool: 92
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 58
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1057
+- fields:
+    event: 65
+    pool: 93
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 2
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1058
+- fields:
+    event: 65
+    pool: 93
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 3
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1059
+- fields:
+    event: 65
+    pool: 93
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 4
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1060
+- fields:
+    event: 65
+    pool: 93
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 5
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1061
+- fields:
+    event: 66
+    pool: 94
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 6
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1062
+- fields:
+    event: 66
+    pool: 94
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 7
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1063
+- fields:
+    event: 66
+    pool: 94
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 8
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1064
+- fields:
+    event: 66
+    pool: 94
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 9
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1065
+- fields:
+    event: 66
+    pool: 94
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 10
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1066
+- fields:
+    event: 66
+    pool: 94
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 11
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1067
+- fields:
+    event: 67
+    pool: 95
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 12
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1068
+- fields:
+    event: 68
+    pool: 96
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 13
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1069
+- fields:
+    event: 68
+    pool: 96
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 14
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1070
+- fields:
+    event: 68
+    pool: 96
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 15
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1071
+- fields:
+    event: 68
+    pool: 96
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 16
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1072
+- fields:
+    event: 68
+    pool: 96
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 17
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1073
+- fields:
+    event: 68
+    pool: 96
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 18
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1074
+- fields:
+    event: 68
+    pool: 96
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 19
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1075
+- fields:
+    event: 68
+    pool: 96
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 20
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1076
+- fields:
+    event: 68
+    pool: 96
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 21
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1077
+- fields:
+    event: 68
+    pool: 96
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 22
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1078
+- fields:
+    event: 68
+    pool: 96
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 23
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1079
+- fields:
+    event: 68
+    pool: 96
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 24
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1080
+- fields:
+    event: 68
+    pool: 96
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 25
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1081
+- fields:
+    event: 68
+    pool: 96
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 26
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1082
+- fields:
+    event: 68
+    pool: 96
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 27
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1083
+- fields:
+    event: 68
+    pool: 96
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 28
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1084
+- fields:
+    event: 68
+    pool: 96
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 29
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1085
+- fields:
+    event: 68
+    pool: 96
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 30
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1086
+- fields:
+    event: 68
+    pool: 96
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 31
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1087
+- fields:
+    event: 68
+    pool: 96
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 32
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1088
+- fields:
+    event: 68
+    pool: 96
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 33
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1089
+- fields:
+    event: 68
+    pool: 96
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 34
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1090
+- fields:
+    event: 68
+    pool: 96
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 35
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1091
+- fields:
+    event: 68
+    pool: 96
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 36
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1092
+- fields:
+    event: 68
+    pool: 96
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 37
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1093
+- fields:
+    event: 68
+    pool: 96
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 38
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1094
+- fields:
+    event: 69
+    pool: 97
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 39
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1095
+- fields:
+    event: 69
+    pool: 97
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 40
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1096
+- fields:
+    event: 69
+    pool: 97
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 41
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1097
+- fields:
+    event: 69
+    pool: 97
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 42
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1098
+- fields:
+    event: 69
+    pool: 97
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 43
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1099
+- fields:
+    event: 69
+    pool: 97
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 44
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1100
+- fields:
+    event: 69
+    pool: 97
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 45
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1101
+- fields:
+    event: 69
+    pool: 97
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 46
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1102
+- fields:
+    event: 70
+    pool: 98
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 47
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1103
+- fields:
+    event: 70
+    pool: 98
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 48
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1104
+- fields:
+    event: 70
+    pool: 98
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 49
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1105
+- fields:
+    event: 71
+    pool: 99
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 50
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1106
+- fields:
+    event: 71
+    pool: 99
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 51
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1107
+- fields:
+    event: 71
+    pool: 99
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 52
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1108
+- fields:
+    event: 71
+    pool: 99
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 53
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1109
+- fields:
+    event: 71
+    pool: 99
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 54
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1110
+- fields:
+    event: 71
+    pool: 99
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 55
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1111
+- fields:
+    event: 71
+    pool: 99
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 56
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1112
+- fields:
+    event: 71
+    pool: 99
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 57
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1113
+- fields:
+    event: 71
+    pool: 99
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 58
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1114
+- fields:
+    event: 71
+    pool: 99
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 2
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1115
+- fields:
+    event: 71
+    pool: 99
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 3
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1116
+- fields:
+    event: 71
+    pool: 99
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 4
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1117
+- fields:
+    event: 71
+    pool: 99
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 5
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1118
+- fields:
+    event: 71
+    pool: 99
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 6
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1119
+- fields:
+    event: 71
+    pool: 99
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 7
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1120
+- fields:
+    event: 72
+    pool: 100
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 8
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1121
+- fields:
+    event: 72
+    pool: 100
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 9
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1122
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 10
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1123
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 11
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1124
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 12
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1125
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 13
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1126
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 14
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1127
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 15
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1128
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 16
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1129
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 17
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1130
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 18
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1131
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 19
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1132
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 20
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1133
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 21
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1134
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 22
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1135
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 23
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1136
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 24
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1137
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 25
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1138
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 26
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1139
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 27
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1140
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 28
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1141
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 29
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1142
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 30
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1143
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 31
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1144
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 32
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1145
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 33
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1146
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 34
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1147
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 35
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1148
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 36
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1149
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 37
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1150
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 38
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1151
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 39
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1152
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 40
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1153
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 41
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1154
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 42
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1155
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 43
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1156
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 44
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1157
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 45
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1158
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 46
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1159
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 47
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1160
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 48
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1161
+- fields:
+    event: 73
+    pool: 101
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 49
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1162
+- fields:
+    event: 74
+    pool: 102
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 50
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1163
+- fields:
+    event: 74
+    pool: 102
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 51
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1164
+- fields:
+    event: 74
+    pool: 102
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 52
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1165
+- fields:
+    event: 74
+    pool: 102
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 53
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1166
+- fields:
+    event: 74
+    pool: 102
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 54
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1167
+- fields:
+    event: 75
+    pool: 103
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 55
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1168
+- fields:
+    event: 75
+    pool: 103
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 56
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1169
+- fields:
+    event: 75
+    pool: 103
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 57
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1170
+- fields:
+    event: 75
+    pool: 103
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 58
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1171
+- fields:
+    event: 75
+    pool: 103
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 2
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1172
+- fields:
+    event: 75
+    pool: 103
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 3
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1173
+- fields:
+    event: 75
+    pool: 103
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 4
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1174
+- fields:
+    event: 75
+    pool: 103
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 5
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1175
+- fields:
+    event: 75
+    pool: 103
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 6
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1176
+- fields:
+    event: 75
+    pool: 103
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 7
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1177
+- fields:
+    event: 77
+    pool: 105
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 8
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1178
+- fields:
+    event: 77
+    pool: 105
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 9
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1179
+- fields:
+    event: 77
+    pool: 105
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 10
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1180
+- fields:
+    event: 77
+    pool: 105
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 11
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1181
+- fields:
+    event: 77
+    pool: 105
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 12
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1182
+- fields:
+    event: 77
+    pool: 105
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 13
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1183
+- fields:
+    event: 77
+    pool: 105
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 14
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1184
+- fields:
+    event: 77
+    pool: 105
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 15
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1185
+- fields:
+    event: 77
+    pool: 105
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 16
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1186
+- fields:
+    event: 77
+    pool: 105
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 17
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1187
+- fields:
+    event: 77
+    pool: 105
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 18
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1188
+- fields:
+    event: 77
+    pool: 105
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 19
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1189
+- fields:
+    event: 77
+    pool: 105
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 20
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1190
+- fields:
+    event: 77
+    pool: 105
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 21
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1191
+- fields:
+    event: 77
+    pool: 105
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 22
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1192
+- fields:
+    event: 77
+    pool: 105
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 23
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1193
+- fields:
+    event: 77
+    pool: 105
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 24
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1194
+- fields:
+    event: 77
+    pool: 105
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 25
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1195
+- fields:
+    event: 77
+    pool: 105
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 26
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1196
+- fields:
+    event: 77
+    pool: 105
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 27
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1197
+- fields:
+    event: 77
+    pool: 105
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 28
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1198
+- fields:
+    event: 77
+    pool: 105
+    registration_date: '2026-01-05T12:00:00+00:00'
+    unregistration_date: null
+    user: 29
+    status: 'SUCCESS_REGISTER'
+  model: events.Registration
+  pk: 1199

--- a/lego/apps/flatpages/fixtures/initial_pages.yaml
+++ b/lego/apps/flatpages/fixtures/initial_pages.yaml
@@ -22,3 +22,14 @@
     slug: personvern
     category: personvern
     content: <p>GDPR og sånt</p>
+
+- model: flatpages.page
+  pk: 4
+  fields:
+    title: Praktisk informasjon om interessegrupper
+    slug: 39-praktisk-informasjon
+    category: grupper
+    require_auth: false
+    content: <p>Interessegrupper er lavterskel sosiale grupper i Abakus. Her
+      finner du praktisk informasjon om hvordan du starter en ny gruppe,
+      vekker en inaktiv gruppe til live, og hva som kreves av deg som leder.</p>

--- a/lego/apps/users/fixtures/development_interest_groups.py
+++ b/lego/apps/users/fixtures/development_interest_groups.py
@@ -1,0 +1,53 @@
+"""
+Interest groups seeded in development only.
+
+Production groups live in initial_abakus_groups.py - these exist so the
+development fixtures (leader memberships, interest events) have groups to
+reference, without fake groups ending up in the production seed data. The
+pks are far above the initial group range so they can never collide with
+real groups added later.
+"""
+
+from lego.apps.users import constants
+from lego.apps.users.models import AbakusGroup
+
+# (pk, name, description, active) - these groups fill the interest group
+# grid in development; the development events and memberships reference the
+# four interest groups that already exist in the initial tree
+DEVELOPMENT_INTEREST_GROUPS = [
+    (9070, "Abasjakk", "lynsjakk og turneringer", True),
+    (9071, "Ababrygg", "hjemmebrygging", True),
+    (9072, "Abapadel", "padel for alle nivåer", True),
+    (9073, "Abaski", "topptur og alpint", True),
+    (9074, "Abasykkel", "landevei og terreng", True),
+    (9075, "Abafilm", "filmkvelder med popkorn", True),
+    (9076, "Abaquiz", "quizlag på byen", True),
+    (9077, "Abakaffe", "kaffebrygging tatt litt for seriøst", True),
+    (9078, "Abafoto", "foto og mørkerom", True),
+    (9079, "Abagolf", "golfsimulator og bane", True),
+    (9080, "Abayoga", "rolig start på dagen", True),
+    (9081, "Abastrikk", "strikk og drikk", True),
+    (9082, "Abaspill", "brettspill og kortspill", True),
+    (9083, "Abamat", "matlaging og middagsklubb", True),
+    (9084, "Abafjell", "fjellturer og friluftsliv", True),
+    (9085, "Abadans", "swing og salsa", True),
+    (9086, "Abadykk", "dykking og fridykking", True),
+    (9087, "Abacurling", "curling på Leangen", False),
+    (9088, "Abavolley", "volleyball", False),
+    (9089, "Abatennis", "tennis i sommerhalvåret", False),
+]
+
+
+def load_development_interest_groups() -> None:
+    parent = AbakusGroup.objects.get(name="Interessegrupper")
+    for pk, name, description, active in DEVELOPMENT_INTEREST_GROUPS:
+        AbakusGroup.objects.update_or_create(
+            pk=pk,
+            defaults={
+                "name": name,
+                "description": description,
+                "type": constants.GROUP_INTEREST,
+                "parent": parent,
+                "active": active,
+            },
+        )

--- a/lego/apps/users/fixtures/development_memberships.yaml
+++ b/lego/apps/users/fixtures/development_memberships.yaml
@@ -378,3 +378,44 @@
       - haydenfoster
     abakus_group:
       - Abarun
+
+# =======================
+# Interest leader user (leader of Abalan, co-leader of Abacava)
+# =======================
+- model: users.Membership
+  pk: 49
+  fields:
+    user:
+      - interestleader
+    abakus_group:
+      - Users
+- model: users.Membership
+  pk: 50
+  fields:
+    user:
+      - interestleader
+    abakus_group:
+      - Abakus
+- model: users.Membership
+  pk: 51
+  fields:
+    user:
+      - interestleader
+    abakus_group:
+      - 5. klasse Datateknologi
+- model: users.Membership
+  pk: 52
+  fields:
+    user:
+      - interestleader
+    abakus_group:
+      - Abalan
+    role: "leader"
+- model: users.Membership
+  pk: 53
+  fields:
+    user:
+      - interestleader
+    abakus_group:
+      - Abacava
+    role: "co-leader"

--- a/lego/apps/users/fixtures/development_users.yaml
+++ b/lego/apps/users/fixtures/development_users.yaml
@@ -533,3 +533,14 @@
     last_name: lee swagger
     email: boblee@swagger.com
     password: "pbkdf2_sha256$120000$rhBO1zmtTZsr$smSDnW2pSOl7kac1ErGVJnRvB5fapOFBQnKqBKr/Q8g=" # Bedkom123
+- model: users.User
+  pk: 59
+  fields:
+    username: interestleader
+    student_username: interestleader
+    gender: female
+    first_name: interesse
+    last_name: leder
+    email: interestleader@aba.wtf
+    password: "pbkdf2_sha256$120000$YKmWfcu6Hqqv$e0yZQh91HMGZQBkElS3ZjW04rs2XCCK34DqK6P73N0g=" # Webkom123
+    last_login: "2026-01-01T13:00:30+00:00"

--- a/lego/utils/management/commands/load_fixtures.py
+++ b/lego/utils/management/commands/load_fixtures.py
@@ -11,6 +11,9 @@ from lego.apps.events.constants import INTEREST_EVENT
 from lego.apps.events.models import Event
 from lego.apps.files.models import File
 from lego.apps.files.storage import storage
+from lego.apps.users.fixtures.development_interest_groups import (
+    load_development_interest_groups,
+)
 from lego.apps.users.fixtures.initial_abakus_groups import load_abakus_groups
 from lego.apps.users.fixtures.test_abakus_groups import load_test_abakus_groups
 from lego.apps.users.models import AbakusGroup, User
@@ -61,6 +64,10 @@ class Command(BaseCommand):
             self.load_fixtures(["users/fixtures/development_users.yaml"])
             self.upload_development_files()
             log.info("Loading development fixtures:")
+            # Fake interest groups fill the group grid in development - kept
+            # out of initial_abakus_groups so the production seed data stays
+            # clean
+            load_development_interest_groups()
             self.load_fixtures(
                 [
                     "users/fixtures/development_users.yaml",

--- a/lego/utils/management/commands/load_fixtures.py
+++ b/lego/utils/management/commands/load_fixtures.py
@@ -186,9 +186,11 @@ class Command(BaseCommand):
             timedelta(days=41),
         ]
         events = list(Event.objects.filter(event_type=INTEREST_EVENT).order_by("id"))
-        assert len(events) == len(
-            offsets
-        ), "interest-event offsets out of sync with fixtures"
+        assert len(events) == len(offsets), (
+            f"{len(events)} interest event fixtures but {len(offsets)} offsets - "
+            "added or removed an interest event in development_events.yaml? "
+            "Update the offsets list above to match."
+        )
         for event, offset in zip(events, offsets, strict=True):
             duration = event.end_time - event.start_time
             event.start_time = now + offset

--- a/lego/utils/management/commands/load_fixtures.py
+++ b/lego/utils/management/commands/load_fixtures.py
@@ -173,6 +173,17 @@ class Command(BaseCommand):
             timedelta(days=10),
             timedelta(days=17),
             timedelta(days=28),
+            # More coming events (fixtures 68-77, appended in id order)
+            timedelta(days=3),
+            timedelta(days=5),
+            timedelta(days=5, hours=3),
+            timedelta(days=8),
+            timedelta(days=12),
+            timedelta(days=16),
+            timedelta(days=21),
+            timedelta(days=27),
+            timedelta(days=34),
+            timedelta(days=41),
         ]
         events = list(Event.objects.filter(event_type=INTEREST_EVENT).order_by("id"))
         assert len(events) == len(


### PR DESCRIPTION
# Description

Development seed data for interest events - nothing here touches production data.

- `development_interest_groups.py` seeds 20 fake interest groups (3 inactive) to fill the
  group grid, loaded only with `load_fixtures --development`. High pks (9070+) so they can
  never collide with real groups; `initial_abakus_groups` is untouched.
- Development fixtures: interest events, pools, registrations and leader memberships,
  referencing the four real interest groups from the initial tree
- `load_fixtures` date offsets keep the seeded events relative to now
- Adds the interest group info flatpage to `initial_pages.yaml` (real content - must be
  created manually in prod, which never runs `load_fixtures`)

Verified with a full `migrate` + `load_fixtures --development` run on a fresh database.
to now.


# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

Resolves #4054

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>