### PR TITLE
Fix missing commas in reserved name lists

### DIFF
--- a/lego/apps/users/tests/test_users_api.py
+++ b/lego/apps/users/tests/test_users_api.py
@@ -190,6 +190,17 @@ class CreateUsersAPITestCase(BaseAPITestCase):
         response = self.client.post(_get_registration_token_url(token), invalid_data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_with_reserved_username(self):
+        for username in ["register", "secure", "users", "weblog"]:
+            with self.subTest(username=username):
+                token = self.create_token(f"reserved_{username}@test.com")
+                invalid_data = self._test_registration_data.copy()
+                invalid_data["username"] = username
+                response = self.client.post(
+                    _get_registration_token_url(token), invalid_data
+                )
+                self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_with_email_as_username(self):
         token = self.create_token(self.new_email_other)
         invalid_data = self._test_registration_data.copy()

--- a/lego/apps/websockets/constants.py
+++ b/lego/apps/websockets/constants.py
@@ -2,7 +2,7 @@ WS_STATUS_CONNECTED = "CONNECTED"
 WS_STATUS_CLOSED = "CLOSED"
 WS_STATUS_ERROR = "ERROR"
 
-WS_GROUP_TYPES = ["global" "user", "event", "comment"]
+WS_GROUP_TYPES = ["global", "user", "event", "comment"]
 
 WS_GROUP_JOIN_BEGIN = "Websockets.GROUP_JOIN.BEGIN"
 WS_GROUP_JOIN_SUCCESS = "Websockets.GROUP_JOIN.SUCCESS"

--- a/lego/utils/validators.py
+++ b/lego/utils/validators.py
@@ -106,7 +106,8 @@ OTHER_SENSITIVE_NAMES = [
     "pricing",
     "privacy",
     "profile",
-    "register" "secure",
+    "register",
+    "secure",
     "signup",
     "ssl",
     "status",
@@ -114,7 +115,8 @@ OTHER_SENSITIVE_NAMES = [
     "terms",
     "tos",
     "user",
-    "users" "weblog",
+    "users",
+    "weblog",
     "work",
 ]
 


### PR DESCRIPTION
## Description

Implicit string concatenation merged four entries into two, so register, secure, users and weblog were never actually reserved usernames.


# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

Resolves #4241 
