### PR TITLE
Stop Dependabot proposing bumps that break the build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,26 @@ updates:
       time: "08:00"
       timezone: Europe/Oslo
     open-pull-requests-limit: 10
+    # Ranges, not whole packages, so patches below them still flow.
+    ignore:
+      # drops rest_framework/documentation.py, imported by lego/urls.py
+      - dependency-name: "djangorestframework"
+        versions: [">=3.17"]
+      # drops the DRF schema methods /api-docs/ needs
+      - dependency-name: "django-filter"
+        versions: [">=25.0"]
+      # drops BaseHealthCheckBackend
+      - dependency-name: "django-health-check"
+        versions: [">=3.21"]
+      # needs redis>=4.6
+      - dependency-name: "channels_redis"
+        versions: [">=4.2"]
+      # swappable model, irreversible secret hashing
+      - dependency-name: "django-oauth-toolkit"
+        versions: [">=2.0"]
+      # drops pkg_resources, imported by coreapi
+      - dependency-name: "setuptools"
+        versions: [">=82"]
     groups:
       # mypy and its stubs are version-coupled and must move together.
       typing:
@@ -34,6 +54,12 @@ updates:
       routine:
         patterns:
           - "*"
+        # celery broker stack; wanted, but needs its own PR
+        exclude-patterns:
+          - "redis"
+          - "hiredis"
+          - "celery"
+          - "kombu"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
The `routine` group swept `djangorestframework 3.16.1 -> 3.18.0` into an eighteen-package PR (**#4220**). DRF 3.17 removed `rest_framework/documentation.py`, which `lego/urls.py:6` imports at module scope, so the whole URLconf fails to load, not just `/api-docs/`. Drone 7070 went red on it. Nothing prevented that, and it would have been reproposed every Monday.

### Scoped ignores, not blanket ones

| Package | Ignored | Why | Exit condition |
|---|---|---|---|
| `djangorestframework` | `>=3.17` | removes `documentation.py`, URLconf dies | replace the coreapi docs endpoint |
| `django-filter` | `>=25.0` | removes the DRF schema methods | same |
| `django-health-check` | `>=3.21` | removes `BaseHealthCheckBackend` | migrate to the v4 base class |
| `channels_redis` | `>=4.2` | needs `redis>=4.6` | move redis off 4.5.5 |
| `django-oauth-toolkit` | `>=2.0` | swappable model, irreversible secret hashing | the rehearsed migration (B7) |

Every current pin sits **below** its ignored range, so security patches inside the safe band still get proposed. A blanket per-package ignore would have silently blocked those too. Each entry carries its reason and its exit condition, so whoever removes it knows what has to be true first.

### celery/redis excluded from the routine group

`redis`, `hiredis`, `celery` and `kombu` now arrive as their own reviewable PR. Moving redis off 4.5.5 is actively wanted, since kombu 5.6.2 declares `redis!=4.5.5` and the current pin is a version the broker library explicitly excludes, but it needs its own testing rather than being one line in an eighteen-package diff.
