### PR TITLE
Fix external payments with no metadata validatation

### DIFF
--- a/lego/apps/events/exceptions.py
+++ b/lego/apps/events/exceptions.py
@@ -87,7 +87,7 @@ class PoolCounterNotEqualToRegistrationCount(ValueError):
 
 
 class WebhookDidNotFindRegistration(ValueError):
-    def __init__(self, event_id, metadata):
+    def __init__(self, event_id: str, metadata: dict) -> None:
         message = (
             f'Stripe webhook with ID: {event_id} for event {metadata["EVENT_ID"]} tried '
             f'getting registration for user {metadata["USER"]}, but did not find any!'

--- a/lego/apps/events/tasks.py
+++ b/lego/apps/events/tasks.py
@@ -403,7 +403,20 @@ def check_for_bump_on_pool_creation_or_expansion(
     event.save(update_fields=["is_ready"])
 
 
-@celery_app.task(serializer="json", bind=True, base=AbakusTask)
+def is_lego_payment(metadata: dict | None, payment_intent_id: str | None) -> bool:
+    """
+    The Stripe account is shared with payments made outside LEGO, which the webhook must
+    ignore. A payment belongs to LEGO if it carries LEGO metadata or matches a
+    registration's payment intent.
+    """
+    if metadata and "EVENT_ID" in metadata:
+        return True
+    if not payment_intent_id:
+        return False
+    return Registration.objects.filter(payment_intent_id=payment_intent_id).exists()
+
+
+@celery_app.task(serializer="json", bind=True, base=AbakusTask)  # type: ignore[misc]
 def stripe_webhook_event(
     self: AbakusTask,
     event_id: str,
@@ -413,27 +426,27 @@ def stripe_webhook_event(
     """
     Task that handles webhook events from Stripe, and updates the users registration in accordance
     with the payment status.
-
-    Payments without metadata are created outside LEGO on the shared Stripe account and are
-    ignored.
     """
     self.setup_logger(logger_context)
     event = stripe.Event.retrieve(event_id)
-
-    if not event.data["object"].get("metadata"):
-        log.info(
-            "stripe_webhook_ignored_external_payment",
-            event_id=event_id,
-            event_type=event_type,
-        )
-        return
 
     if event_type in [
         constants.STRIPE_EVENT_INTENT_SUCCESS,
         constants.STRIPE_EVENT_INTENT_PAYMENT_FAILED,
         constants.STRIPE_EVENT_INTENT_PAYMENT_CANCELED,
     ]:
-        serializer = StripePaymentIntentSerializer(data=event.data["object"])
+        payment_intent = event.data["object"]
+        if not is_lego_payment(
+            payment_intent.get("metadata"), payment_intent.get("id")
+        ):
+            log.info(
+                "stripe_webhook_ignored_external_payment",
+                event_id=event_id,
+                event_type=event_type,
+            )
+            return
+
+        serializer = StripePaymentIntentSerializer(data=payment_intent)
         serializer.is_valid(raise_exception=True)
 
         metadata = serializer.data["metadata"]
@@ -468,7 +481,16 @@ def stripe_webhook_event(
         registration.save()
 
     elif event_type in [constants.STRIPE_EVENT_CHARGE_REFUNDED]:
-        serializer = StripeChargeSerializer(data=event.data["object"])
+        charge = event.data["object"]
+        if not is_lego_payment(charge.get("metadata"), charge.get("payment_intent")):
+            log.info(
+                "stripe_webhook_ignored_external_payment",
+                event_id=event_id,
+                event_type=event_type,
+            )
+            return
+
+        serializer = StripeChargeSerializer(data=charge)
         serializer.is_valid(raise_exception=True)
 
         metadata = serializer.data["metadata"]

--- a/lego/apps/events/tasks.py
+++ b/lego/apps/events/tasks.py
@@ -404,13 +404,29 @@ def check_for_bump_on_pool_creation_or_expansion(
 
 
 @celery_app.task(serializer="json", bind=True, base=AbakusTask)
-def stripe_webhook_event(self, event_id, event_type, logger_context=None):
+def stripe_webhook_event(
+    self: AbakusTask,
+    event_id: str,
+    event_type: str,
+    logger_context: dict | None = None,
+) -> None:
     """
     Task that handles webhook events from Stripe, and updates the users registration in accordance
     with the payment status.
+
+    Payments without metadata are created outside LEGO on the shared Stripe account and are
+    ignored.
     """
     self.setup_logger(logger_context)
     event = stripe.Event.retrieve(event_id)
+
+    if not event.data["object"].get("metadata"):
+        log.info(
+            "stripe_webhook_ignored_external_payment",
+            event_id=event_id,
+            event_type=event_type,
+        )
+        return
 
     if event_type in [
         constants.STRIPE_EVENT_INTENT_SUCCESS,

--- a/lego/apps/events/tests/test_async_tasks.py
+++ b/lego/apps/events/tests/test_async_tasks.py
@@ -10,6 +10,7 @@ from lego.apps.events.exceptions import PoolCounterNotEqualToRegistrationCount
 from lego.apps.events.models import Event, Registration
 from lego.apps.events.tasks import (
     AsyncRegister,
+    async_initiate_payment,
     async_register,
     async_retrieve_payment,
     bump_waiting_users_to_new_pool,
@@ -589,6 +590,47 @@ class StripePaymentTestCase(BaseTestCase):
         ]
         async_register(registration.id)
         mock_initiate_payment.assert_not_called()
+
+
+class StripePaymentIntentMetadataTestCase(BaseTestCase):
+    fixtures = [
+        "test_abakus_groups.yaml",
+        "test_users.yaml",
+        "test_events.yaml",
+        "test_companies.yaml",
+    ]
+
+    def setUp(self):
+        self.event = Event.objects.get(title="POOLS_AND_PRICED")
+        self.event.start_time = timezone.now() + timedelta(days=1)
+        self.event.end_time = timezone.now() + timedelta(days=1, hours=2)
+        self.event.merge_time = timezone.now() + timedelta(hours=12)
+        self.event.payment_due_date = timezone.now() + timedelta(days=2)
+        self.event.save()
+
+    @mock.patch("lego.apps.events.tasks.stripe.PaymentIntent.create")
+    def test_payment_intent_is_created_with_webhook_metadata(self, mock_create):
+        """
+        stripe_webhook_event ignores payments without metadata, so every payment
+        intent LEGO creates must carry the full metadata contract.
+        """
+        user = get_dummy_users(1)[0]
+        AbakusGroup.objects.get(name="Abakus").add_user(user)
+        registration = Registration.objects.get_or_create(event=self.event, user=user)[
+            0
+        ]
+
+        async_initiate_payment(registration.id)
+
+        self.assertEqual(
+            mock_create.call_args.kwargs["metadata"],
+            {
+                "EVENT_ID": self.event.id,
+                "USER_ID": user.id,
+                "USER": user.full_name,
+                "EMAIL": user.email,
+            },
+        )
 
 
 class PaymentDueTestCase(BaseTestCase):

--- a/lego/apps/events/tests/test_async_tasks.py
+++ b/lego/apps/events/tests/test_async_tasks.py
@@ -520,8 +520,7 @@ class PenaltyExpiredTestCase(BaseTestCase):
         self.assertEqual(self.event.number_of_registrations, 2)
 
 
-@skipIf(not stripe.api_key, "No API Key set. Set STRIPE_TEST_KEY in ENV to run test.")
-class StripePaymentTestCase(BaseTestCase):
+class PricedEventTestCase(BaseTestCase):
     fixtures = [
         "test_abakus_groups.yaml",
         "test_users.yaml",
@@ -536,6 +535,12 @@ class StripePaymentTestCase(BaseTestCase):
         self.event.merge_time = timezone.now() + timedelta(hours=12)
         self.event.payment_due_date = timezone.now() + timedelta(days=2)
         self.event.save()
+
+
+@skipIf(not stripe.api_key, "No API Key set. Set STRIPE_TEST_KEY in ENV to run test.")
+class StripePaymentTestCase(PricedEventTestCase):
+    def setUp(self):
+        super().setUp()
         self.registration = self.event.registrations.first()
 
     @mock.patch("lego.apps.events.tasks.save_and_notify_payment")
@@ -592,22 +597,7 @@ class StripePaymentTestCase(BaseTestCase):
         mock_initiate_payment.assert_not_called()
 
 
-class StripePaymentIntentMetadataTestCase(BaseTestCase):
-    fixtures = [
-        "test_abakus_groups.yaml",
-        "test_users.yaml",
-        "test_events.yaml",
-        "test_companies.yaml",
-    ]
-
-    def setUp(self):
-        self.event = Event.objects.get(title="POOLS_AND_PRICED")
-        self.event.start_time = timezone.now() + timedelta(days=1)
-        self.event.end_time = timezone.now() + timedelta(days=1, hours=2)
-        self.event.merge_time = timezone.now() + timedelta(hours=12)
-        self.event.payment_due_date = timezone.now() + timedelta(days=2)
-        self.event.save()
-
+class StripePaymentIntentMetadataTestCase(PricedEventTestCase):
     @mock.patch("lego.apps.events.tasks.stripe.PaymentIntent.create")
     def test_payment_intent_is_created_with_webhook_metadata(self, mock_create):
         """

--- a/lego/apps/events/tests/test_webhooks.py
+++ b/lego/apps/events/tests/test_webhooks.py
@@ -2,12 +2,15 @@ from unittest import mock
 
 from django.test import override_settings
 from rest_framework import status
+from rest_framework.exceptions import ValidationError
 
 import stripe
 from stripe.error import SignatureVerificationError
 
 from lego.apps.events.exceptions import WebhookDidNotFindRegistration
+from lego.apps.events.models import Event, Registration
 from lego.apps.events.tasks import stripe_webhook_event
+from lego.apps.events.tests.utils import get_dummy_users
 from lego.utils.test_utils import BaseAPITestCase, BaseTestCase
 
 
@@ -61,19 +64,108 @@ class StripeWebhookTestCase(BaseAPITestCase):
 
 
 class StripeWebhookEventTaskTestCase(BaseTestCase):
-    def stripe_event(self, payment_intent: dict) -> stripe.Event:
+    fixtures = [
+        "test_abakus_groups.yaml",
+        "test_users.yaml",
+        "test_events.yaml",
+        "test_companies.yaml",
+    ]
+
+    def stripe_event(self, stripe_object: dict) -> stripe.Event:
         return stripe.Event.construct_from(
-            {"id": "evt_1", "data": {"object": payment_intent}}, "api_key"
+            {"id": "evt_1", "data": {"object": stripe_object}}, "api_key"
         )
 
+    def assert_ignored_as_external(self, mock_log, event_type: str) -> None:
+        mock_log.info.assert_called_once_with(
+            "stripe_webhook_ignored_external_payment",
+            event_id="evt_1",
+            event_type=event_type,
+        )
+
+    @mock.patch("lego.apps.events.tasks.log")
     @mock.patch("lego.apps.events.tasks.stripe.Event.retrieve")
-    def test_ignores_payment_without_metadata(self, mock_retrieve):
+    def test_ignores_external_payment_without_metadata(self, mock_retrieve, mock_log):
         """Payments created outside LEGO on the shared Stripe account are ignored"""
         mock_retrieve.return_value = self.stripe_event(
             {"id": "pi_1", "amount": 84500, "status": "succeeded", "metadata": {}}
         )
 
         stripe_webhook_event(event_id="evt_1", event_type="payment_intent.succeeded")
+
+        self.assert_ignored_as_external(mock_log, "payment_intent.succeeded")
+
+    @mock.patch("lego.apps.events.tasks.log")
+    @mock.patch("lego.apps.events.tasks.stripe.Event.retrieve")
+    def test_ignores_external_payment_with_foreign_metadata(
+        self, mock_retrieve, mock_log
+    ):
+        """External payments are ignored even when they carry their own metadata"""
+        mock_retrieve.return_value = self.stripe_event(
+            {
+                "id": "pi_1",
+                "amount": 84500,
+                "status": "succeeded",
+                "metadata": {"order_id": "42"},
+            }
+        )
+
+        stripe_webhook_event(event_id="evt_1", event_type="payment_intent.succeeded")
+
+        self.assert_ignored_as_external(mock_log, "payment_intent.succeeded")
+
+    @mock.patch("lego.apps.events.tasks.log")
+    @mock.patch("lego.apps.events.tasks.stripe.Event.retrieve")
+    def test_ignores_external_refund(self, mock_retrieve, mock_log):
+        """Refunds of payments created outside LEGO are ignored"""
+        mock_retrieve.return_value = self.stripe_event(
+            {
+                "id": "ch_1",
+                "amount": 84500,
+                "amount_refunded": 84500,
+                "status": "succeeded",
+                "payment_intent": "pi_unknown",
+                "metadata": {},
+            }
+        )
+
+        stripe_webhook_event(event_id="evt_1", event_type="charge.refunded")
+
+        self.assert_ignored_as_external(mock_log, "charge.refunded")
+
+    @mock.patch("lego.apps.events.tasks.stripe.Event.retrieve")
+    def test_raises_for_partial_lego_metadata(self, mock_retrieve):
+        """A LEGO payment with incomplete metadata must fail loudly, not be ignored"""
+        mock_retrieve.return_value = self.stripe_event(
+            {
+                "id": "pi_1",
+                "amount": 84500,
+                "status": "succeeded",
+                "last_payment_error": None,
+                "metadata": {"EVENT_ID": 1},
+            }
+        )
+
+        with self.assertRaises(ValidationError):
+            stripe_webhook_event(
+                event_id="evt_1", event_type="payment_intent.succeeded"
+            )
+
+    @mock.patch("lego.apps.events.tasks.stripe.Event.retrieve")
+    def test_raises_for_lego_payment_with_stripped_metadata(self, mock_retrieve):
+        """A payment matching a registration's payment intent must fail loudly when
+        its metadata is gone, not be ignored as external"""
+        event = Event.objects.get(title="POOLS_AND_PRICED")
+        user = get_dummy_users(1)[0]
+        Registration.objects.create(event=event, user=user, payment_intent_id="pi_1")
+        mock_retrieve.return_value = self.stripe_event(
+            {"id": "pi_1", "amount": 84500, "status": "succeeded", "metadata": {}}
+        )
+
+        with self.assertRaises(ValidationError):
+            stripe_webhook_event(
+                event_id="evt_1", event_type="payment_intent.succeeded"
+            )
 
     @mock.patch("lego.apps.events.tasks.stripe.Event.retrieve")
     def test_raises_when_lego_payment_has_no_registration(self, mock_retrieve):
@@ -85,8 +177,8 @@ class StripeWebhookEventTaskTestCase(BaseTestCase):
                 "status": "succeeded",
                 "last_payment_error": None,
                 "metadata": {
-                    "EVENT_ID": 1,
-                    "USER_ID": 1,
+                    "EVENT_ID": 999,
+                    "USER_ID": 999,
                     "USER": "Test User",
                     "EMAIL": "test@abakus.no",
                 },

--- a/lego/apps/events/tests/test_webhooks.py
+++ b/lego/apps/events/tests/test_webhooks.py
@@ -3,9 +3,12 @@ from unittest import mock
 from django.test import override_settings
 from rest_framework import status
 
+import stripe
 from stripe.error import SignatureVerificationError
 
-from lego.utils.test_utils import BaseAPITestCase
+from lego.apps.events.exceptions import WebhookDidNotFindRegistration
+from lego.apps.events.tasks import stripe_webhook_event
+from lego.utils.test_utils import BaseAPITestCase, BaseTestCase
 
 
 @override_settings(STRIPE_WEBHOOK_SECRET="test_secret")
@@ -55,3 +58,42 @@ class StripeWebhookTestCase(BaseAPITestCase):
 
         response = self.client.post(self.url, payload, HTTP_STRIPE_SIGNATURE="valid")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class StripeWebhookEventTaskTestCase(BaseTestCase):
+    def stripe_event(self, payment_intent: dict) -> stripe.Event:
+        return stripe.Event.construct_from(
+            {"id": "evt_1", "data": {"object": payment_intent}}, "api_key"
+        )
+
+    @mock.patch("lego.apps.events.tasks.stripe.Event.retrieve")
+    def test_ignores_payment_without_metadata(self, mock_retrieve):
+        """Payments created outside LEGO on the shared Stripe account are ignored"""
+        mock_retrieve.return_value = self.stripe_event(
+            {"id": "pi_1", "amount": 84500, "status": "succeeded", "metadata": {}}
+        )
+
+        stripe_webhook_event(event_id="evt_1", event_type="payment_intent.succeeded")
+
+    @mock.patch("lego.apps.events.tasks.stripe.Event.retrieve")
+    def test_raises_when_lego_payment_has_no_registration(self, mock_retrieve):
+        """Payments with LEGO metadata must match a registration"""
+        mock_retrieve.return_value = self.stripe_event(
+            {
+                "id": "pi_1",
+                "amount": 84500,
+                "status": "succeeded",
+                "last_payment_error": None,
+                "metadata": {
+                    "EVENT_ID": 1,
+                    "USER_ID": 1,
+                    "USER": "Test User",
+                    "EMAIL": "test@abakus.no",
+                },
+            }
+        )
+
+        with self.assertRaises(WebhookDidNotFindRegistration):
+            stripe_webhook_event(
+                event_id="evt_1", event_type="payment_intent.succeeded"
+            )

--- a/lego/utils/tasks.py
+++ b/lego/utils/tasks.py
@@ -35,7 +35,7 @@ class AbakusTask(Task):
         log.info("async_task_created", task_id=async_result.id, task_name=self.name)
         return async_result
 
-    def setup_logger(self, logger_context):
+    def setup_logger(self, logger_context: dict | None) -> None:
         logger_context = logger_context or {}
         logger_context["task_name"] = self.name
         logger_context["task_id"] = self.request.id


### PR DESCRIPTION
# Description

Lego would crash when a Stripe payment without metadata and Sentry would trigger an error (false alarm). This could be external payments for persons that are allowed to attend Abakus events like "Immatrikuleringsball". These a re valid requests and should not crash, but rather skipped.

Added tests to ensure that Stripe payments internal to lego fail if no metadata is attached to the payment.


# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

Resolves #4192 
