### PR TITLE
Fix: Improve app notifications

### DIFF
--- a/lego/apps/events/notifications.py
+++ b/lego/apps/events/notifications.py
@@ -38,6 +38,7 @@ class EventBumpNotification(Notification):
             context={"event": event.title},
             title="Flyttet opp fra venteliste",
             instance=event,
+            data={"screen": "/authed/events/[id]", "params": {"id": str(event.id)}},
         )
 
 
@@ -127,6 +128,7 @@ class EventAdminRegistrationNotification(Notification):
             context={"event": event.title},
             title="Adminpåmeldt til arrangement",
             instance=event,
+            data={"screen": "/authed/events/[id]", "params": {"id": str(event.id)}}
         )
 
 
@@ -161,4 +163,5 @@ class EventAdminUnregistrationNotification(Notification):
             context={"event": event.title},
             title="Fjernet fra arrangement",
             instance=event,
+            data={"screen": "/authed/events/[id]", "params": {"id": str(event.id)}}
         )

--- a/lego/apps/events/notifications.py
+++ b/lego/apps/events/notifications.py
@@ -128,7 +128,7 @@ class EventAdminRegistrationNotification(Notification):
             context={"event": event.title},
             title="Adminpåmeldt til arrangement",
             instance=event,
-            data={"screen": "/authed/events/[id]", "params": {"id": str(event.id)}}
+            data={"screen": "/authed/events/[id]", "params": {"id": str(event.id)}},
         )
 
 
@@ -163,5 +163,5 @@ class EventAdminUnregistrationNotification(Notification):
             context={"event": event.title},
             title="Fjernet fra arrangement",
             instance=event,
-            data={"screen": "/authed/events/[id]", "params": {"id": str(event.id)}}
+            data={"screen": "/authed/events/[id]", "params": {"id": str(event.id)}},
         )

--- a/lego/apps/followers/notifications.py
+++ b/lego/apps/followers/notifications.py
@@ -28,4 +28,5 @@ class RegistrationReminderNotification(Notification):
             context={"event": event.title},
             title="Påmelding til arrangement",
             instance=event,
+            data={"screen": "/authed/events/[id]", "params": {"id": str(event.id)}}
         )

--- a/lego/apps/followers/notifications.py
+++ b/lego/apps/followers/notifications.py
@@ -28,5 +28,5 @@ class RegistrationReminderNotification(Notification):
             context={"event": event.title},
             title="Påmelding til arrangement",
             instance=event,
-            data={"screen": "/authed/events/[id]", "params": {"id": str(event.id)}}
+            data={"screen": "/authed/events/[id]", "params": {"id": str(event.id)}},
         )

--- a/lego/apps/notifications/notification.py
+++ b/lego/apps/notifications/notification.py
@@ -41,7 +41,7 @@ class Notification:
         """
         return send_email.delay(*args, **kwargs)
 
-    def _delay_push(self, template, context, title, instance=None):
+    def _delay_push(self, template, context, title, instance=None, data=None):
         """
         Helper for push messages. Does the work in a celery task.
         """
@@ -55,6 +55,7 @@ class Notification:
             title=title,
             template=template,
             context=context,
+            data=data
         )
 
     def generate_mail(self):

--- a/lego/apps/notifications/notification.py
+++ b/lego/apps/notifications/notification.py
@@ -55,7 +55,7 @@ class Notification:
             title=title,
             template=template,
             context=context,
-            data=data
+            data=data,
         )
 
     def generate_mail(self):

--- a/lego/apps/notifications/views.py
+++ b/lego/apps/notifications/views.py
@@ -99,6 +99,7 @@ class GCMDeviceViewSet(GCMDeviceAuthorizedViewSet):
 
 class ExpoDeviceViewSet(viewsets.ViewSet):
     permission_classes = [IsAuthenticated]
+    serializer_class = ExpoDeviceSerializer
 
     def create(self, request):
         serializer = ExpoDeviceSerializer(data=request.data)

--- a/lego/utils/push.py
+++ b/lego/utils/push.py
@@ -10,12 +10,13 @@ log = get_logger()
 
 
 class PushMessage:
-    def __init__(self, user, template, context, title, target=None):
+    def __init__(self, user, template, context, title, target=None, data=None):
         self.user = user
         self.template = template
         self.context = context
         self.target = target
         self.title = title
+        self.data = data
 
     def _get_unread_count(self):
         feed = NotificationFeed
@@ -38,7 +39,7 @@ class PushMessage:
 
         expo_device = ExpoDevice.objects.filter(user=self.user, is_active=True).first()
         if expo_device:
-            expo_device.messages.send(title=self.title, body=message)
+            expo_device.messages.send(title=self.title, body=message, data=self.data)
 
         log.info(
             "send_push",

--- a/lego/utils/tasks.py
+++ b/lego/utils/tasks.py
@@ -59,7 +59,7 @@ def send_email(self, logger_context=None, **kwargs):
 
 
 @celery_app.task(bind=True, max_retries=5, base=AbakusTask)
-def send_push(self, user, title, target=None, logger_context=None, **kwargs):
+def send_push(self, user, title, target=None, data=None, logger_context=None, **kwargs):
     """
     Generic task to send push messages.
     """
@@ -69,6 +69,7 @@ def send_push(self, user, title, target=None, logger_context=None, **kwargs):
     kwargs["user"] = recipient
     kwargs["target"] = target
     kwargs["title"] = title
+    kwargs["data"] = data
 
     message = PushMessage(**kwargs)
 

--- a/lego/utils/tasks.py
+++ b/lego/utils/tasks.py
@@ -65,7 +65,7 @@ def send_email(self, logger_context=None, **kwargs):
 
 
 @celery_app.task(bind=True, max_retries=5, base=AbakusTask)
-def send_push(self, user, title, target=None, logger_context=None, **kwargs):
+def send_push(self, user, title, target=None, data=None, logger_context=None, **kwargs):
     """
     Generic task to send push messages.
     """
@@ -75,6 +75,7 @@ def send_push(self, user, title, target=None, logger_context=None, **kwargs):
     kwargs["user"] = recipient
     kwargs["target"] = target
     kwargs["title"] = title
+    kwargs["data"] = data
 
     message = PushMessage(**kwargs)
 


### PR DESCRIPTION
# Description
- Add serializer_class to ExpoDeviceViewSet to fix OpenAPI Schema generation on `abakus-app`.
- Ship data with the push notification so that when an user clicks on the notification, they will be sent to the specific page.

This is not fixed for every push notifications yet. Only for events.


# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

Resolves #4278 