### PR TITLE
Fix a fresh clone not being able to run, and shorten setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,12 @@ ci_settings:
 	echo "from .test import *" > lego/settings/local.py
 
 fixme:
-	docker run --rm -v "${PWD}:/code" -it abakus/lego-testbase:python3.11 "bash" "-c" "cd /code && pip install -q uv==0.11.6 && uv run --frozen --only-group lint ruff check --fix lego && uv run --frozen --only-group lint ruff format lego"
+	uv run --only-group lint ruff check --fix lego
+	uv run --only-group lint ruff format lego
 
+# UV_PROJECT_ENVIRONMENT keeps the container venv out of the bind mount, so it
+# cannot overwrite the host .venv with a linux one.
 devenv:
-	docker run --net=host --rm -v "${PWD}:/code" -it abakus/lego-testbase:python3.11 "bash" "-c" "cd /code && pip install -q uv==0.11.6 && uv sync --frozen --all-groups && exec bash"
+	docker run --net=host --rm -v "${PWD}:/code" -e UV_PROJECT_ENVIRONMENT=/tmp/venv -it abakus/lego-testbase:python3.11 "bash" "-c" "cd /code && pip install -q uv==0.11.6 && uv sync --frozen --all-groups && exec bash"
 
 .PHONY: help docs ci_settings fixme devenv

--- a/README.md
+++ b/README.md
@@ -19,18 +19,17 @@ LEGO requires `python3.11`, `docker` and `uv`. Services like Postgres, Redis, Th
 ```bash
 $ git clone git@github.com:webkom/lego.git && cd lego/
 $ echo "from .development import *" > lego/settings/local.py
-$ uv sync
-$ source .venv/bin/activate
 $ docker compose up -d
-$ python manage.py initialize_development
+$ uv run python manage.py initialize_development
 ```
 
-### Activate and run (every time)
+`uv run` creates `.venv` on first use and re-syncs it against `uv.lock`, so there is nothing to install up front and nothing to activate.
+
+### Run (every time)
 
 ```bash
-$ source .venv/bin/activate
 $ docker compose up -d
-$ python manage.py runserver
+$ uv run python manage.py runserver
 ```
 
 #### Notes
@@ -38,12 +37,11 @@ $ python manage.py runserver
 ```bash
 # Note 1: Whenever you switch branches you might need to make minor changes
 
-$ uv sync # If the branch has changes in the dependencies
-$ python manage.py migrate # If the branch has a database in another state than yours
+$ uv run python manage.py migrate # If the branch has a database in another state than yours
 
 # Note 2: When you make changes to models, or constants used by models, you need to create new migrations
 
-$ python manage.py makemigrations # Creates one or more new files that must be commited
+$ uv run python manage.py makemigrations # Creates one or more new files that must be commited
 
 # Remember to format generated migrations! (using e.g. `make fixme`)
 ```
@@ -144,6 +142,15 @@ $ apt-get install libpq-dev python3-dev
 ```
 
 > For MACOS you need to `brew install postgresql`
+
+Exporting a survey as PDF needs `pango`, which `weasyprint` loads at runtime. On
+MACOS install it with `brew install pango`. If it still fails to load, uv has
+picked a python whose dylib path does not include homebrew's; rebuild the venv
+against homebrew's interpreter:
+
+```bash
+$ rm -rf .venv && uv sync --python "$(brew --prefix)/bin/python3.11"
+```
 
 If you get ld: library not found for -lssl
 

--- a/lego/apps/surveys/tests/test_surveys_api.py
+++ b/lego/apps/surveys/tests/test_surveys_api.py
@@ -1,9 +1,24 @@
+from unittest import skipIf
+
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
 from lego.apps.surveys.models import Survey
 from lego.apps.users.models import AbakusGroup, User
+
+
+def _weasyprint_available():
+    """weasyprint loads pango through cffi, so importing it fails without it."""
+    try:
+        import weasyprint  # noqa: F401
+    except (ImportError, OSError):
+        return False
+    return True
+
+
+WEASYPRINT = _weasyprint_available()
+SKIP_REASON = "weasyprint could not load pango. Install it to run this test."
 
 
 def _get_list_url():
@@ -462,6 +477,7 @@ class SurveyViewSetTestCase(APITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    @skipIf(not WEASYPRINT, SKIP_REASON)
     def test_survey_export_admin_pdf(self):
         """Test that admins can export a survey as pdf"""
         self.client.force_authenticate(user=self.admin_user)
@@ -487,6 +503,7 @@ class SurveyViewSetTestCase(APITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    @skipIf(not WEASYPRINT, SKIP_REASON)
     def test_survey_export_admin_pdf_larger_survey(self):
         """Test that admins can export a survey as pdf"""
         self.client.force_authenticate(user=self.admin_user)

--- a/lego/apps/surveys/views.py
+++ b/lego/apps/surveys/views.py
@@ -10,8 +10,6 @@ from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from weasyprint import HTML
-
 from lego.apps.permissions.api.permissions import LegoPermissions
 from lego.apps.permissions.api.views import AllowedPermissionsMixin
 from lego.apps.permissions.constants import EDIT
@@ -121,6 +119,10 @@ class SurveyViewSet(AllowedPermissionsMixin, viewsets.ModelViewSet):
         html_string = render_to_string(
             "surveys/pdf/survey_report_template.html", context
         )
+
+        # Imported here so that loading the URLconf does not require pango,
+        # which weasyprint links at import time.
+        from weasyprint import HTML
 
         pdf = HTML(string=html_string).write_pdf()
 

--- a/lego/settings/development.py
+++ b/lego/settings/development.py
@@ -47,7 +47,7 @@ CACHES = {
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 INTERNAL_IPS = ["127.0.0.1"]
-INSTALLED_APPS += ["coverage", "debug_toolbar"]
+INSTALLED_APPS += ["debug_toolbar"]
 MIDDLEWARE += ["debug_toolbar.middleware.DebugToolbarMiddleware"]
 DEBUG_TOOLBAR_PANELS = [
     "debug_toolbar.panels.history.HistoryPanel",


### PR DESCRIPTION
# Description

A fresh clone could not be set up by following the README. Two bugs, one of them mine, plus the simplification uv allows.

- **`manage.py` failed outright.** `development.py` listed `coverage` in `INSTALLED_APPS`, but coverage lives in its own dependency group and `uv sync` does not install it. Poetry installed every non-optional group, so this only surfaced after the uv migration. It is not a django app anyway, and was added in 2022 for a tox problem that no longer exists.

- **Django would not boot on macOS.** `weasyprint` links pango at import time, and the import sat at module level in a views file the URLconf loads, so every `manage.py` invocation needed pango present. It is used in exactly one place, so the import moves there. Pango is now needed to export a survey PDF and nothing else.

- **`make fixme` destroyed the developer's venv**, 145 packages down to 1 with an interpreter macOS cannot execute. It ran uv inside a container with the repo bind mounted, so uv rebuilt `/code/.venv`. The pre-uv version avoided this with `mktemp`; my rewrite in #4243 dropped that. ruff is a static binary pinned by the lock, so `fixme` now runs on the host, 15s down to 0.2s. `devenv` had the same bug and keeps the container with `UV_PROJECT_ENVIRONMENT` outside the mount.

- **The two PDF tests skip when pango is missing**, the way the stripe tests skip without an API key.

`uv run` creates `.venv` and re-syncs it against the lock, so setup drops from six commands to four and the daily loop from three to two.

# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

Walked the documented setup on throwaway checkouts with no `.venv` and no `local.py`, across the three cases a contributor can land in: homebrew python, another python such as anaconda, and no system 3.11 at all where uv downloads its own. All three boot.

Suite green both ways: with pango 1267 tests, OK (skipped=10), and the PDF tests genuinely run; without it 1267, OK (skipped=12). CI has pango, so coverage of the endpoint is unchanged.
