### PR TITLE
Fix Feide student verification

### DIFF
--- a/lego/apps/users/tests/test_student_confirmation_api.py
+++ b/lego/apps/users/tests/test_student_confirmation_api.py
@@ -1,29 +1,37 @@
 from enum import Enum
 from unittest import mock
 
-from django.http import HttpResponseRedirect
 from rest_framework import status
+
+from authlib.integrations.base_client.errors import OAuthError
 
 from lego.apps.users import constants
 from lego.apps.users.models import AbakusGroup, User
+from lego.apps.users.views.oidc import get_state_cache_key, oauth_cache
 from lego.utils.test_utils import BaseAPITestCase
 
 
 class MockFeideOAUTH:
     _auth_url = "https://auth.mock-feide.no/auth"
+    _state = "state"
 
     def __init__(self, token="valid_token"):
         self.token = token
 
-    def authorize_redirect(self, request, redirect_url):
-        return HttpResponseRedirect(self._auth_url)
+    def create_authorization_url(self, redirect_uri):
+        return {"url": self._auth_url, "state": self._state}
 
-    def authorize_access_token(self, request):
+    def fetch_access_token(self, **kwargs):
         return _token(self.token)
 
     def userinfo(self, **kwargs):
         uid = f"{kwargs.get('token')['access_token']}@ntnu.no"
         return {"https://n.feide.no/claims/eduPersonPrincipalName": uid}
+
+
+class MockFeideOAUTHInvalidGrant(MockFeideOAUTH):
+    def fetch_access_token(self, **kwargs):
+        raise OAuthError(error="invalid_grant")
 
 
 mockFeide = MockFeideOAUTH()
@@ -218,7 +226,15 @@ class ValidateOIDCAPITestCase(BaseAPITestCase):
         self.abakus_group.add_user(self.user_with_student_confirmation)
         self.user_without_student_confirmation = User.objects.get(username="test2")
 
+        oauth_cache.delete(get_state_cache_key(self.user_with_student_confirmation.id))
+        oauth_cache.delete(
+            get_state_cache_key(self.user_without_student_confirmation.id)
+        )
+
         self.client.force_authenticate(self.user_without_student_confirmation)
+
+    def _authorize(self):
+        self.client.get(_get_oidc_authorize_url())
 
     def test_with_unauthenticated_user(self, *args):
         self.client.force_authenticate(None)
@@ -227,6 +243,7 @@ class ValidateOIDCAPITestCase(BaseAPITestCase):
 
     @mock.patch("lego.apps.users.views.oidc.oauth.feide", MockFeideOAUTH(Token.DATA))
     def test_data_1st(self, *args):
+        self._authorize()
         response = self.client.get(_get_validate_url())
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -244,6 +261,7 @@ class ValidateOIDCAPITestCase(BaseAPITestCase):
 
     @mock.patch("lego.apps.users.views.oidc.oauth.feide", MockFeideOAUTH(Token.KOMTEK))
     def test_komtek_1st(self, *args):
+        self._authorize()
         response = self.client.get(_get_validate_url())
 
         json = response.json()
@@ -262,6 +280,7 @@ class ValidateOIDCAPITestCase(BaseAPITestCase):
         "lego.apps.users.views.oidc.oauth.feide", MockFeideOAUTH(Token.DATA_MASTER)
     )
     def test_data_4th(self, *args):
+        self._authorize()
         response = self.client.get(_get_validate_url())
 
         json = response.json()
@@ -282,6 +301,7 @@ class ValidateOIDCAPITestCase(BaseAPITestCase):
         "lego.apps.users.views.oidc.oauth.feide", MockFeideOAUTH(Token.KOMTEK_MASTER)
     )
     def test_komtek_4th(self, *args):
+        self._authorize()
         response = self.client.get(_get_validate_url())
 
         json = response.json()
@@ -302,6 +322,7 @@ class ValidateOIDCAPITestCase(BaseAPITestCase):
         "lego.apps.users.views.oidc.oauth.feide", MockFeideOAUTH(Token.SECCLO_MASTER)
     )
     def test_secclo_master(self, *args):
+        self._authorize()
         response = self.client.get(_get_validate_url())
 
         json = response.json()
@@ -322,6 +343,7 @@ class ValidateOIDCAPITestCase(BaseAPITestCase):
         "lego.apps.users.views.oidc.oauth.feide", MockFeideOAUTH(Token.MULTI_OTHER)
     )
     def test_with_other_study_informatics(self, *args):
+        self._authorize()
         response = self.client.get(_get_validate_url())
 
         json = response.json()
@@ -343,6 +365,7 @@ class ValidateOIDCAPITestCase(BaseAPITestCase):
         You should keep your grade when re-authenticating
         """
         self.client.force_authenticate(self.user_with_student_confirmation)
+        self._authorize()
         response = self.client.get(_get_validate_url())
 
         json = response.json()
@@ -366,6 +389,7 @@ class ValidateOIDCAPITestCase(BaseAPITestCase):
         You should keep your validation status and grade when switching to indok
         """
         self.client.force_authenticate(self.user_with_student_confirmation)
+        self._authorize()
         response = self.client.get(_get_validate_url())
 
         json = response.json()
@@ -389,6 +413,7 @@ class ValidateOIDCAPITestCase(BaseAPITestCase):
         It should only be allowed to auth a single user with a feide account
         """
         self.client.force_authenticate(self.user_with_student_confirmation)
+        self._authorize()
         response = self.client.get(_get_validate_url())
 
         json = response.json()
@@ -399,6 +424,7 @@ class ValidateOIDCAPITestCase(BaseAPITestCase):
         )
 
         self.client.force_authenticate(self.user_without_student_confirmation)
+        self._authorize()
         response = self.client.get(_get_validate_url())
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         json = response.json()
@@ -413,3 +439,42 @@ class ValidateOIDCAPITestCase(BaseAPITestCase):
                 pk=self.abakus_group.pk
             ).exists()
         )
+
+    @mock.patch("lego.apps.users.views.oidc.oauth.feide", MockFeideOAUTH(Token.DATA))
+    def test_without_prior_authorize(self, *args):
+        response = self.client.get(_get_validate_url())
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json().get("status"), "error")
+
+    @mock.patch("lego.apps.users.views.oidc.oauth.feide", MockFeideOAUTH(Token.DATA))
+    def test_with_mismatching_state(self, *args):
+        self._authorize()
+        response = self.client.get(_get_oidc_validate_url("code", "wrong-state"))
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json().get("status"), "error")
+
+    @mock.patch("lego.apps.users.views.oidc.oauth.feide", MockFeideOAUTH(Token.DATA))
+    def test_with_replayed_state(self, *args):
+        self._authorize()
+        first = self.client.get(_get_validate_url())
+        self.assertEqual(first.status_code, status.HTTP_200_OK)
+        second = self.client.get(_get_validate_url())
+        self.assertEqual(second.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @mock.patch("lego.apps.users.views.oidc.oauth.feide", MockFeideOAUTH(Token.DATA))
+    def test_with_state_from_another_user(self, *args):
+        """
+        The state is bound to the user who started the flow, so no session
+        cookie is required and another user cannot complete the flow
+        """
+        self._authorize()
+        self.client.force_authenticate(self.user_with_student_confirmation)
+        response = self.client.get(_get_validate_url())
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @mock.patch("lego.apps.users.views.oidc.oauth.feide", MockFeideOAUTHInvalidGrant())
+    def test_with_rejected_authorization_code(self, *args):
+        self._authorize()
+        response = self.client.get(_get_validate_url())
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json().get("status"), "error")

--- a/lego/apps/users/tests/test_student_confirmation_api.py
+++ b/lego/apps/users/tests/test_student_confirmation_api.py
@@ -1,13 +1,18 @@
+import json
 from enum import Enum
 from unittest import mock
+from urllib.parse import parse_qs, urlparse
 
+from django.conf import settings
 from rest_framework import status
+from rest_framework.test import APIClient
 
+import requests
 from authlib.integrations.base_client.errors import OAuthError
 
 from lego.apps.users import constants
 from lego.apps.users.models import AbakusGroup, User
-from lego.apps.users.views.oidc import get_state_cache_key, oauth_cache
+from lego.apps.users.views.oidc import get_state_cache_key, oauth, oauth_cache
 from lego.utils.test_utils import BaseAPITestCase
 
 
@@ -478,3 +483,114 @@ class ValidateOIDCAPITestCase(BaseAPITestCase):
         response = self.client.get(_get_validate_url())
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json().get("status"), "error")
+
+
+FEIDE_METADATA = {
+    "issuer": "https://feide.test",
+    "authorization_endpoint": "https://feide.test/oauth/authorization",
+    "token_endpoint": "https://feide.test/oauth/token",
+    "userinfo_endpoint": "https://feide.test/openid/userinfo",
+    "jwks_uri": "https://feide.test/openid/jwks",
+}
+
+
+def _json_response(url, data):
+    response = requests.Response()
+    response.status_code = 200
+    response.url = url
+    response.headers["Content-Type"] = "application/json"
+    response._content = json.dumps(data).encode()
+    return response
+
+
+class FeideOIDCFlowTestCase(BaseAPITestCase):
+    """
+    Runs authorize and validate through the real authlib client against a
+    stubbed Feide, using a separate cookie-less client for each request.
+    The webapp calls the API cross-origin and never sends cookies, so this
+    guards against the flow depending on session state again (which broke
+    with the authlib >= 1.6 session-bound state)
+    """
+
+    fixtures = ["test_abakus_groups.yaml", "test_users.yaml"]
+
+    def setUp(self):
+        self.abakus_group = AbakusGroup.objects.get(name="Abakus")
+        self.grade_data_1 = AbakusGroup.objects.create(
+            name=constants.FIRST_GRADE_DATA, type=constants.GROUP_GRADE
+        )
+        self.user = User.objects.get(username="test2")
+        self.feide_requests = []
+        self.original_client_id = oauth.feide.client_id
+        self.original_client_secret = oauth.feide.client_secret
+        self.original_server_metadata = oauth.feide.server_metadata
+        oauth.feide.client_id = "test-client-id"
+        oauth.feide.client_secret = "test-client-secret"
+        oauth.feide.server_metadata = {}
+
+    def tearDown(self):
+        oauth.feide.client_id = self.original_client_id
+        oauth.feide.client_secret = self.original_client_secret
+        oauth.feide.server_metadata = self.original_server_metadata
+
+    def _fake_feide_send(self, session, request, **kwargs):
+        self.feide_requests.append(request)
+        if request.url == settings.FEIDE_OIDC_CONFIGURATION_ENDPOINT:
+            return _json_response(request.url, FEIDE_METADATA)
+        if request.url == FEIDE_METADATA["token_endpoint"]:
+            body = parse_qs(request.body)
+            self.assertEqual(body["code"], ["test-code"])
+            self.assertEqual(body["grant_type"], ["authorization_code"])
+            return _json_response(
+                request.url,
+                {
+                    "access_token": "feide-access-token",
+                    "token_type": "Bearer",
+                    "expires_in": 3600,
+                },
+            )
+        if request.url == FEIDE_METADATA["userinfo_endpoint"]:
+            self.assertEqual(
+                request.headers.get("Authorization"), "Bearer feide-access-token"
+            )
+            return _json_response(
+                request.url,
+                {
+                    "https://n.feide.no/claims/eduPersonPrincipalName": "teststudent@ntnu.no"
+                },
+            )
+        if request.url == settings.FEIDE_GROUPS_ENDPOINT:
+            return _json_response(request.url, data_resp)
+        raise AssertionError(f"Unexpected request to {request.url}")
+
+    def test_flow_succeeds_without_session_cookies(self):
+        with mock.patch.object(
+            requests.sessions.Session,
+            "send",
+            autospec=True,
+            side_effect=self._fake_feide_send,
+        ):
+            authorize_client = APIClient()
+            authorize_client.force_authenticate(self.user)
+            authorize_response = authorize_client.get(_get_oidc_authorize_url())
+            self.assertEqual(authorize_response.status_code, status.HTTP_200_OK)
+
+            auth_url = authorize_response.json()["url"]
+            self.assertTrue(
+                auth_url.startswith(FEIDE_METADATA["authorization_endpoint"])
+            )
+            state = parse_qs(urlparse(auth_url).query)["state"][0]
+
+            validate_client = APIClient()
+            validate_client.force_authenticate(self.user)
+            self.assertEqual(len(validate_client.cookies), 0)
+            validate_response = validate_client.get(
+                _get_oidc_validate_url("test-code", state)
+            )
+
+        self.assertEqual(validate_response.status_code, status.HTTP_200_OK)
+        json_body = validate_response.json()
+        self.assertEqual(json_body["status"], "success")
+        self.assertEqual(json_body["studyProgrammes"], ["Computer Science"])
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.student_username, "teststudent")

--- a/lego/apps/users/tests/test_student_confirmation_api.py
+++ b/lego/apps/users/tests/test_student_confirmation_api.py
@@ -1,4 +1,5 @@
 import json
+import time
 from enum import Enum
 from unittest import mock
 from urllib.parse import parse_qs, urlparse
@@ -9,25 +10,29 @@ from rest_framework.test import APIClient
 
 import requests
 from authlib.integrations.base_client.errors import OAuthError
+from authlib.jose import JsonWebKey, jwt as jose_jwt
 
 from lego.apps.users import constants
 from lego.apps.users.models import AbakusGroup, User
-from lego.apps.users.views.oidc import get_state_cache_key, oauth, oauth_cache
+from lego.apps.users.views.oidc import oauth, oauth_cache
 from lego.utils.test_utils import BaseAPITestCase
 
 
 class MockFeideOAUTH:
     _auth_url = "https://auth.mock-feide.no/auth"
-    _state = "state"
 
-    def __init__(self, token="valid_token"):
+    def __init__(self, token="valid_token", state="state"):
         self.token = token
+        self._state = state
 
     def create_authorization_url(self, redirect_uri):
-        return {"url": self._auth_url, "state": self._state}
+        return {"url": self._auth_url, "state": self._state, "nonce": "nonce"}
 
     def fetch_access_token(self, **kwargs):
         return _token(self.token)
+
+    def parse_id_token(self, token, nonce):
+        return None
 
     def userinfo(self, **kwargs):
         uid = f"{kwargs.get('token')['access_token']}@ntnu.no"
@@ -231,10 +236,7 @@ class ValidateOIDCAPITestCase(BaseAPITestCase):
         self.abakus_group.add_user(self.user_with_student_confirmation)
         self.user_without_student_confirmation = User.objects.get(username="test2")
 
-        oauth_cache.delete(get_state_cache_key(self.user_with_student_confirmation.id))
-        oauth_cache.delete(
-            get_state_cache_key(self.user_without_student_confirmation.id)
-        )
+        oauth_cache.clear()
 
         self.client.force_authenticate(self.user_without_student_confirmation)
 
@@ -453,10 +455,39 @@ class ValidateOIDCAPITestCase(BaseAPITestCase):
 
     @mock.patch("lego.apps.users.views.oidc.oauth.feide", MockFeideOAUTH(Token.DATA))
     def test_with_mismatching_state(self, *args):
+        """
+        A stale or wrong callback must not consume the pending flow's state
+        """
         self._authorize()
         response = self.client.get(_get_oidc_validate_url("code", "wrong-state"))
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json().get("status"), "error")
+
+        response = self.client.get(_get_validate_url())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json().get("status"), "success")
+
+    def test_completing_first_of_two_started_flows(self, *args):
+        """
+        Starting a second flow (e.g. another tab) must not invalidate the
+        first one
+        """
+        with mock.patch(
+            "lego.apps.users.views.oidc.oauth.feide",
+            MockFeideOAUTH(Token.DATA, state="state-a"),
+        ):
+            self._authorize()
+        with mock.patch(
+            "lego.apps.users.views.oidc.oauth.feide",
+            MockFeideOAUTH(Token.DATA, state="state-b"),
+        ):
+            self._authorize()
+        with mock.patch(
+            "lego.apps.users.views.oidc.oauth.feide", MockFeideOAUTH(Token.DATA)
+        ):
+            response = self.client.get(_get_oidc_validate_url("code", "state-a"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json().get("status"), "success")
 
     @mock.patch("lego.apps.users.views.oidc.oauth.feide", MockFeideOAUTH(Token.DATA))
     def test_with_replayed_state(self, *args):
@@ -491,6 +522,7 @@ FEIDE_METADATA = {
     "token_endpoint": "https://feide.test/oauth/token",
     "userinfo_endpoint": "https://feide.test/openid/userinfo",
     "jwks_uri": "https://feide.test/openid/jwks",
+    "id_token_signing_alg_values_supported": ["RS256"],
 }
 
 
@@ -514,39 +546,62 @@ class FeideOIDCFlowTestCase(BaseAPITestCase):
 
     fixtures = ["test_abakus_groups.yaml", "test_users.yaml"]
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.jwk = JsonWebKey.generate_key("RSA", 2048, is_private=True)
+
     def setUp(self):
         self.abakus_group = AbakusGroup.objects.get(name="Abakus")
         self.grade_data_1 = AbakusGroup.objects.create(
             name=constants.FIRST_GRADE_DATA, type=constants.GROUP_GRADE
         )
         self.user = User.objects.get(username="test2")
-        self.feide_requests = []
-        self.original_client_id = oauth.feide.client_id
-        self.original_client_secret = oauth.feide.client_secret
-        self.original_server_metadata = oauth.feide.server_metadata
-        oauth.feide.client_id = "test-client-id"
-        oauth.feide.client_secret = "test-client-secret"
-        oauth.feide.server_metadata = {}
+        self.expected_nonce = None
+        for attribute, value in (
+            ("client_id", "test-client-id"),
+            ("client_secret", "test-client-secret"),
+            ("server_metadata", {}),
+        ):
+            patcher = mock.patch.object(oauth.feide, attribute, value)
+            patcher.start()
+            self.addCleanup(patcher.stop)
 
-    def tearDown(self):
-        oauth.feide.client_id = self.original_client_id
-        oauth.feide.client_secret = self.original_client_secret
-        oauth.feide.server_metadata = self.original_server_metadata
+    def _make_id_token(self):
+        now = int(time.time())
+        claims = {
+            "iss": FEIDE_METADATA["issuer"],
+            "sub": "feide-subject",
+            "aud": "test-client-id",
+            "iat": now,
+            "exp": now + 300,
+            "nonce": self.expected_nonce,
+        }
+        return jose_jwt.encode({"alg": "RS256"}, claims, self.jwk).decode()
 
     def _fake_feide_send(self, session, request, **kwargs):
-        self.feide_requests.append(request)
         if request.url == settings.FEIDE_OIDC_CONFIGURATION_ENDPOINT:
             return _json_response(request.url, FEIDE_METADATA)
+        if request.url == FEIDE_METADATA["jwks_uri"]:
+            return _json_response(request.url, {"keys": [self.jwk.as_dict()]})
         if request.url == FEIDE_METADATA["token_endpoint"]:
             body = parse_qs(request.body)
             self.assertEqual(body["code"], ["test-code"])
             self.assertEqual(body["grant_type"], ["authorization_code"])
+            self.assertEqual(
+                body["redirect_uri"],
+                [f"{settings.FRONTEND_URL}/users/me/settings/student-confirmation"],
+            )
+            self.assertTrue(
+                request.headers.get("Authorization", "").startswith("Basic ")
+            )
             return _json_response(
                 request.url,
                 {
                     "access_token": "feide-access-token",
                     "token_type": "Bearer",
                     "expires_in": 3600,
+                    "id_token": self._make_id_token(),
                 },
             )
         if request.url == FEIDE_METADATA["userinfo_endpoint"]:
@@ -563,6 +618,15 @@ class FeideOIDCFlowTestCase(BaseAPITestCase):
             return _json_response(request.url, data_resp)
         raise AssertionError(f"Unexpected request to {request.url}")
 
+    def _authorize_and_get_callback_params(self, client):
+        authorize_response = client.get(_get_oidc_authorize_url())
+        self.assertEqual(authorize_response.status_code, status.HTTP_200_OK)
+        auth_url = authorize_response.json()["url"]
+        self.assertTrue(auth_url.startswith(FEIDE_METADATA["authorization_endpoint"]))
+        query = parse_qs(urlparse(auth_url).query)
+        self.expected_nonce = query["nonce"][0]
+        return query["state"][0]
+
     def test_flow_succeeds_without_session_cookies(self):
         with mock.patch.object(
             requests.sessions.Session,
@@ -572,14 +636,7 @@ class FeideOIDCFlowTestCase(BaseAPITestCase):
         ):
             authorize_client = APIClient()
             authorize_client.force_authenticate(self.user)
-            authorize_response = authorize_client.get(_get_oidc_authorize_url())
-            self.assertEqual(authorize_response.status_code, status.HTTP_200_OK)
-
-            auth_url = authorize_response.json()["url"]
-            self.assertTrue(
-                auth_url.startswith(FEIDE_METADATA["authorization_endpoint"])
-            )
-            state = parse_qs(urlparse(auth_url).query)["state"][0]
+            state = self._authorize_and_get_callback_params(authorize_client)
 
             validate_client = APIClient()
             validate_client.force_authenticate(self.user)
@@ -594,3 +651,21 @@ class FeideOIDCFlowTestCase(BaseAPITestCase):
         self.assertEqual(json_body["studyProgrammes"], ["Computer Science"])
         self.user.refresh_from_db()
         self.assertEqual(self.user.student_username, "teststudent")
+
+    def test_id_token_with_wrong_nonce_is_rejected(self):
+        with mock.patch.object(
+            requests.sessions.Session,
+            "send",
+            autospec=True,
+            side_effect=self._fake_feide_send,
+        ):
+            client = APIClient()
+            client.force_authenticate(self.user)
+            state = self._authorize_and_get_callback_params(client)
+            self.expected_nonce = "attacker-controlled-nonce"
+            validate_response = client.get(_get_oidc_validate_url("test-code", state))
+
+        self.assertEqual(validate_response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(validate_response.json()["status"], "error")
+        self.user.refresh_from_db()
+        self.assertIsNone(self.user.student_username)

--- a/lego/apps/users/views/oidc.py
+++ b/lego/apps/users/views/oidc.py
@@ -13,6 +13,7 @@ import requests
 import sentry_sdk
 from authlib.integrations.base_client.errors import OAuthError
 from authlib.integrations.django_client import OAuth
+from authlib.jose.errors import JoseError
 from requests import Response
 from structlog import get_logger
 
@@ -36,8 +37,8 @@ oauth.register(
 FEIDE_STATE_TTL_SECONDS = 3600
 
 
-def get_state_cache_key(user_id: int) -> str:
-    return f"feide_oidc_state_{user_id}"
+def get_state_cache_key(user_id: int, state: str) -> str:
+    return f"feide_oidc_state_{user_id}_{state}"
 
 
 def get_feide_groups(bearer: str) -> Response:
@@ -68,13 +69,13 @@ class OIDCViewSet(viewsets.GenericViewSet):
             redirect_uri
         )
         state_data: dict[str, str] = {
-            "state": authorization_data["state"],
+            "nonce": authorization_data["nonce"],
             "redirect_uri": redirect_uri,
         }
-        if "code_verifier" in authorization_data:
-            state_data["code_verifier"] = authorization_data["code_verifier"]
         oauth_cache.set(
-            get_state_cache_key(user.id), state_data, FEIDE_STATE_TTL_SECONDS
+            get_state_cache_key(user.id, authorization_data["state"]),
+            state_data,
+            FEIDE_STATE_TTL_SECONDS,
         )
         return JsonResponse(
             FeideAuthorizeSerializer({"url": authorization_data["url"]}).data,
@@ -90,36 +91,38 @@ class OIDCViewSet(viewsets.GenericViewSet):
         code = request.query_params.get("code")
         state = request.query_params.get("state")
 
-        cache_key = get_state_cache_key(user.id)
-        state_data: dict[str, str] | None = oauth_cache.get(cache_key)
-        oauth_cache.delete(cache_key)
+        state_data: dict[str, str] | None = None
+        if code and state:
+            cache_key = get_state_cache_key(user.id, state)
+            state_data = oauth_cache.get(cache_key)
+            if state_data is not None and not oauth_cache.delete(cache_key):
+                state_data = None
 
-        if not code or state_data is None or state != state_data["state"]:
-            sentry_sdk.capture_message("Failed while validating access token", "fatal")
+        if state_data is None:
+            sentry_sdk.capture_message(
+                "Feide validation attempted with unknown or already used state",
+                "warning",
+            )
             return JsonResponse(
                 {
                     "status": "error",
-                    "detail": "Error when validating OAUTH acccess token",
+                    "detail": "Error when validating OAuth access token",
                 },
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        token_params: dict[str, str] = {
-            "redirect_uri": state_data["redirect_uri"],
-            "code": code,
-        }
-        if "code_verifier" in state_data:
-            token_params["code_verifier"] = state_data["code_verifier"]
-
         try:
-            token = oauth.feide.fetch_access_token(**token_params)
-        except OAuthError as e:
+            token = oauth.feide.fetch_access_token(
+                redirect_uri=state_data["redirect_uri"], code=code
+            )
+            oauth.feide.parse_id_token(token, nonce=state_data["nonce"])
+        except (OAuthError, JoseError) as e:
             sentry_sdk.capture_message("Failed while validating access token", "fatal")
             sentry_sdk.capture_exception(error=e)
             return JsonResponse(
                 {
                     "status": "error",
-                    "detail": "Error when validating OAUTH acccess token",
+                    "detail": "Error when validating OAuth access token",
                 },
                 status=status.HTTP_400_BAD_REQUEST,
             )

--- a/lego/apps/users/views/oidc.py
+++ b/lego/apps/users/views/oidc.py
@@ -11,7 +11,7 @@ from rest_framework.request import Request
 
 import requests
 import sentry_sdk
-from authlib.integrations.base_client.errors import MismatchingStateError
+from authlib.integrations.base_client.errors import OAuthError
 from authlib.integrations.django_client import OAuth
 from requests import Response
 from structlog import get_logger
@@ -32,6 +32,12 @@ oauth.register(
     server_metadata_url=settings.FEIDE_OIDC_CONFIGURATION_ENDPOINT,
     client_kwargs={"scope": "openid"},
 )
+
+FEIDE_STATE_TTL_SECONDS = 3600
+
+
+def get_state_cache_key(user_id: int) -> str:
+    return f"feide_oidc_state_{user_id}"
 
 
 def get_feide_groups(bearer: str) -> Response:
@@ -56,10 +62,22 @@ class OIDCViewSet(viewsets.GenericViewSet):
 
     @action(detail=False, methods=["GET"])
     def authorize(self, request: Request) -> JsonResponse:
+        user: User = request.user  # type: ignore[assignment]
         redirect_uri = f"{settings.FRONTEND_URL}/users/me/settings/student-confirmation"
-        auth_uri = oauth.feide.authorize_redirect(request, redirect_uri).url
+        authorization_data: dict[str, str] = oauth.feide.create_authorization_url(
+            redirect_uri
+        )
+        state_data: dict[str, str] = {
+            "state": authorization_data["state"],
+            "redirect_uri": redirect_uri,
+        }
+        if "code_verifier" in authorization_data:
+            state_data["code_verifier"] = authorization_data["code_verifier"]
+        oauth_cache.set(
+            get_state_cache_key(user.id), state_data, FEIDE_STATE_TTL_SECONDS
+        )
         return JsonResponse(
-            FeideAuthorizeSerializer({"url": auth_uri}).data,
+            FeideAuthorizeSerializer({"url": authorization_data["url"]}).data,
             status=status.HTTP_200_OK,
         )
 
@@ -69,36 +87,33 @@ class OIDCViewSet(viewsets.GenericViewSet):
 
         user: User = request.user  # type: ignore[assignment]
 
-        try:
-            token = oauth.feide.authorize_access_token(request)
-            userinfo = oauth.feide.userinfo(token=token)
-            principal_name = userinfo[
-                "https://n.feide.no/claims/eduPersonPrincipalName"
-            ]
-            uid = get_uid_from_principalName(principal_name)
-            if uid is None:
-                sentry_sdk.capture_message(
-                    "Could not extract student username from principal_name",
-                    "fatal",
-                    principle_name=principal_name,
-                )
-                validation_status = "error"
-            else:
-                try:
-                    validation_status = "success"
-                    with transaction.atomic():
-                        user.student_username = uid
-                        user.save()
+        code = request.query_params.get("code")
+        state = request.query_params.get("state")
 
-                except IntegrityError:
-                    return JsonResponse(
-                        {
-                            "status": "error",
-                            "detail": f"The feide account {uid} is already linked to another user",
-                        },
-                        status=status.HTTP_400_BAD_REQUEST,
-                    )
-        except MismatchingStateError as e:
+        cache_key = get_state_cache_key(user.id)
+        state_data: dict[str, str] | None = oauth_cache.get(cache_key)
+        oauth_cache.delete(cache_key)
+
+        if not code or state_data is None or state != state_data["state"]:
+            sentry_sdk.capture_message("Failed while validating access token", "fatal")
+            return JsonResponse(
+                {
+                    "status": "error",
+                    "detail": "Error when validating OAUTH acccess token",
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        token_params: dict[str, str] = {
+            "redirect_uri": state_data["redirect_uri"],
+            "code": code,
+        }
+        if "code_verifier" in state_data:
+            token_params["code_verifier"] = state_data["code_verifier"]
+
+        try:
+            token = oauth.feide.fetch_access_token(**token_params)
+        except OAuthError as e:
             sentry_sdk.capture_message("Failed while validating access token", "fatal")
             sentry_sdk.capture_exception(error=e)
             return JsonResponse(
@@ -108,6 +123,32 @@ class OIDCViewSet(viewsets.GenericViewSet):
                 },
                 status=status.HTTP_400_BAD_REQUEST,
             )
+
+        userinfo = oauth.feide.userinfo(token=token)
+        principal_name = userinfo["https://n.feide.no/claims/eduPersonPrincipalName"]
+        uid = get_uid_from_principalName(principal_name)
+        if uid is None:
+            sentry_sdk.capture_message(
+                "Could not extract student username from principal_name",
+                "fatal",
+                extras={"principal_name": principal_name},
+            )
+            validation_status = "error"
+        else:
+            try:
+                validation_status = "success"
+                with transaction.atomic():
+                    user.student_username = uid
+                    user.save()
+
+            except IntegrityError:
+                return JsonResponse(
+                    {
+                        "status": "error",
+                        "detail": f"The feide account {uid} is already linked to another user",
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
 
         try:
             groups_res = get_feide_groups(token["access_token"])


### PR DESCRIPTION
## Description

Feide student verification has been broken in production since mid-May ([LEGO-10H](https://abakus.sentry.io/issues/LEGO-10H)).
The authlib 1.6 upgrade (#4143) started binding the OAuth state to the Django session, but the webapp calls the API cross-origin without cookies, so every `/oidc/validate/` request failed with `MismatchingStateError`.

Changes:
- Store the OAuth state in the oauth Redis cache keyed by user id + state, removing the session dependency while keeping the state single-use and bound to the authenticated user.
- Verify the id_token (signature, claims, nonce) as authlib's wrapper previously did.
- Consume the state atomically, and let a stale callback fail without destroying a pending flow.
- Catch `OAuthError` from the token exchange (previously an uncaught 500).
- Log state misses as warnings; fatal is reserved for real token validation failures, so LEGO-10H should flatline after deploy.


## Testing

- New integration test runs the real authlib client against a stubbed Feide (signed id_token + JWKS) with separate cookie-less clients, mirroring the browser. It fails on master and passes here.
- New tests: replay, mismatching state, cross-user state, second-tab flows, wrong-nonce id_token, rejected authorization code.
- Verified locally end to end with cookie-less requests


- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

Dependent on [frontend PR](https://github.com/webkom/lego/pull/4191)

Resolves #4190 
