### PR TITLE
Fix registration reminders skipping pools that open later

### DIFF
--- a/lego/apps/followers/tasks.py
+++ b/lego/apps/followers/tasks.py
@@ -16,22 +16,27 @@ log = get_logger()
 def send_registration_reminder_mail(self, logger_context=None):
     self.setup_logger(logger_context)
 
-    pools = Pool.objects.filter(
-        activation_date__gt=timezone.now(),
-        activation_date__lte=timezone.now() + timedelta(minutes=60),
-    ).prefetch_related("event", "event__followers", "event__followers__follower")
+    pools = (
+        Pool.objects.filter(
+            activation_date__gt=timezone.now(),
+            activation_date__lte=timezone.now() + timedelta(minutes=60),
+        )
+        .order_by("activation_date")
+        .prefetch_related("event", "event__followers", "event__followers__follower")
+    )
 
     for pool in pools:
+        pool_group_ids = set(pool.permission_groups.values_list("id", flat=True))
         for followsevent in pool.event.followers.all():
+            if followsevent.notification_sent:
+                continue
+
             user = followsevent.follower
-            if (
-                pool.permission_groups.filter(
-                    id__in=[group.id for group in user.all_groups]
-                ).exists()
-                and not pool.event.registrations.filter(user=user).exists()
-                and not followsevent.notification_sent
-            ):
-                notification = RegistrationReminderNotification(user, event=pool.event)
-                notification.notify()
+            if pool_group_ids.isdisjoint(group.id for group in user.all_groups):
+                continue
+            if pool.event.registrations.filter(user=user).exists():
+                continue
+
+            RegistrationReminderNotification(user, event=pool.event).notify()
             followsevent.notification_sent = True
             followsevent.save()

--- a/lego/apps/followers/tests/test_reminder_tasks.py
+++ b/lego/apps/followers/tests/test_reminder_tasks.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 from django.utils import timezone
 
-from lego.apps.events.models import Pool, Registration
+from lego.apps.events.models import Event, Pool, Registration
 from lego.apps.events.tests.utils import get_dummy_users
 from lego.apps.followers.models import FollowEvent
 from lego.apps.followers.notifications import RegistrationReminderNotification
@@ -25,12 +25,24 @@ class RegistrationReminderTestCase(BaseTestCase):
         Pool.objects.all().update(
             activation_date=timezone.now() + timedelta(hours=2), name="Webkom"
         )
-        self.recipient = get_dummy_users(1)[0]
+        self.recipient, self.bedkom_member, self.outsider = get_dummy_users(3)
         AbakusGroup.objects.get(name="Webkom").add_user(self.recipient)
+        AbakusGroup.objects.get(name="Bedkom").add_user(self.bedkom_member)
         self.pool = Pool.objects.first()
         self.notifier = RegistrationReminderNotification(
             self.recipient, event=self.pool.event
         )
+
+    def create_staggered_event(self):
+        """
+        An event whose two pools belong to disjoint groups, as when registration
+        opens at different times for different classes.
+        """
+        event = Event.objects.get(title="POOLS_NO_REGISTRATIONS")
+        webkom_pool, bedkom_pool = event.pools.order_by("id")
+        webkom_pool.permission_groups.set([AbakusGroup.objects.get(name="Webkom")])
+        bedkom_pool.permission_groups.set([AbakusGroup.objects.get(name="Bedkom")])
+        return event, webkom_pool, bedkom_pool
 
     def test_follows_registration_under_one_hour(self, mock_notification):
         current_time = timezone.now()
@@ -108,3 +120,68 @@ class RegistrationReminderTestCase(BaseTestCase):
         )
         send_registration_reminder_mail.delay()
         mock_notification.assert_not_called()
+
+    def test_follower_of_later_pool_is_reminded_when_their_own_pool_opens(
+        self, mock_notification
+    ):
+        """
+        A follower without access to the pool opening first must stay unmarked,
+        so they are still reminded when the pool they can join opens.
+        """
+        event, webkom_pool, bedkom_pool = self.create_staggered_event()
+        webkom_pool.activation_date = timezone.now() + timedelta(minutes=45)
+        webkom_pool.save()
+        webkom_follow = FollowEvent.objects.create(
+            follower=self.recipient, target=event
+        )
+        bedkom_follow = FollowEvent.objects.create(
+            follower=self.bedkom_member, target=event
+        )
+
+        send_registration_reminder_mail.delay()
+
+        self.assertEqual(mock_notification.call_count, 1)
+        webkom_follow.refresh_from_db()
+        bedkom_follow.refresh_from_db()
+        self.assertTrue(webkom_follow.notification_sent)
+        self.assertFalse(bedkom_follow.notification_sent)
+
+        bedkom_pool.activation_date = timezone.now() + timedelta(minutes=45)
+        bedkom_pool.save()
+
+        send_registration_reminder_mail.delay()
+
+        self.assertEqual(mock_notification.call_count, 2)
+        bedkom_follow.refresh_from_db()
+        self.assertTrue(bedkom_follow.notification_sent)
+
+    def test_reminds_followers_of_every_pool_opening_in_the_same_window(
+        self, mock_notification
+    ):
+        event, _, _ = self.create_staggered_event()
+        event.pools.all().update(activation_date=timezone.now() + timedelta(minutes=45))
+        webkom_follow = FollowEvent.objects.create(
+            follower=self.recipient, target=event
+        )
+        bedkom_follow = FollowEvent.objects.create(
+            follower=self.bedkom_member, target=event
+        )
+
+        send_registration_reminder_mail.delay()
+
+        self.assertEqual(mock_notification.call_count, 2)
+        webkom_follow.refresh_from_db()
+        bedkom_follow.refresh_from_db()
+        self.assertTrue(webkom_follow.notification_sent)
+        self.assertTrue(bedkom_follow.notification_sent)
+
+    def test_follower_without_access_to_any_pool_is_not_marked(self, mock_notification):
+        event, _, _ = self.create_staggered_event()
+        event.pools.all().update(activation_date=timezone.now() + timedelta(minutes=45))
+        follow = FollowEvent.objects.create(follower=self.outsider, target=event)
+
+        send_registration_reminder_mail.delay()
+
+        mock_notification.assert_not_called()
+        follow.refresh_from_db()
+        self.assertFalse(follow.notification_sent)


### PR DESCRIPTION
## Description

`send_registration_reminder_mail` marked every follower of an event as notified, regardless of whether they had access to the pool that triggered the reminder. Since `notification_sent` is never reset, that consumed the flag for followers who could not join yet.

The flag is now set only when a reminder is actually sent. Pools are processed by activation date so the reminder matches the follower's earliest opening, and the pool's permission groups are fetched once per pool instead of once per follower.

# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

Resolves #4264 
