### PR TITLE
Properly leave ws groups

### DIFF
--- a/lego/apps/websockets/consumers.py
+++ b/lego/apps/websockets/consumers.py
@@ -57,7 +57,9 @@ class GroupConsumer(JsonWebsocketConsumer):
             if group in self.user_groups:
                 AsyncToSync(self.channel_layer.group_discard)(group, self.channel_name)
                 self.user_groups.remove(group)
-                self.send_message(constants.WS_GROUP_LEAVE_SUCCESS)
+                self.send_message(
+                    constants.WS_GROUP_LEAVE_SUCCESS, payload={"group": group}
+                )
 
     def send_message(self, type: str, payload=None, meta=None):
         """


### PR DESCRIPTION


Makes it possible for client to know which group it left to keep matching state and avoid errors


