### PR TITLE
Bump sentry-sdk to 2.68.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3825,23 +3825,25 @@ crt = ["botocore[crt] (>=1.20.29,<2.0a.0)"]
 
 [[package]]
 name = "sentry-sdk"
-version = "1.45.1"
+version = "2.68.0"
 description = "Python client for Sentry (https://sentry.io)"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 groups = ["main"]
 files = [
-    {file = "sentry_sdk-1.45.1-py2.py3-none-any.whl", hash = "sha256:608887855ccfe39032bfd03936e3a1c4f4fc99b3a4ac49ced54a4220de61c9c1"},
-    {file = "sentry_sdk-1.45.1.tar.gz", hash = "sha256:a16c997c0f4e3df63c0fc5e4207ccb1ab37900433e0f72fef88315d317829a26"},
+    {file = "sentry_sdk-2.68.0-py3-none-any.whl", hash = "sha256:538e56c2d03679d42f7c0cb5f1af73a7a510b00abc7e296c13ac49b107b713a4"},
+    {file = "sentry_sdk-2.68.0.tar.gz", hash = "sha256:648c58e9887311a03470a41539e24bdbbf64a30ca4f5336f7e3dcc87276400b3"},
 ]
 
 [package.dependencies]
 certifi = "*"
-urllib3 = {version = ">=1.26.11", markers = "python_version >= \"3.6\""}
+urllib3 = ">=1.26.11"
 
 [package.extras]
 aiohttp = ["aiohttp (>=3.5)"]
+anthropic = ["anthropic (>=0.16)"]
 arq = ["arq (>=0.23)"]
+asyncio = ["httpcore[asyncio] (==1.*)"]
 asyncpg = ["asyncpg (>=0.23)"]
 beam = ["apache-beam (>=2.12)"]
 bottle = ["bottle (>=0.12.13)"]
@@ -3853,14 +3855,26 @@ django = ["django (>=1.8)"]
 falcon = ["falcon (>=1.4)"]
 fastapi = ["fastapi (>=0.79.0)"]
 flask = ["blinker (>=1.1)", "flask (>=0.11)", "markupsafe"]
-grpcio = ["grpcio (>=1.21.1)"]
+google-genai = ["google-genai (>=1.29.0)"]
+grpcio = ["grpcio (>=1.21.1)", "protobuf (>=3.8.0)"]
+http2 = ["httpcore[http2] (==1.*)"]
 httpx = ["httpx (>=0.16.0)"]
 huey = ["huey (>=2)"]
+huggingface-hub = ["huggingface_hub (>=0.22)"]
+langchain = ["langchain (>=0.0.210)"]
+langgraph = ["langgraph (>=0.6.6)"]
+launchdarkly = ["launchdarkly-server-sdk (>=9.8.0)"]
+litellm = ["litellm (>=1.77.5,!=1.82.7,!=1.82.8)"]
+litestar = ["litestar (>=2.0.0)"]
 loguru = ["loguru (>=0.5)"]
+mcp = ["mcp (>=1.15.0)"]
 openai = ["openai (>=1.0.0)", "tiktoken (>=0.3.0)"]
+openfeature = ["openfeature-sdk (>=0.7.1)"]
 opentelemetry = ["opentelemetry-distro (>=0.35b0)"]
-opentelemetry-experimental = ["opentelemetry-distro (>=0.40b0,<1.0)", "opentelemetry-instrumentation-aiohttp-client (>=0.40b0,<1.0)", "opentelemetry-instrumentation-django (>=0.40b0,<1.0)", "opentelemetry-instrumentation-fastapi (>=0.40b0,<1.0)", "opentelemetry-instrumentation-flask (>=0.40b0,<1.0)", "opentelemetry-instrumentation-requests (>=0.40b0,<1.0)", "opentelemetry-instrumentation-sqlite3 (>=0.40b0,<1.0)", "opentelemetry-instrumentation-urllib (>=0.40b0,<1.0)"]
-pure-eval = ["asttokens", "executing", "pure-eval"]
+opentelemetry-experimental = ["opentelemetry-distro"]
+opentelemetry-otlp = ["opentelemetry-distro[otlp] (>=0.35b0)"]
+pure-eval = ["asttokens", "executing", "pure_eval"]
+pydantic-ai = ["pydantic-ai (>=1.0.0)"]
 pymongo = ["pymongo (>=3.1)"]
 pyspark = ["pyspark (>=2.4.4)"]
 quart = ["blinker (>=1.1)", "quart (>=0.16.1)"]
@@ -3869,7 +3883,9 @@ sanic = ["sanic (>=0.8)"]
 sqlalchemy = ["sqlalchemy (>=1.2)"]
 starlette = ["starlette (>=0.19.1)"]
 starlite = ["starlite (>=1.48)"]
-tornado = ["tornado (>=5)"]
+statsig = ["statsig (>=0.55.3)"]
+tornado = ["tornado (>=6)"]
+unleash = ["UnleashClient (>=6.0.1)"]
 
 [[package]]
 name = "service-identity"
@@ -4783,4 +4799,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "2eceec17475b3a20c27bf50986eb6fe00650bd4f983adbcac7260b3fe3a432b1"
+content-hash = "f86c169a369871742a5c3cbf4106331786c778e777cec9b406b0dea8021971ce"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ django-push-notifications = "3.0.0"
 # Logging/errors
 structlog = "21.5.0"
 structlog-sentry = "1.4.0"
-sentry-sdk = "1.45.1"
+sentry-sdk = "2.68.0"
 #
 # channels
 channels = { version = "4.3.2", extras = ["daphne"] }


### PR DESCRIPTION
Only `sentry-sdk` changes: `1.45.1 -> 2.68.0`. Nothing else moves in the lock.

### The 2.0 removals are not used here

`Hub`, `configure_scope`, `push_scope`, `with_locals`, `request_bodies` — zero real usages. (A grep for `Hub` returns three hits, all of them the string `"Enter a valid GitHub username."`.)

The entire API surface is:

```
settings/production.py   sentry_sdk.init(...)
users/views/oidc.py      capture_message  x4
                         capture_exception(error=e)  x2
```

### Verified on 2.68.0, not inferred

- `capture_exception(error=...)` still accepts that keyword — it sits inside an `except` block, so a rename would have failed silently
- `capture_message(msg, level)` still takes level positionally
- Driving the **exact production `init()`** through a stub transport produced events with the correct tags:

```
level=fatal  release=test-release  environment=test
level=error  release=test-release  environment=test
```

- `structlog-sentry 1.4.0` imports and runs against the 2.x SDK, so **#3571 is not a prerequisite** (it is also closed — 2.1.0 predates sentry-sdk 2.0; 2.2.1 is the version that pairs with it)

`1241 tests, OK (skipped=10)`, flake8 and black clean.

### What still needs a human on staging

That events reach the **real** Sentry project. The above proves the tags are attached; it cannot prove the DSN, project routing and ingestion still work end to end. Suggested: deploy to staging, trigger a deliberate error, confirm it lands with the right release, then production.

Also worth a glance at event volume afterwards: 2.x enables tracing plumbing in the integrations by default, and `send_default_pii=True` is already set.

### Pre-existing, not caused by this

`structlog.processors.format_exc_info` runs before `SentryJsonProcessor` in `lego/settings/logging.py:88-93` and consumes `exc_info`, so structlog-originated events reach Sentry with the traceback flattened into a string. Reproduces identically on 1.45.1. Separate fix.
