### PR TITLE
Declare pango in the image instead of inheriting it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,14 @@ ENV RELEASE=${RELEASE}
 # PYTHONPATH alone is enough to run the app.
 ENV UV_PROJECT_ENVIRONMENT=/usr/local
 
+# weasyprint loads pango at runtime to render the survey PDF. python:3.11
+# happens to ship it, but nothing here asked for it, so a slimmer base would
+# drop it and PDF export would start failing in production with a green build.
+RUN set -e \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends libpango-1.0-0 libpangoft2-1.0-0 \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN mkdir /app
 COPY pyproject.toml /app/pyproject.toml
 COPY uv.lock /app/uv.lock
@@ -38,7 +46,9 @@ WORKDIR /app
 COPY --from=ghcr.io/astral-sh/uv:0.11.6 /uv /usr/local/bin/uv
 
 RUN set -e \
-    && uv sync --frozen --no-default-groups --group docs --group prod
+    && uv sync --frozen --no-default-groups --group docs --group prod \
+    # Fail the build, rather than a request in production, if pango goes missing.
+    && python -c "import weasyprint"
 
 COPY . /app/
 


### PR DESCRIPTION
# Description

`weasyprint` loads pango at runtime to render the survey PDF, but nothing in the Dockerfile asks for it. It is only present because `python:3.11` is buildpack-deps based and happens to ship it.

That means the app works by luck. Switching to `python:3.11-slim`, an obvious optimization on a 3.25GB image, drops pango: the build stays green, the app still boots, and PDF export starts failing in production. CI would not catch it either, since the pdf tests run in the testbase image rather than this one.

So install it explicitly, and assert the import at build time. If pango ever goes missing the build fails instead of a request.

# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

Image builds and `import weasyprint` succeeds inside it, resolving from `/usr/local` as expected given `UV_PROJECT_ENVIRONMENT`. Size is unchanged at 3.25GB, since the packages were already there by inheritance.

The two packages were verified as sufficient by building `python:3.11-slim` with only them plus weasyprint: it imported and rendered a real PDF, in a 414MB image. That is not proposed here, but it means moving to a slim base is now a viable follow-up rather than a silent breakage.

This does not affect local development. Running the pdf tests still needs pango installed locally; #4262 makes them skip when it is absent.
