### PR TITLE
fix: restrict comments to authenticated users

### DIFF
--- a/lego/apps/articles/serializers.py
+++ b/lego/apps/articles/serializers.py
@@ -50,10 +50,12 @@ class DetailedArticleSerializer(TagSerializerMixin, BasisModelSerializer):
             "youtube_url",
         )
 
+
 class AuthDetailedArticleSerializer(
     ObjectPermissionsSerializerMixin, DetailedArticleSerializer
 ):
     comments = CommentSerializer(read_only=True, many=True)
+
     class Meta:
         model = Article
         fields = (

--- a/lego/apps/articles/serializers.py
+++ b/lego/apps/articles/serializers.py
@@ -16,7 +16,6 @@ from lego.utils.serializers import (
 
 
 class DetailedArticleSerializer(TagSerializerMixin, BasisModelSerializer):
-    comments = CommentSerializer(read_only=True, many=True)
     cover = ImageField(required=False, options={"height": 500})
     cover_placeholder = ImageField(
         source="cover", required=False, options={"height": 50, "filters": ["blur(20)"]}
@@ -42,7 +41,6 @@ class DetailedArticleSerializer(TagSerializerMixin, BasisModelSerializer):
             "cover_placeholder",
             "authors",
             "description",
-            "comments",
             "content_target",
             "tags",
             "content",
@@ -52,15 +50,16 @@ class DetailedArticleSerializer(TagSerializerMixin, BasisModelSerializer):
             "youtube_url",
         )
 
-
-class DetailedArticleAdminSerializer(
+class AuthDetailedArticleSerializer(
     ObjectPermissionsSerializerMixin, DetailedArticleSerializer
 ):
+    comments = CommentSerializer(read_only=True, many=True)
     class Meta:
         model = Article
         fields = (
             DetailedArticleSerializer.Meta.fields
             + ObjectPermissionsSerializerMixin.Meta.fields
+            + ("comments",)
         )
 
 

--- a/lego/apps/articles/views.py
+++ b/lego/apps/articles/views.py
@@ -9,7 +9,7 @@ from rest_framework.viewsets import ModelViewSet
 from lego.apps.articles.filters import ArticleFilterSet
 from lego.apps.articles.models import Article
 from lego.apps.articles.serializers import (
-    DetailedArticleAdminSerializer,
+    AuthDetailedArticleSerializer,
     DetailedArticleSerializer,
     PublicArticleSerializer,
 )
@@ -27,18 +27,17 @@ class ArticlesViewSet(AllowedPermissionsMixin, ModelViewSet):
     def get_queryset(self):
         queryset = self.queryset.select_related("created_by").prefetch_related("tags")
 
-        if self.action == "list":
-            return queryset
-
-        return queryset.prefetch_related(
-            "comments", "comments__created_by", *OBJECT_PERMISSIONS_FIELDS
-        )
+        if self.request and self.request.user.is_authenticated:
+            return queryset.prefetch_related(
+                "comments", "comments__created_by", *OBJECT_PERMISSIONS_FIELDS
+            )
+        return queryset
 
     def get_serializer_class(self):
         if self.action == "list":
             return PublicArticleSerializer
         if self.request and self.request.user.is_authenticated:
-            return DetailedArticleAdminSerializer
+            return AuthDetailedArticleSerializer
 
         return super().get_serializer_class()
 

--- a/lego/apps/events/serializers/events.py
+++ b/lego/apps/events/serializers/events.py
@@ -132,7 +132,6 @@ class EventReadSerializer(
 class EventReadDetailedSerializer(
     TagSerializerMixin, BasisModelSerializer, ObjectPermissionsSerializerMixin
 ):
-    comments = CommentSerializer(read_only=True, many=True)
     content_target = CharField(read_only=True)
     cover = ImageField(required=False, options={"height": 500})
     cover_placeholder = ImageField(
@@ -161,7 +160,6 @@ class EventReadDetailedSerializer(
             "event_type",
             "event_status_type",
             "location",
-            "comments",
             "content_target",
             "start_time",
             "end_time",
@@ -300,6 +298,7 @@ class EventReadUserDetailedSerializer(EventReadDetailedSerializer):
 
 
 class EventReadAuthUserDetailedSerializer(EventReadUserDetailedSerializer):
+    comments = CommentSerializer(read_only=True, many=True)
     pools = PoolReadAuthSerializer(many=True)
     waiting_registrations = RegistrationReadSerializer(many=True)
     unanswered_surveys = serializers.SerializerMethodField()
@@ -313,6 +312,7 @@ class EventReadAuthUserDetailedSerializer(EventReadUserDetailedSerializer):
 
     class Meta(EventReadUserDetailedSerializer.Meta):
         fields = EventReadUserDetailedSerializer.Meta.fields + (  # type: ignore
+            "comments",
             "created_by",
             "responsible_users",
             "waiting_registrations",

--- a/lego/apps/events/tests/test_events_api.py
+++ b/lego/apps/events/tests/test_events_api.py
@@ -306,6 +306,7 @@ class ListEventsTestCase(BaseAPITestCase):
 class RetrieveEventsTestCase(BaseAPITestCase):
     fixtures = [
         "test_abakus_groups.yaml",
+        "test_comments.yaml",
         "test_companies.yaml",
         "test_users.yaml",
         "test_events.yaml",
@@ -335,6 +336,15 @@ class RetrieveEventsTestCase(BaseAPITestCase):
         event_response = self.client.get(_get_detail_url(1))
         for pool in event_response.json()["pools"]:
             self.assertIsNone(pool.get("registrations", None))
+
+    def test_unauth_cant_see_comments(self):
+        event_response = self.client.get(_get_detail_url(4))
+        self.assertNotIn("comments", event_response.json())
+
+    def test_auth_can_see_comments(self):
+        self.client.force_authenticate(self.abakus_user)
+        event_response = self.client.get(_get_detail_url(4))
+        self.assertIn("comments", event_response.json())
 
     def test_abakus_see_registrations(self):
         """Tests that a user that is allowed to register for the event can see the registrations"""

--- a/lego/apps/gallery/serializers.py
+++ b/lego/apps/gallery/serializers.py
@@ -81,8 +81,10 @@ class GalleryPictureSerializer(serializers.ModelSerializer):
         gallery = Gallery.objects.get(pk=self.context["view"].kwargs["gallery_pk"])
         return {"gallery": gallery, **attrs}
 
+
 class AuthGalleryPictureSerializer(GalleryPictureSerializer):
     comments = CommentSerializer(read_only=True, many=True)
+
     class Meta:
         model = GalleryPicture
         fields = GalleryPictureSerializer.Meta.fields + ("comments",)

--- a/lego/apps/gallery/serializers.py
+++ b/lego/apps/gallery/serializers.py
@@ -59,7 +59,6 @@ class GalleryPictureSerializer(serializers.ModelSerializer):
         options={"height": 200, "width": 300, "smart": True},
     )
     raw_file = FileField(source="file", read_only=True)
-    comments = CommentSerializer(read_only=True, many=True)
     content_target = CharField(read_only=True)
     taggees = PublicUserField(many=True, queryset=User.objects.all(), required=False)
 
@@ -74,7 +73,6 @@ class GalleryPictureSerializer(serializers.ModelSerializer):
             "file",
             "thumbnail",
             "raw_file",
-            "comments",
             "content_target",
         )
         read_only_fields = ("raw_file", "thumbnail", "gallery")
@@ -82,6 +80,12 @@ class GalleryPictureSerializer(serializers.ModelSerializer):
     def validate(self, attrs):
         gallery = Gallery.objects.get(pk=self.context["view"].kwargs["gallery_pk"])
         return {"gallery": gallery, **attrs}
+
+class AuthGalleryPictureSerializer(GalleryPictureSerializer):
+    comments = CommentSerializer(read_only=True, many=True)
+    class Meta:
+        model = GalleryPicture
+        fields = GalleryPictureSerializer.Meta.fields + ("comments",)
 
 
 class GallerySerializer(BasisModelSerializer):

--- a/lego/apps/gallery/views.py
+++ b/lego/apps/gallery/views.py
@@ -15,6 +15,7 @@ from .serializers import (
     GalleryListSerializer,
     GalleryMetadataSerializer,
     GalleryPictureSerializer,
+    AuthGalleryPictureSerializer,
     GallerySerializer,
 )
 
@@ -71,7 +72,7 @@ class GalleryPictureViewSet(viewsets.ModelViewSet):
     queryset = (
         GalleryPicture.objects.all()
         .select_related("file")
-        .prefetch_related("comments", "taggees")
+        .prefetch_related("taggees")
     )
     serializer_class = GalleryPictureSerializer
     pagination_class = GalleryPicturePagination
@@ -82,4 +83,14 @@ class GalleryPictureViewSet(viewsets.ModelViewSet):
         if gallery_id:
             return queryset.filter(gallery_id=gallery_id)
 
+        if self.request and self.request.user.is_authenticated:
+            return queryset.prefetch_related("comments")
+
         return GalleryPicture.objects.none()
+
+    def get_serializer_class(self):
+        if self.action in ["retrieve"]:
+            if self.request and self.request.user.is_authenticated:
+                return AuthGalleryPictureSerializer
+
+        return super().get_serializer_class()

--- a/lego/apps/gallery/views.py
+++ b/lego/apps/gallery/views.py
@@ -11,11 +11,11 @@ from lego.apps.permissions.constants import OBJECT_PERMISSIONS_FIELDS
 
 from .models import Gallery, GalleryPicture
 from .serializers import (
+    AuthGalleryPictureSerializer,
     GalleryAdminSerializer,
     GalleryListSerializer,
     GalleryMetadataSerializer,
     GalleryPictureSerializer,
-    AuthGalleryPictureSerializer,
     GallerySerializer,
 )
 
@@ -70,9 +70,7 @@ class GalleryPictureViewSet(viewsets.ModelViewSet):
     """
 
     queryset = (
-        GalleryPicture.objects.all()
-        .select_related("file")
-        .prefetch_related("taggees")
+        GalleryPicture.objects.all().select_related("file").prefetch_related("taggees")
     )
     serializer_class = GalleryPictureSerializer
     pagination_class = GalleryPicturePagination

--- a/lego/apps/polls/serializers.py
+++ b/lego/apps/polls/serializers.py
@@ -27,9 +27,6 @@ class OptionUpdateSerializer(OptionSerializer):
 
 
 class PollSerializer(BasisModelSerializer):
-    comments = CommentSerializer(read_only=True, many=True)
-    content_target = CharField(read_only=True)
-
     options = HiddenResultsOptionSerializer(many=True)
     total_votes = IntegerField(read_only=True)
 
@@ -51,17 +48,12 @@ class PollSerializer(BasisModelSerializer):
             "results_hidden",
             "total_votes",
             "tags",
-            "comments",
-            "content_target",
             "has_answered",
             "pinned",
         )
 
 
 class DetailedPollSerializer(TagSerializerMixin, BasisModelSerializer):
-    comments = CommentSerializer(read_only=True, many=True)
-    content_target = CharField(read_only=True)
-
     options = OptionSerializer(many=True)
     total_votes = IntegerField(read_only=True)
 
@@ -82,8 +74,6 @@ class DetailedPollSerializer(TagSerializerMixin, BasisModelSerializer):
             "options",
             "results_hidden",
             "total_votes",
-            "comments",
-            "content_target",
             "tags",
             "has_answered",
             "pinned",

--- a/lego/apps/polls/serializers.py
+++ b/lego/apps/polls/serializers.py
@@ -2,9 +2,8 @@ from typing import Iterator
 
 from django.db import transaction
 from rest_framework import serializers
-from rest_framework.fields import CharField, IntegerField
+from rest_framework.fields import IntegerField
 
-from lego.apps.comments.serializers.comments import CommentSerializer
 from lego.apps.polls.models import Option, Poll
 from lego.apps.tags.serializers import TagSerializerMixin
 from lego.utils.serializers import BasisModelSerializer


### PR DESCRIPTION
# Description

Mainly removes comments from publicly available serializers and move them to ones requiring authentication.

For the polls, as far as I could see the comments have been unused, hence why simply removing it, however it could maybe be a cool feature to add? Reactions too?

# Testing
- [X] The code quality is at a minimum required level of quality, readability, and performance.
- [X] I have thoroughly tested my changes.

Resolves #4135 
