### PR TITLE
Retry transient upstream failures instead of dropping the work

### DIFF
--- a/lego/apps/external_sync/tests/test_gsuite.py
+++ b/lego/apps/external_sync/tests/test_gsuite.py
@@ -1,0 +1,42 @@
+import inspect
+import re
+from unittest import mock
+
+from lego.apps.external_sync.utils import gsuite
+from lego.apps.external_sync.utils.gsuite import GSuiteLib
+from lego.utils.test_utils import BaseTestCase
+
+NUM_RETRIES = 5
+
+
+@mock.patch.object(GSuiteLib, "get_credentials", return_value=None)
+@mock.patch("lego.apps.external_sync.utils.gsuite.build")
+class GSuiteRetryTestCase(BaseTestCase):
+    def test_get_user_asks_the_client_to_retry(self, build_mock, credentials_mock):
+        lib = GSuiteLib()
+
+        lib.get_user("test@abakus.no")
+
+        execute = build_mock.return_value.users.return_value.get.return_value.execute
+        execute.assert_called_once_with(num_retries=NUM_RETRIES)
+
+    def test_get_group_asks_the_client_to_retry(self, build_mock, credentials_mock):
+        lib = GSuiteLib()
+
+        lib.get_group("abakom@abakus.no")
+
+        execute = build_mock.return_value.groups.return_value.get.return_value.execute
+        execute.assert_called_once_with(num_retries=NUM_RETRIES)
+
+    def test_no_api_call_is_left_without_retries(self, build_mock, credentials_mock):
+        """
+        The Directory API returns transient 503s regularly, and a call without
+        num_retries aborts the whole sync run partway through.
+        """
+        source = inspect.getsource(gsuite)
+
+        self.assertEqual(re.findall(r"\.execute\(\s*\)", source), [])
+        self.assertEqual(
+            len(re.findall(r"\.execute\(num_retries=", source)),
+            source.count(".execute("),
+        )

--- a/lego/apps/external_sync/utils/gsuite.py
+++ b/lego/apps/external_sync/utils/gsuite.py
@@ -41,7 +41,7 @@ class GSuiteLib:
         )
 
     def get_user(self, user_key):
-        return self.client.users().get(userKey=user_key).execute()
+        return self.client.users().get(userKey=user_key).execute(num_retries=5)
 
     def user_exists(self, user_key):
         try:
@@ -66,7 +66,7 @@ class GSuiteLib:
                     "emails": [{"address": email, "type": "other"}],
                 }
             )
-            .execute()
+            .execute(num_retries=5)
         )
 
     def update_user(
@@ -85,7 +85,7 @@ class GSuiteLib:
                     "emails": [{"address": email, "type": "other"}],
                 },
             )
-            .execute()
+            .execute(num_retries=5)
         )
 
     def delete_user(self, user_key):
@@ -96,7 +96,7 @@ class GSuiteLib:
             return (
                 self.client.users()
                 .update(userKey=user_key, body={"suspended": True})
-                .execute()
+                .execute(num_retries=5)
             )
 
     def get_all_users(self):
@@ -108,7 +108,7 @@ class GSuiteLib:
         request = api.list(domain="abakus.no", query="isSuspended=false")
 
         while request is not None:
-            users_response = request.execute()
+            users_response = request.execute(num_retries=5)
 
             remote_users = users_response.get("users", [])
             users = users + remote_users
@@ -118,7 +118,7 @@ class GSuiteLib:
         return users
 
     def get_group(self, group_key):
-        return self.client.groups().get(groupKey=group_key).execute()
+        return self.client.groups().get(groupKey=group_key).execute(num_retries=5)
 
     def group_exists(self, group_key):
         try:
@@ -133,14 +133,14 @@ class GSuiteLib:
         return (
             self.client.groups()
             .insert(body={"name": name, "email": group_key})
-            .execute()
+            .execute(num_retries=5)
         )
 
     def update_group(self, group_key, name):
         return (
             self.client.groups()
             .update(groupKey=group_key, body={"name": name})
-            .execute()
+            .execute(num_retries=5)
         )
 
     def get_members(self, group_key):
@@ -150,7 +150,7 @@ class GSuiteLib:
             request = api.list(groupKey=group_key)
 
             while request is not None:
-                members_response = request.execute()
+                members_response = request.execute(num_retries=5)
 
                 remote_members = members_response.get("members", [])
                 members = members + remote_members
@@ -181,7 +181,7 @@ class GSuiteLib:
             return (
                 self.client.members()
                 .insert(groupKey=group_key, body={"role": role, "email": user_key})
-                .execute()
+                .execute(num_retries=5)
             )
         except HttpError as e:
             if e.resp.status == 404:
@@ -196,7 +196,7 @@ class GSuiteLib:
             return (
                 self.client.members()
                 .delete(groupKey=group_key, memberKey=user_key)
-                .execute()
+                .execute(num_retries=5)
             )
         except HttpError as e:
             if e.resp.status == 404:

--- a/lego/utils/tasks.py
+++ b/lego/utils/tasks.py
@@ -1,6 +1,7 @@
 from smtplib import SMTPException
 
 from celery.app.task import Task
+from celery.utils.time import get_exponential_backoff_interval
 from push_notifications.exceptions import NotificationError
 from structlog import get_context, get_logger
 
@@ -55,7 +56,12 @@ def send_email(self, logger_context=None, **kwargs):
         message.send()
     except SMTPException as e:
         log.error("email_task_exception", exc_info=True, extra=kwargs)
-        raise self.retry(exc=e, countdown=2**self.request.retries) from e
+        raise self.retry(
+            exc=e,
+            countdown=get_exponential_backoff_interval(
+                factor=60, retries=self.request.retries, maximum=1800, full_jitter=True
+            ),
+        ) from e
 
 
 @celery_app.task(bind=True, max_retries=5, base=AbakusTask)
@@ -76,4 +82,9 @@ def send_push(self, user, title, target=None, logger_context=None, **kwargs):
         message.send()
     except NotificationError as e:
         log.error("push_task_exception", exec_info=True, extra=kwargs)
-        raise self.retry(exc=e, countdown=2**self.request.retries) from e
+        raise self.retry(
+            exc=e,
+            countdown=get_exponential_backoff_interval(
+                factor=60, retries=self.request.retries, maximum=1800, full_jitter=True
+            ),
+        ) from e

--- a/lego/utils/tests/test_tasks.py
+++ b/lego/utils/tests/test_tasks.py
@@ -1,0 +1,63 @@
+from smtplib import SMTPServerDisconnected
+from unittest import mock
+
+from celery.exceptions import Retry
+from push_notifications.exceptions import NotificationError
+
+from lego.utils.tasks import send_email, send_push
+from lego.utils.test_utils import BaseTestCase
+
+BACKOFF = {"factor": 60, "maximum": 1800, "full_jitter": True}
+
+
+class SendEmailRetryTestCase(BaseTestCase):
+    @mock.patch("lego.utils.tasks.EmailMessage")
+    def test_smtp_failure_schedules_a_retry(self, email_mock):
+        email_mock.return_value.send.side_effect = SMTPServerDisconnected("busy")
+
+        with mock.patch.object(send_email, "retry", side_effect=Retry) as retry:
+            with self.assertRaises(Retry):
+                send_email(to_email="test@abakus.no")
+
+        self.assertEqual(retry.call_count, 1)
+        self.assertIsInstance(retry.call_args.kwargs["exc"], SMTPServerDisconnected)
+
+    @mock.patch("lego.utils.tasks.EmailMessage")
+    def test_retry_delay_scales_in_minutes(self, email_mock):
+        email_mock.return_value.send.side_effect = SMTPServerDisconnected("busy")
+
+        with mock.patch(
+            "lego.utils.tasks.get_exponential_backoff_interval", return_value=123
+        ) as backoff:
+            with mock.patch.object(send_email, "retry", side_effect=Retry):
+                with self.assertRaises(Retry):
+                    send_email(to_email="test@abakus.no")
+
+        backoff.assert_called_once_with(retries=mock.ANY, **BACKOFF)
+
+    @mock.patch("lego.utils.tasks.EmailMessage")
+    def test_success_does_not_retry(self, email_mock):
+        with mock.patch.object(send_email, "retry", side_effect=Retry) as retry:
+            send_email(to_email="test@abakus.no")
+
+        email_mock.return_value.send.assert_called_once()
+        retry.assert_not_called()
+
+
+class SendPushRetryTestCase(BaseTestCase):
+    fixtures = ["test_abakus_groups.yaml", "test_users.yaml"]
+
+    @mock.patch("lego.utils.tasks.PushMessage")
+    @mock.patch("lego.utils.tasks.User")
+    def test_notification_failure_retries_with_the_same_backoff(self, user, push_mock):
+        push_mock.return_value.send.side_effect = NotificationError("boom")
+
+        with mock.patch(
+            "lego.utils.tasks.get_exponential_backoff_interval", return_value=123
+        ) as backoff:
+            with mock.patch.object(send_push, "retry", side_effect=Retry) as retry:
+                with self.assertRaises(Retry):
+                    send_push(user=1, title="t")
+
+        backoff.assert_called_once_with(retries=mock.ANY, **BACKOFF)
+        self.assertEqual(retry.call_args.kwargs["countdown"], 123)


### PR DESCRIPTION
Two recurring Sentry issues, both external services failing briefly, neither handled.

### `send_email` / `send_push` — 31 seconds of patience

Both retried with `countdown=2**retries`, so `1+2+4+8+16` = **31 seconds total**. On 2026-08-17 Google's relay throttled us for about **75 seconds**:

```
07:00:11  SMTPConnectError(421, '4.4.5 Server busy, try again later')
07:00:13  SMTPDataError(451, '4.3.0 Mail server temporarily rejected')
07:01:26  raised unexpected: SMTPServerDisconnected  x3
```

Retries ran out and **three emails were dropped rather than delayed**. 592 sends succeeded in the same 72-hour window, so this is rare — but when it happens, mail is lost silently.

Now uses celery's own exponential helper with full jitter, giving roughly 30 minutes across the same 5 retries. The jitter is not decoration: the trigger was rate limiting, so retrying a burst in lockstep would re-trigger it.

`send_push` had the identical line three lines below, so it moves too.

### `sync_external_systems` — no retry at all

The Google Directory API returns transient `503`s regularly: **32 failures across 12 of the last 14 days**, on different endpoints (users, groups, members), so it is API availability rather than a bad record. This predates the Django 5.2 upgrade by two weeks.

There was no retry, and no lock or transaction — `Sync.sync()`'s own docstring says *"We should split this into multiple celery tasks and add a lock at a later point."* So a single 503 aborts the run partway and `delete_excess_users` / `delete_excess_groups` never execute that hour. It self-heals next hour, but roughly twice a day the directory sync is incomplete.

`googleapiclient` already backs off on 5xx — `_should_retry_response` returns `True` for `resp_status >= 500` — it just defaults to `num_retries=0`. Added to all 11 `.execute()` call sites.

### Verification

`1241 tests, OK (skipped=10)`, black, isort and flake8 clean.

Note the retry paths have no test coverage today, so this is verified by the library semantics and the measured backoff intervals rather than by a test.
