### PR TITLE
Fix pool counter drift on bump paths

### DIFF
--- a/lego/apps/events/exceptions.py
+++ b/lego/apps/events/exceptions.py
@@ -78,11 +78,37 @@ class EventNotReady(ValueError):
 
 
 class PoolCounterNotEqualToRegistrationCount(ValueError):
-    def __init__(self, pool, registration_count, event):
+    MAX_POOLS_IN_MESSAGE = 10
+
+    def __init__(self, mismatches):
+        """
+        :param mismatches: list of (pool_id, event_id, counter, registration_count)
+        """
+        # Celery and pickle rebuild exceptions as cls(*args), and args hold the message.
+        if isinstance(mismatches, str):
+            self.mismatches = []
+            super().__init__(mismatches)
+            return
+
+        self.mismatches = mismatches
+        details = [
+            f"Pool {pool_id} for event {event_id} was supposed to have "
+            f"{counter} registrations, but has {registration_count}"
+            for pool_id, event_id, counter, registration_count in mismatches
+        ]
+
+        if len(details) == 1:
+            super().__init__(f"{details[0]}!")
+            return
+
+        listed = details[: self.MAX_POOLS_IN_MESSAGE]
+        remaining = len(details) - len(listed)
         message = (
-            f"Pool {pool.id} for event {event.id} was supposed to have "
-            f"{pool.counter} registrations, but has {registration_count}!"
+            f"{len(details)} pools have a counter that does not match their "
+            f"registration count: " + "; ".join(listed)
         )
+        if remaining:
+            message += f"; and {remaining} more"
         super().__init__(message)
 
 

--- a/lego/apps/events/exceptions.py
+++ b/lego/apps/events/exceptions.py
@@ -78,8 +78,6 @@ class EventNotReady(ValueError):
 
 
 class PoolCounterNotEqualToRegistrationCount(ValueError):
-    MAX_POOLS_IN_MESSAGE = 10
-
     def __init__(self, mismatches):
         """
         :param mismatches: list of (pool_id, event_id, counter, registration_count)
@@ -101,15 +99,10 @@ class PoolCounterNotEqualToRegistrationCount(ValueError):
             super().__init__(f"{details[0]}!")
             return
 
-        listed = details[: self.MAX_POOLS_IN_MESSAGE]
-        remaining = len(details) - len(listed)
-        message = (
+        super().__init__(
             f"{len(details)} pools have a counter that does not match their "
-            f"registration count: " + "; ".join(listed)
+            f"registration count: " + "; ".join(details)
         )
-        if remaining:
-            message += f"; and {remaining} more"
-        super().__init__(message)
 
 
 class WebhookDidNotFindRegistration(ValueError):

--- a/lego/apps/events/migrations/0048_resync_pool_counters.py
+++ b/lego/apps/events/migrations/0048_resync_pool_counters.py
@@ -1,0 +1,39 @@
+from django.db import migrations
+from django.db.models import Count, IntegerField, OuterRef, Subquery
+from django.db.models.functions import Coalesce
+
+
+def resync_pool_counters(apps, _):
+    """
+    Repair counters left drifted by the bump paths, which used to move registrations
+    into a pool without adjusting `Pool.counter`. Soft-deleted registrations are
+    excluded to match `pool.registrations`.
+    """
+    pool = apps.get_model("events", "Pool")
+    registration = apps.get_model("events", "Registration")
+
+    actual_count = (
+        registration.objects.filter(pool=OuterRef("pk"), deleted=False)
+        .order_by()
+        .values("pool")
+        .annotate(count=Count("pk"))
+        .values("count")
+    )
+
+    pool.objects.update(
+        counter=Coalesce(
+            Subquery(actual_count, output_field=IntegerField()),
+            0,
+            output_field=IntegerField(),
+        )
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("events", "0047_alter_event_event_type"),
+    ]
+
+    operations = [
+        migrations.RunPython(resync_pool_counters, migrations.RunPython.noop),
+    ]

--- a/lego/apps/events/models.py
+++ b/lego/apps/events/models.py
@@ -6,7 +6,7 @@ from typing import Any, Optional
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models, transaction
-from django.db.models import CharField, Count, ManyToManyField, QuerySet, Sum
+from django.db.models import CharField, Count, F, ManyToManyField, QuerySet, Sum
 from django.utils import timezone
 
 from lego.apps.action_handlers.events import handle_event
@@ -463,15 +463,16 @@ class Event(Content, BasisModel, ObjectPermissionsModel):
                     new_pool: Optional[Pool] = None
                     if to_pool:
                         new_pool = to_pool
-                        new_pool.increment()
                     else:
                         for pool in self.pools.select_for_update().all():
                             if self.can_register(first_waiting.user, pool):
                                 new_pool = pool
-                                new_pool.increment()
                                 break
-                    first_waiting.pool = new_pool
-                    first_waiting.save(update_fields=["pool"])
+                    if new_pool:
+                        first_waiting.move_to_pool(new_pool)
+                    else:
+                        first_waiting.pool = None
+                        first_waiting.save(update_fields=["pool"])
                     handle_event(first_waiting, "bump")
 
     def early_bump(self, opening_pool: Pool) -> None:
@@ -488,8 +489,7 @@ class Event(Content, BasisModel, ObjectPermissionsModel):
             if self.heed_penalties and reg.user.number_of_penalties() >= 3:
                 continue
             if self.can_register(reg.user, opening_pool, future=True):
-                reg.pool = opening_pool
-                reg.save()
+                reg.move_to_pool(opening_pool)
                 handle_event(reg, "bump")
         self.check_for_bump_or_rebalance(opening_pool)
 
@@ -510,8 +510,7 @@ class Event(Content, BasisModel, ObjectPermissionsModel):
                 if self.heed_penalties and reg.user.number_of_penalties() >= 3:
                     continue
                 if self.can_register(reg.user, pool, future=True):
-                    reg.pool = pool
-                    reg.save()
+                    reg.move_to_pool(pool)
                     handle_event(reg, "bump")
             self.check_for_bump_or_rebalance(pool)
 
@@ -556,8 +555,7 @@ class Event(Content, BasisModel, ObjectPermissionsModel):
                 if group in user_groups:
                     moveable = True
             if moveable:
-                old_registration.pool = to_pool
-                old_registration.save()
+                old_registration.move_to_pool(to_pool)
                 self.bump(to_pool=from_pool)
                 bumped = True
         return bumped
@@ -841,13 +839,19 @@ class Pool(BasisModel):
         return self.registrations.count()
 
     def increment(self) -> Pool:
-        self.counter += 1
-        self.save(update_fields=["counter"])
-        return self
+        return self._adjust_counter(1)
 
     def decrement(self) -> Pool:
-        self.counter -= 1
-        self.save(update_fields=["counter"])
+        return self._adjust_counter(-1)
+
+    def _adjust_counter(self, delta: int) -> Pool:
+        """
+        Adjust relative to the stored value, since callers often hold a Pool loaded
+        before other registrations were processed. `all_objects` so the write reaches
+        soft-deleted rows too, matching the unfiltered `refresh_from_db`.
+        """
+        Pool.all_objects.filter(pk=self.pk).update(counter=F("counter") + delta)
+        self.refresh_from_db(fields=["counter"])
         return self
 
     def permission_group_ids(self) -> set[int]:
@@ -1021,6 +1025,27 @@ class Registration(BasisModel):
             status=constants.SUCCESS_REGISTER,
             **kwargs,
         )
+
+    def move_to_pool(self, to_pool: Pool) -> Registration:
+        """
+        Move a registration into `to_pool`, keeping both pool counters in sync.
+        Every path that changes a registration's pool must go through here, or
+        `Pool.counter` drifts away from the real registration count.
+
+        :param to_pool: The pool the registration is moved into.
+        :return: The registration (in `to_pool`)
+        """
+        from_pool = self.pool
+        if from_pool == to_pool:
+            return self
+
+        with transaction.atomic():
+            if from_pool:
+                from_pool.decrement()
+            to_pool.increment()
+            self.pool = to_pool
+            self.save(update_fields=["pool"])
+        return self
 
     def add_to_waiting_list(self, **kwargs: Any) -> Registration:
         return self.set_values(

--- a/lego/apps/events/tasks.py
+++ b/lego/apps/events/tasks.py
@@ -610,6 +610,7 @@ def check_that_pool_counters_match_registration_number(self, logger_context=None
         Q(merge_time__gte=timezone.now()) | Q(merge_time__isnull=True),
     ).values_list("id", flat=True)
 
+    mismatches = []
     for event_id in events_ids:
         with transaction.atomic():
             locked_event = Event.objects.select_for_update().get(pk=event_id)
@@ -617,7 +618,17 @@ def check_that_pool_counters_match_registration_number(self, logger_context=None
             for pool in locked_pools:
                 registration_count = pool.registrations.count()
                 if pool.counter != registration_count:
-                    log.critical("pool_counter_not_equal_registration_count", pool=pool)
-                    raise PoolCounterNotEqualToRegistrationCount(
-                        pool, registration_count, locked_event
+                    log.critical(
+                        "pool_counter_not_equal_registration_count",
+                        pool_id=pool.id,
+                        pool_name=pool.name,
+                        event_id=locked_event.id,
+                        counter=pool.counter,
+                        registration_count=registration_count,
                     )
+                    mismatches.append(
+                        (pool.id, locked_event.id, pool.counter, registration_count)
+                    )
+
+    if mismatches:
+        raise PoolCounterNotEqualToRegistrationCount(mismatches)

--- a/lego/apps/events/tests/test_async_tasks.py
+++ b/lego/apps/events/tests/test_async_tasks.py
@@ -294,6 +294,24 @@ class PoolActivationTestCase(BaseAPITestCase):
         self.assertEqual(self.pool_two.registrations.count(), 0)
         self.assertEqual(self.event.waiting_registrations.count(), 1)
 
+    def test_pool_counter_is_updated_when_users_are_early_bumped(self):
+        """Early bumping into an activating pool must keep the pool counter in sync."""
+        users = get_dummy_users(3)
+
+        for user in users:
+            AbakusGroup.objects.get(name="Webkom").add_user(user)
+            registration = Registration.objects.get_or_create(
+                event=self.event, user=user
+            )[0]
+            self.event.register(registration)
+
+        bump_waiting_users_to_new_pool()
+
+        self.pool_two.refresh_from_db()
+        self.assertEqual(self.pool_two.registrations.count(), 2)
+        self.assertEqual(self.pool_two.counter, 2)
+        check_that_pool_counters_match_registration_number()
+
     def test_ensure_pool_counters_raise_error_when_incorrect(self):
         """Test that counter raises error due to incorrect counter"""
 
@@ -309,6 +327,31 @@ class PoolActivationTestCase(BaseAPITestCase):
 
         with self.assertRaises(PoolCounterNotEqualToRegistrationCount):
             check_that_pool_counters_match_registration_number()
+
+    def test_pool_counter_check_collects_every_mismatch(self):
+        """Test that a drifted pool does not hide drift in the pools checked after it"""
+
+        users = get_dummy_users(4)
+        for user in users:
+            AbakusGroup.objects.get(name="Webkom").add_user(user)
+
+        for user in users[:3]:
+            Registration.objects.get_or_create(
+                event=self.event, user=user, pool=self.pool_one
+            )
+        Registration.objects.get_or_create(
+            event=self.event, user=users[3], pool=self.pool_two
+        )
+
+        with self.assertRaises(PoolCounterNotEqualToRegistrationCount) as raised:
+            check_that_pool_counters_match_registration_number()
+
+        drifted_pool_ids = {
+            pool_id
+            for pool_id, event_id, _, _ in raised.exception.mismatches
+            if event_id == self.event.id
+        }
+        self.assertEqual(drifted_pool_ids, {self.pool_one.id, self.pool_two.id})
 
     def test_ensure_pool_counters_match_registration_number(self):
         """Test that method does not raise error when counter is ok"""

--- a/lego/apps/events/tests/test_registrations.py
+++ b/lego/apps/events/tests/test_registrations.py
@@ -817,6 +817,55 @@ class RegistrationTestCase(BaseTestCase):
         self.assertEqual(abakus_pool.registrations.count(), 1)
         self.assertEqual(webkom_pool.registrations.count(), 2)
 
+    def test_rebalance_pool_keeps_pool_counters_in_sync(self):
+        """Rebalancing moves a registration between pools and must keep both counters in sync"""
+        event = Event.objects.get(title="POOLS_NO_REGISTRATIONS")
+        abakus_pool = event.pools.get(name="Abakusmember")
+        webkom_pool = event.pools.get(name="Webkom")
+        users = get_dummy_users(4)
+        abakus_user = users[0]
+        webkom_users = users[1:]
+        AbakusGroup.objects.get(name="Abakus").add_user(abakus_user)
+        for user in webkom_users:
+            AbakusGroup.objects.get(name="Webkom").add_user(user)
+
+        for user in [abakus_user] + list(webkom_users):
+            registration = Registration.objects.get_or_create(event=event, user=user)[0]
+            event.register(registration)
+
+        registration_to_unregister = Registration.objects.get(
+            event=event, user=webkom_users[0]
+        )
+        event.unregister(registration_to_unregister)
+
+        self.assertTrue(event.rebalance_pool(abakus_pool, webkom_pool))
+
+        for pool in [abakus_pool, webkom_pool]:
+            pool.refresh_from_db()
+            self.assertEqual(pool.counter, pool.registrations.count())
+
+    def test_bump_on_pool_creation_keeps_pool_counter_in_sync(self):
+        """Bumping waiting registrations into a new pool must keep the pool counter in sync"""
+        event = Event.objects.get(title="POOLS_NO_REGISTRATIONS")
+        users = get_dummy_users(6)
+        for user in users:
+            AbakusGroup.objects.get(name="Abakus").add_user(user)
+            registration = Registration.objects.get_or_create(event=event, user=user)[0]
+            event.register(registration)
+
+        new_pool = Pool.objects.create(
+            name="test",
+            capacity=3,
+            event=event,
+            activation_date=(timezone.now() - timedelta(hours=24)),
+        )
+        new_pool.permission_groups.set([AbakusGroup.objects.get(name="Abakus")])
+        event.bump_on_pool_creation_or_expansion()
+
+        new_pool.refresh_from_db()
+        self.assertEqual(new_pool.registrations.count(), 3)
+        self.assertEqual(new_pool.counter, 3)
+
     def test_rebalance_pool_method_should_not_overflow(self):
         """Test rebalancing method by moving registered user's pool to fit waiting list user"""
         event = Event.objects.get(title="POOLS_NO_REGISTRATIONS")


### PR DESCRIPTION
## Problem

`Pool.counter` is what `add_to_pool` admits on, but three of the six paths that move a registration into a pool never updated it: `early_bump`, `bump_on_pool_creation_or_expansion` and `rebalance_pool`.
Counters drifted below the real registration count, so full pools kept admitting past capacity and the nightly checker failed.
`increment()`/`decrement()` also did a read-modify-write on the in-memory instance, so a caller holding a stale `Pool` wrote back a wrong absolute value.

## Fix

- `Registration.move_to_pool()` is now the single place that changes a registration's pool, adjusting both counters in one transaction. `bump`, `early_bump`, `bump_on_pool_creation_or_expansion` and `rebalance_pool` go through it, so no call site has to remember the pairing.
- `Pool.increment()`/`decrement()` use an `F()` expression, correct regardless of staleness or concurrency.
- Migration `0048` recomputes every counter from the registrations that exist, repairing rows written before this fix.
- The checker collects all mismatches instead of raising on the first, and logs `pool_id`, `event_id`, `counter` and `registration_count` as structured fields. It previously logged only the pool name.

Follow-ups: merged single-pool events still skip the decrement on unregister, so seats sit empty; `rebalance_pool` reports `bumped` when nobody was bumped; `check_for_bump_on_pool_creation_or_expansion` takes no lock; and longer term `Pool.counter` should go away entirely.


# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

Resolves #4287 