### PR TITLE
Oauth user scope autocomplete

### DIFF
--- a/lego/apps/oauth/authentication.py
+++ b/lego/apps/oauth/authentication.py
@@ -3,6 +3,13 @@ from structlog import get_logger
 
 log = get_logger()
 
+USER_SCOPE_PATHS = frozenset(
+    {
+        "/api/v1/users/oauth2_userdata/",
+        "/api/v1/search-autocomplete/",
+    }
+)
+
 
 class Authentication(OAuth2Authentication):
     """
@@ -20,10 +27,14 @@ class Authentication(OAuth2Authentication):
         if token.allow_scopes(["all"]):
             return authentication
 
-        # Temporary only allow requests to the oauth2_userdata endpoint
-        if (
-            token.allow_scopes(["user"])
-            and request.path == "/api/v1/users/oauth2_userdata/"
-        ):
+        # Paths a `user`-scoped token may reach. Everything else requires `all`.
+        #
+        # search-autocomplete is read-only and already AllowAny for session
+        # users, and every hit is filtered through `has_permission` before it is
+        # returned, so a token here sees no more than the person holding it
+        # would see in the web UI. It is allowlisted so applications like
+        # admissions can let a signed-in member look someone up by name without
+        # holding an `all`-scoped credential of their own.
+        if token.allow_scopes(["user"]) and request.path in USER_SCOPE_PATHS:
             return authentication
         return None

--- a/lego/apps/oauth/authentication.py
+++ b/lego/apps/oauth/authentication.py
@@ -27,14 +27,10 @@ class Authentication(OAuth2Authentication):
         if token.allow_scopes(["all"]):
             return authentication
 
-        # Paths a `user`-scoped token may reach. Everything else requires `all`.
+        # Paths accessible to 'user' scoped tokens. All other endpoints require 'all'
         #
-        # search-autocomplete is read-only and already AllowAny for session
-        # users, and every hit is filtered through `has_permission` before it is
-        # returned, so a token here sees no more than the person holding it
-        # would see in the web UI. It is allowlisted so applications like
-        # admissions can let a signed-in member look someone up by name without
-        # holding an `all`-scoped credential of their own.
+        # Is needed to allow client applications (like admissions) to search users without
+        # holding 'all' access
         if token.allow_scopes(["user"]) and request.path in USER_SCOPE_PATHS:
             return authentication
         return None

--- a/lego/apps/oauth/fixtures/development_applications.yaml
+++ b/lego/apps/oauth/fixtures/development_applications.yaml
@@ -15,7 +15,10 @@
   fields:
     client_id: sC6GkHr8GS2OSRpFzKL2aASnz2eTPLYqK8TAGihF
     user: 3
-    redirect_uris: http://127.0.0.1:5000/complete/lego/
+    redirect_uris: |-
+      http://127.0.0.1:5000/complete/lego/
+      http://127.0.0.1:5002/complete/lego/
+      http://localhost:5002/complete/lego/
     client_type: public
     authorization_grant_type: authorization-code
     client_secret: fBySp20wgSEcxGmFFHB8BHEqjGu0oU0e1QmDyQ7bU8GZLFsa3GIPAbXyYlbOxnwslZLKGEQJr96i9u50bL4Iq1wWQrmDPoUc8P7nJHAENbrw1l5HblOgDkoKvxPKHnk2

--- a/lego/apps/oauth/tests/test_authentication.py
+++ b/lego/apps/oauth/tests/test_authentication.py
@@ -1,0 +1,58 @@
+from django.utils import timezone
+from rest_framework import status
+
+from datetime import timedelta
+
+from oauth2_provider.models import AccessToken
+
+from lego.apps.oauth.models import APIApplication
+from lego.apps.users.models import User
+from lego.utils.test_utils import BaseAPITestCase
+
+
+class UserScopeAuthenticationTestCase(BaseAPITestCase):
+    """A `user`-scoped token reaches an explicit allowlist and nothing else."""
+
+    fixtures = ["test_users.yaml", "test_applications.yaml"]
+
+    def setUp(self):
+        self.user = User.objects.get(id=1)
+        self.application = APIApplication.objects.first()
+
+    def _token(self, scope):
+        token = AccessToken.objects.create(
+            application=self.application,
+            user=self.user,
+            token=f"token-{scope.replace(' ', '-')}",
+            scope=scope,
+            expires=timezone.now() + timedelta(days=1),
+        )
+        return f"Bearer {token.token}"
+
+    def test_user_scope_reaches_autocomplete(self):
+        """Applications such as admissions let a signed-in member look someone
+        up by name; without this they would have to hold an `all` token."""
+        response = self.client.post(
+            "/api/v1/search-autocomplete/",
+            {"query": "test", "types": ["users.user"]},
+            HTTP_AUTHORIZATION=self._token("user"),
+        )
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+
+    def test_user_scope_is_still_refused_elsewhere(self):
+        """The allowlist must stay an allowlist."""
+        response = self.client.get(
+            "/api/v1/users/",
+            HTTP_AUTHORIZATION=self._token("user"),
+        )
+
+        self.assertEqual(status.HTTP_401_UNAUTHORIZED, response.status_code)
+
+    def test_all_scope_is_unaffected(self):
+        response = self.client.get(
+            "/api/v1/users/",
+            HTTP_AUTHORIZATION=self._token("all"),
+        )
+
+        self.assertNotEqual(status.HTTP_401_UNAUTHORIZED, response.status_code)

--- a/lego/apps/oauth/tests/test_authentication.py
+++ b/lego/apps/oauth/tests/test_authentication.py
@@ -1,7 +1,7 @@
+from datetime import timedelta
+
 from django.utils import timezone
 from rest_framework import status
-
-from datetime import timedelta
 
 from oauth2_provider.models import AccessToken
 


### PR DESCRIPTION
Removed need for an all-scoped token just to look up members by name. Because all-scoped tokens grant full API access, this created an unnecessary security risk for a simple search.

Added an explicit allowlist and adding /api/v1/search-autocomplete/ to it. Since this endpoint is read-only, uses existing session permissions, and filters results through has_permission, token access remains strictly aligned with what the user can already see in the web UI.



https://github.com/user-attachments/assets/9a9effd7-ff49-4464-8b28-e624032371a0



# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

Resolves #4267 
