### PR TITLE
Remove the pool.counter

### DIFF
--- a/lego/apps/events/exceptions.py
+++ b/lego/apps/events/exceptions.py
@@ -77,15 +77,6 @@ class EventNotReady(ValueError):
     pass
 
 
-class PoolCounterNotEqualToRegistrationCount(ValueError):
-    def __init__(self, pool, registration_count, event):
-        message = (
-            f"Pool {pool.id} for event {event.id} was supposed to have "
-            f"{pool.counter} registrations, but has {registration_count}!"
-        )
-        super().__init__(message)
-
-
 class WebhookDidNotFindRegistration(ValueError):
     def __init__(self, event_id, metadata):
         message = (

--- a/lego/apps/events/fixtures/test_events.yaml
+++ b/lego/apps/events/fixtures/test_events.yaml
@@ -205,7 +205,6 @@
     name: Abakusmember
     capacity: 2
     event: 1
-    counter: 2
     activation_date: "2011-09-01T13:20:30+03:00"
     permission_groups:
       - - Abakus
@@ -256,7 +255,6 @@
     name: Abakusmember
     capacity: 3
     event: 5
-    counter: 3
     activation_date: "2011-09-01T13:20:30+03:00"
     permission_groups:
       - - Abakus
@@ -267,7 +265,6 @@
     name: Abakusmember
     capacity: 0
     event: 9
-    counter: 0
     activation_date: "2011-09-01T13:20:30+03:00"
     permission_groups:
       - - Abakus
@@ -278,7 +275,6 @@
     name: Abakusmember
     capacity: 2
     event: 10
-    counter: 1
     activation_date: "2019-09-01T13:20:30+03:00"
     permission_groups:
       - - Abakus
@@ -289,7 +285,6 @@
     name: Abakusmember
     capacity: 1
     event: 13
-    counter: 1
     activation_date: "2019-09-01T13:20:30+03:00"
     permission_groups:
       - - Abakus

--- a/lego/apps/events/fixtures/test_multiple_events.yaml
+++ b/lego/apps/events/fixtures/test_multiple_events.yaml
@@ -768,7 +768,6 @@
     name: Abakusmember
     capacity: 0
     event: 55
-    counter: 0
     activation_date: "2011-09-01T13:20:30+03:00"
     permission_groups:
       - - Abakus

--- a/lego/apps/events/migrations/0048_remove_pool_counter.py
+++ b/lego/apps/events/migrations/0048_remove_pool_counter.py
@@ -1,0 +1,14 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("events", "0047_alter_event_event_type"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="pool",
+            name="counter",
+        ),
+    ]

--- a/lego/apps/events/models.py
+++ b/lego/apps/events/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta
-from typing import Any, Optional
+from typing import Any, Iterator, Optional
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -117,16 +117,7 @@ class Event(Content, BasisModel, ObjectPermissionsModel):
         return self.title
 
     def save(self, *args: Any, **kwargs: Any) -> None:
-        """
-        By re-setting the pool counters on save, we can ensure that counters are updated if an
-        event that has been merged gets un-merged. We want to avoid having to increment counters
-        when registering after merge_time for performance reasons
-        """
-        with transaction.atomic():
-            super().save(*args, **kwargs)
-            for pool in self.pools.select_for_update().all():
-                pool.counter = pool.registrations.count()
-                pool.save(update_fields=["counter"])
+        super().save(*args, **kwargs)
 
         if self.pinned:
             for pinned_item in Event.objects.filter(pinned=True).exclude(pk=self.pk):
@@ -176,9 +167,6 @@ class Event(Content, BasisModel, ObjectPermissionsModel):
                 raise RegistrationExists()
 
             if pool:
-                locked_pool = Pool.objects.select_for_update().get(pk=pool.id)
-                locked_pool.increment()
-
                 registration.add_direct_to_pool(
                     pool,
                     feedback=feedback,
@@ -444,9 +432,8 @@ class Event(Content, BasisModel, ObjectPermissionsModel):
             if self.is_merged:
                 self.bump()
             elif not open_pool.is_full:
-                for registration in self.waiting_registrations:
-                    if open_pool in self.get_possible_pools(registration.user):
-                        return self.bump(to_pool=open_pool)
+                if next(self.get_eligible_waiting_registrations(pool=open_pool), None):
+                    return self.bump(to_pool=open_pool)
                 self.try_to_rebalance(open_pool=open_pool)
 
     def bump(self, to_pool: Optional[Pool] = None) -> None:
@@ -463,15 +450,12 @@ class Event(Content, BasisModel, ObjectPermissionsModel):
                     new_pool: Optional[Pool] = None
                     if to_pool:
                         new_pool = to_pool
-                        new_pool.increment()
                     else:
                         for pool in self.pools.select_for_update().all():
                             if self.can_register(first_waiting.user, pool):
                                 new_pool = pool
-                                new_pool.increment()
                                 break
-                    first_waiting.pool = new_pool
-                    first_waiting.save(update_fields=["pool"])
+                    first_waiting.move_to_pool(new_pool)
                     handle_event(first_waiting, "bump")
 
     def early_bump(self, opening_pool: Pool) -> None:
@@ -482,15 +466,13 @@ class Event(Content, BasisModel, ObjectPermissionsModel):
 
         :param opening_pool: The pool about to be activated.
         """
-        for reg in self.waiting_registrations:
+        for reg in self.get_eligible_waiting_registrations(
+            pool=opening_pool, future=True
+        ):
             if opening_pool.is_full:
                 break
-            if self.heed_penalties and reg.user.number_of_penalties() >= 3:
-                continue
-            if self.can_register(reg.user, opening_pool, future=True):
-                reg.pool = opening_pool
-                reg.save()
-                handle_event(reg, "bump")
+            reg.move_to_pool(opening_pool)
+            handle_event(reg, "bump")
         self.check_for_bump_or_rebalance(opening_pool)
 
     def bump_on_pool_creation_or_expansion(self) -> None:
@@ -502,17 +484,15 @@ class Event(Content, BasisModel, ObjectPermissionsModel):
         This method does the same as `early_bump`, but only accepts people that can be bumped now,
         not people that can be bumped in the future.
         """
-        open_pools: list[Pool] = [pool for pool in self.pools.all() if not pool.is_full]
+        open_pools: list[Pool] = [
+            pool for pool in self.pools.select_for_update().all() if not pool.is_full
+        ]
         for pool in open_pools:
-            for reg in self.waiting_registrations:
+            for reg in self.get_eligible_waiting_registrations(pool=pool, future=True):
                 if self.is_full or pool.is_full:
                     break
-                if self.heed_penalties and reg.user.number_of_penalties() >= 3:
-                    continue
-                if self.can_register(reg.user, pool, future=True):
-                    reg.pool = pool
-                    reg.save()
-                    handle_event(reg, "bump")
+                reg.move_to_pool(pool)
+                handle_event(reg, "bump")
             self.check_for_bump_or_rebalance(pool)
 
     def try_to_rebalance(self, open_pool: Pool) -> None:
@@ -556,8 +536,7 @@ class Event(Content, BasisModel, ObjectPermissionsModel):
                 if group in user_groups:
                     moveable = True
             if moveable:
-                old_registration.pool = to_pool
-                old_registration.save()
+                old_registration.move_to_pool(to_pool)
                 self.bump(to_pool=from_pool)
                 bumped = True
         return bumped
@@ -579,42 +558,55 @@ class Event(Content, BasisModel, ObjectPermissionsModel):
             },
         )[0]
 
+    def get_eligible_waiting_registrations(
+        self,
+        pool: Optional[Pool] = None,
+        future: bool = False,
+    ) -> Iterator[Registration]:
+        """
+        Yields waiting_registrations, in order, eligible to be admitted to
+        `pool` (or, if None, eligible in general -- the merged-event case,
+        where the caller checks permission per-pool afterward).
+
+        :param pool: Restrict to users with permission for this pool. If
+                      None, permission is not checked here.
+        :param future: Passed through to can_register -- True skips the
+                        pool's activation_date check (early_bump and
+                        bump_on_pool_creation_or_expansion admit ahead of
+                        the normal activation moment).
+        """
+        now = timezone.now()
+        for registration in self.waiting_registrations:
+            if self.heed_penalties:
+                penalties = registration.user.number_of_penalties()
+                if penalties >= 3:
+                    continue
+                # With a pool given, can_register() below covers activation timing;
+                # without one (merged case), only this check does.
+                if penalties > 0 or pool is None:
+                    earliest_reg = self.get_earliest_registration_time(
+                        registration.user, [pool] if pool else None, penalties
+                    )
+                    if not earliest_reg or earliest_reg >= now:
+                        continue
+            if pool is not None and not self.can_register(
+                registration.user, pool, future=future
+            ):
+                continue
+            yield registration
+
     def pop_from_waiting_list(
         self, to_pool: Optional[Pool] = None
     ) -> Registration | None:
         """
-        Pops the first user in the waiting list that can join `to_pool`.
-        If `from_pool=None`, pops the first user in the waiting list overall.
+        Pops the first user in the waiting list eligible for `to_pool`.
+        If `to_pool=None`, pops the first eligible user overall (post-merge
+        -- the caller checks permission per-pool afterward).
 
         :param to_pool: The pool we are bumping to. If post-merge, there is no pool.
         :return: The registration that is first in line for said pool.
         """
-
-        if to_pool:
-            for registration in self.waiting_registrations:
-                if self.heed_penalties:
-                    penalties: int = registration.user.number_of_penalties()
-                    earliest_reg: Optional[date] = self.get_earliest_registration_time(
-                        registration.user, [to_pool], penalties
-                    )
-                    if penalties < 3 and earliest_reg and earliest_reg < timezone.now():
-                        if self.can_register(registration.user, to_pool):
-                            return registration
-                elif self.can_register(registration.user, to_pool):
-                    return registration
-            return None
-
-        if self.heed_penalties:
-            for registration in self.waiting_registrations:
-                penalties = registration.user.number_of_penalties()
-                earliest_reg = self.get_earliest_registration_time(
-                    registration.user, None, penalties
-                )
-                if penalties < 3 and earliest_reg and earliest_reg < timezone.now():
-                    return registration
-            return None
-
-        return self.waiting_registrations.first()
+        return next(self.get_eligible_waiting_registrations(pool=to_pool), None)
 
     @staticmethod
     def has_pool_permission(user: User, pool: Pool) -> bool:
@@ -812,8 +804,6 @@ class Pool(BasisModel):
     activation_date = models.DateTimeField()
     permission_groups = models.ManyToManyField(AbakusGroup)
 
-    counter = models.PositiveSmallIntegerField(default=0)
-
     class Meta:
         ordering = ["id"]
 
@@ -839,16 +829,6 @@ class Pool(BasisModel):
     @property
     def registration_count(self) -> int:
         return self.registrations.count()
-
-    def increment(self) -> Pool:
-        self.counter += 1
-        self.save(update_fields=["counter"])
-        return self
-
-    def decrement(self) -> Pool:
-        self.counter -= 1
-        self.save(update_fields=["counter"])
-        return self
 
     def permission_group_ids(self) -> set[int]:
         return set(self.permission_groups.values_list("id", flat=True))
@@ -1002,15 +982,17 @@ class Registration(BasisModel):
             self.delete_presence_penalties_for_event()
 
     def add_to_pool(self, pool: Pool) -> Registration:
-        allowed: bool = False
+        # Admission must happen inside the same locked transaction as
+        # the capacity check, or two concurrent callers can both pass it.
         with transaction.atomic():
             locked_pool: Pool = Pool.objects.select_for_update().get(pk=pool.id)
-            if locked_pool.capacity == 0 or locked_pool.counter < locked_pool.capacity:
-                locked_pool.increment()
-                allowed = True
+            allowed = locked_pool.capacity == 0 or (
+                locked_pool.registrations.count() < locked_pool.capacity
+            )
 
-        if allowed:
-            return self.add_direct_to_pool(pool)
+            if allowed:
+                return self.add_direct_to_pool(pool)
+
         return self.add_to_waiting_list()
 
     def add_direct_to_pool(self, pool: Pool, **kwargs: Any) -> Registration:
@@ -1031,6 +1013,9 @@ class Registration(BasisModel):
             **kwargs,
         )
 
+    def move_to_pool(self, pool: Optional[Pool]) -> Registration:
+        return self.set_values(pool=pool)
+
     def unregister(
         self,
         is_merged: bool = False,
@@ -1044,13 +1029,6 @@ class Registration(BasisModel):
         if followEvent is not None:
             followEvent.delete()
 
-        # We do not care about the counter if the event is merged or pool is None
-        if self.pool and not is_merged:
-            with transaction.atomic():
-                locked_pool: Pool = Pool.objects.select_for_update().get(
-                    pk=self.pool.id
-                )
-                locked_pool.decrement()
         return self.set_values(
             pool=None,
             unregistration_date=timezone.now(),

--- a/lego/apps/events/tasks.py
+++ b/lego/apps/events/tasks.py
@@ -2,7 +2,6 @@ import uuid
 from datetime import timedelta
 
 from django.db import IntegrityError, transaction
-from django.db.models import Q
 from django.utils import timezone
 
 import stripe
@@ -12,11 +11,7 @@ from structlog import get_logger
 from lego import celery_app
 from lego.apps.action_handlers.events import handle_event
 from lego.apps.events import constants
-from lego.apps.events.exceptions import (
-    EventHasClosed,
-    PoolCounterNotEqualToRegistrationCount,
-    WebhookDidNotFindRegistration,
-)
+from lego.apps.events.exceptions import EventHasClosed, WebhookDidNotFindRegistration
 from lego.apps.events.models import Event, Registration
 from lego.apps.events.notifications import EventPaymentOverdueCreatorNotification
 from lego.apps.events.serializers.registrations import (
@@ -41,19 +36,18 @@ class AsyncRegister(AbakusTask):
     registration = None
 
     def on_failure(self, *args):
-        if self.request.retries == self.max_retries:
-            with transaction.atomic():
-                registration = Registration.objects.select_for_update().get(
-                    id=self.registration.id
-                )
-                if registration.status != constants.SUCCESS_REGISTER:
-                    registration.status = constants.FAILURE_REGISTER
-                    registration.save()
-            notify_user_registration(
-                constants.SOCKET_REGISTRATION_FAILURE,
-                self.registration,
-                error_message="Registrering feilet",
+        with transaction.atomic():
+            registration = Registration.objects.select_for_update().get(
+                id=self.registration.id
             )
+            if registration.status != constants.SUCCESS_REGISTER:
+                registration.status = constants.FAILURE_REGISTER
+                registration.save()
+        notify_user_registration(
+            constants.SOCKET_REGISTRATION_FAILURE,
+            self.registration,
+            error_message="Registrering feilet",
+        )
 
 
 class Payment(AbakusTask):
@@ -142,6 +136,7 @@ def async_register(self, registration_id, logger_context=None):
             exception=e,
             registration_id=self.registration.id,
         )
+        raise
     except (ValueError, IntegrityError) as e:
         log.error(
             "registration_error", exception=e, registration_id=self.registration.id
@@ -396,11 +391,12 @@ def check_for_bump_on_pool_creation_or_expansion(
     """Task checking for bumps when event and pools are updated"""
     self.setup_logger(logger_context)
 
-    # Event is locked using the instance field "is_ready"
-    event = Event.objects.get(pk=event_id)
-    event.bump_on_pool_creation_or_expansion()
-    event.is_ready = True
-    event.save(update_fields=["is_ready"])
+    with transaction.atomic():
+        locked_event = Event.objects.select_for_update().get(pk=event_id)
+        locked_event.bump_on_pool_creation_or_expansion()
+
+    locked_event.is_ready = True
+    locked_event.save(update_fields=["is_ready"])
 
 
 @celery_app.task(serializer="json", bind=True, base=AbakusTask)
@@ -594,30 +590,3 @@ def notify_event_creator_when_payment_overdue(self, logger_context=None):
                 event_id=event.id,
                 creator=event.created_by,
             )
-
-
-@celery_app.task(serializer="json", bind=True, base=AbakusTask)
-def check_that_pool_counters_match_registration_number(self, logger_context=None):
-    """
-    Task that checks whether pools counters are in sync with number of registrations. We do not
-    enforce this check for events that are merged, hence the merge_time filter, because
-    incrementing the counter decreases the registration performance
-    """
-    self.setup_logger(logger_context)
-
-    events_ids = Event.objects.filter(
-        Q(start_time__gte=timezone.now()),
-        Q(merge_time__gte=timezone.now()) | Q(merge_time__isnull=True),
-    ).values_list("id", flat=True)
-
-    for event_id in events_ids:
-        with transaction.atomic():
-            locked_event = Event.objects.select_for_update().get(pk=event_id)
-            locked_pools = locked_event.pools.select_for_update().all()
-            for pool in locked_pools:
-                registration_count = pool.registrations.count()
-                if pool.counter != registration_count:
-                    log.critical("pool_counter_not_equal_registration_count", pool=pool)
-                    raise PoolCounterNotEqualToRegistrationCount(
-                        pool, registration_count, locked_event
-                    )

--- a/lego/apps/events/tests/test_async_tasks.py
+++ b/lego/apps/events/tests/test_async_tasks.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 import stripe
 
 from lego.apps.events import constants
-from lego.apps.events.exceptions import PoolCounterNotEqualToRegistrationCount
+from lego.apps.events.exceptions import EventHasClosed
 from lego.apps.events.models import Event, Registration
 from lego.apps.events.tasks import (
     AsyncRegister,
@@ -14,7 +14,6 @@ from lego.apps.events.tasks import (
     async_retrieve_payment,
     bump_waiting_users_to_new_pool,
     check_events_for_registrations_with_expired_penalties,
-    check_that_pool_counters_match_registration_number,
     notify_event_creator_when_payment_overdue,
     notify_user_when_payment_soon_overdue,
     set_all_events_ready_and_bump,
@@ -87,7 +86,8 @@ class AsyncRegisterTestCase(BaseAPITestCase):
         )
 
     def test_async_register_on_failure(self):
-        """"""
+        """on_failure must not clobber a registration that already
+        succeeded before some later, unrelated step failed."""
 
         user = get_dummy_users(1)[0]
         AbakusGroup.objects.get(name="Abakus").add_user(user)
@@ -98,28 +98,60 @@ class AsyncRegisterTestCase(BaseAPITestCase):
 
         async_register(registration.id)
 
-        with mock.patch("lego.utils.tasks.AbakusTask") as mocked_cls:
-            with mock.patch("celery.app.task.Task.request") as mocked_request:
-                mocked_request.return_value = mocked_request
-                mocked_request.retries = 3
+        task = AsyncRegister()
+        task.registration = registration
 
-                mocked_cls._get_request.return_value = mocked_request
-                task = AsyncRegister()
-                task.max_retries = 3
+        self.assertEqual(self.event.number_of_registrations, 1)
+        self.assertEqual(
+            self.event.registrations.first().status, constants.SUCCESS_REGISTER
+        )
 
-                task.registration = registration
+        task.on_failure()
 
-                self.assertEqual(self.event.number_of_registrations, 1)
-                self.assertEqual(
-                    self.event.registrations.first().status, constants.SUCCESS_REGISTER
-                )
+        self.assertEqual(self.event.number_of_registrations, 1)
+        self.assertEqual(
+            self.event.registrations.first().status, constants.SUCCESS_REGISTER
+        )
 
-                task.on_failure()
+    def test_async_register_on_failure_marks_failure(self):
+        """on_failure must mark FAILURE_REGISTER even on an immediate,
+        non-retried failure -- the old retries==max_retries guard's bug."""
 
-                self.assertEqual(self.event.number_of_registrations, 1)
-                self.assertEqual(
-                    self.event.registrations.first().status, constants.SUCCESS_REGISTER
-                )
+        user = get_dummy_users(1)[0]
+        AbakusGroup.objects.get(name="Abakus").add_user(user)
+
+        registration = Registration.objects.get_or_create(event=self.event, user=user)[
+            0
+        ]
+        registration.status = constants.PENDING_REGISTER
+        registration.save()
+
+        task = AsyncRegister()
+        task.registration = registration
+
+        task.on_failure()
+
+        registration.refresh_from_db()
+        self.assertEqual(registration.status, constants.FAILURE_REGISTER)
+
+    def test_async_register_event_has_closed_propagates(self):
+        """EventHasClosed must propagate out of async_register instead of
+        being swallowed, so on_failure (tested above) actually runs."""
+
+        self.event.start_time = timezone.now() + timedelta(minutes=1)
+        self.event.save()
+
+        user = get_dummy_users(1)[0]
+        AbakusGroup.objects.get(name="Abakus").add_user(user)
+
+        registration = Registration.objects.get_or_create(event=self.event, user=user)[
+            0
+        ]
+        registration.status = constants.PENDING_REGISTER
+        registration.save()
+
+        with self.assertRaises(EventHasClosed):
+            async_register(registration.id)
 
 
 class PoolActivationTestCase(BaseAPITestCase):
@@ -253,6 +285,35 @@ class PoolActivationTestCase(BaseAPITestCase):
         self.assertEqual(self.pool_two.registrations.count(), 0)
         self.assertEqual(self.event.waiting_registrations.count(), 1)
 
+    def test_isnt_bumped_before_penalty_delay_elapses(self):
+        """Users with 1-2 penalties must wait out the penalty registration
+        delay before being early-bumped -- previously early_bump ignored
+        this delay entirely and would bump them immediately."""
+        filler, on_time_user, penalized_user = get_dummy_users(3)
+
+        for user in (filler, on_time_user, penalized_user):
+            AbakusGroup.objects.get(name="Webkom").add_user(user)
+
+        Penalty.objects.create(
+            user=penalized_user, reason="test", weight=1, source_event=self.event
+        )
+
+        for user in (filler, on_time_user, penalized_user):
+            registration = Registration.objects.get_or_create(
+                event=self.event, user=user
+            )[0]
+            self.event.register(registration)
+
+        # `filler` takes pool_one's only slot; the other two land in the waiting list.
+        self.assertEqual(self.pool_one.registrations.count(), 1)
+        self.assertEqual(self.event.waiting_registrations.count(), 2)
+
+        bump_waiting_users_to_new_pool()
+
+        self.assertEqual(self.pool_two.registrations.count(), 1)
+        self.assertEqual(self.pool_two.registrations.first().user, on_time_user)
+        self.assertEqual(self.event.waiting_registrations.count(), 1)
+
     def test_isnt_bumped_if_activation_is_far_into_the_future(self):
         """Users should not be bumped if the pool is activated more than
         35 minutes in the future."""
@@ -293,44 +354,6 @@ class PoolActivationTestCase(BaseAPITestCase):
 
         self.assertEqual(self.pool_two.registrations.count(), 0)
         self.assertEqual(self.event.waiting_registrations.count(), 1)
-
-    def test_ensure_pool_counters_raise_error_when_incorrect(self):
-        """Test that counter raises error due to incorrect counter"""
-
-        users = get_dummy_users(3)
-
-        for user in users:
-            AbakusGroup.objects.get(name="Webkom").add_user(user)
-            Registration.objects.get_or_create(
-                event=self.event, user=user, pool=self.pool_one
-            )
-
-        self.assertGreater(self.pool_one.registrations.count(), self.pool_one.counter)
-
-        with self.assertRaises(PoolCounterNotEqualToRegistrationCount):
-            check_that_pool_counters_match_registration_number()
-
-    def test_ensure_pool_counters_match_registration_number(self):
-        """Test that method does not raise error when counter is ok"""
-
-        self.assertEqual(self.pool_one.registrations.count(), self.pool_one.counter)
-        check_that_pool_counters_match_registration_number()
-
-    def test_pool_counter_check_ignore_merged_events(self):
-        """Test that counter raises error due to incorrect counter"""
-
-        self.event.merge_time = timezone.now() - timedelta(days=1)
-        self.event.save()
-        users = get_dummy_users(3)
-
-        for user in users:
-            AbakusGroup.objects.get(name="Webkom").add_user(user)
-            reg = Registration.objects.get_or_create(event=self.event, user=user)[0]
-            self.event.register(reg)
-
-        self.assertGreater(self.pool_one.registrations.count(), self.pool_one.counter)
-
-        check_that_pool_counters_match_registration_number()
 
     def test_set_all_events_ready_and_bump(self):
         """Test that events are set as ready when task is complete"""

--- a/lego/apps/events/tests/test_concurrency.py
+++ b/lego/apps/events/tests/test_concurrency.py
@@ -1,0 +1,228 @@
+"""
+Real multi-threaded, multi-connection tests for Registration.add_to_pool's
+select_for_update() gate -- needs BaseAPITransactionTestCase since a plain
+TestCase's single wrapping transaction wouldn't exercise real locking.
+"""
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import timedelta
+
+from django.db import connections
+from django.utils import timezone
+
+from lego.apps.events import constants
+from lego.apps.events.models import Event, Pool, Registration
+from lego.apps.events.tests.utils import get_dummy_users
+from lego.apps.users.models import AbakusGroup
+from lego.utils.test_utils import BaseAPITransactionTestCase
+
+
+def _register(event_id: int, user_id: int) -> None:
+    """Runs in its own thread/connection: the full register() path."""
+    try:
+        event = Event.objects.get(pk=event_id)
+        registration = Registration.objects.get_or_create(event=event, user_id=user_id)[
+            0
+        ]
+        event.register(registration)
+    finally:
+        connections.close_all()
+
+
+def _unregister(event_id: int, user_id: int) -> None:
+    """Runs in its own thread/connection: the full unregister() path."""
+    try:
+        event = Event.objects.get(pk=event_id)
+        registration = Registration.objects.get(event=event, user_id=user_id)
+        event.unregister(registration)
+    finally:
+        connections.close_all()
+
+
+def _run_burst(event_id: int, users: list) -> None:
+    """Adds each user to Abakus, then fires a concurrent registration burst."""
+    abakus = AbakusGroup.objects.get(name="Abakus")
+    for user in users:
+        abakus.add_user(user)
+    connections.close_all()
+
+    with ThreadPoolExecutor(max_workers=40) as ex:
+        futures = [ex.submit(_register, event_id, u.id) for u in users]
+        for f in as_completed(futures):
+            f.result()  # re-raise any worker exception
+
+
+class ConcurrentRegistrationBurstTestCase(BaseAPITransactionTestCase):
+    """Big-load tests: many more registration attempts than capacity,
+    fired at the same pool at once."""
+
+    fixtures = [
+        "test_abakus_groups.yaml",
+        "test_users.yaml",
+        "test_events.yaml",
+        "test_companies.yaml",
+    ]
+
+    def test_large_single_pool_burst_never_oversells(self):
+        """300 concurrent registrants racing a single pool with capacity 50
+        -- exactly 50 must end up admitted, the rest waiting, and the pool
+        must never be observed over capacity."""
+        event = Event.objects.get(title="POOLS_NO_REGISTRATIONS")
+        event.start_time = timezone.now() + timedelta(days=1)
+        event.merge_time = None
+        event.save()
+
+        pool = event.pools.get(name="Abakusmember")
+        pool.activation_date = timezone.now() - timedelta(days=1)
+        pool.capacity = 50
+        pool.save()
+        # The fixture's other pool ("Webkom") is left in place -- none of these users
+        # belong to that group, so get_possible_pools() never routes them there.
+
+        users = get_dummy_users(300)
+        _run_burst(event.id, users)
+
+        pool.refresh_from_db()
+        self.assertLessEqual(pool.registrations.count(), pool.capacity)
+        self.assertEqual(pool.registrations.count(), 50)
+        self.assertEqual(event.waiting_registrations.count(), 250)
+        self.assertEqual(
+            Registration.objects.filter(
+                event=event, status=constants.SUCCESS_REGISTER
+            ).count(),
+            300,
+        )
+
+    def test_large_merged_event_burst_never_oversells(self):
+        """Same burst, but against an already-merged event with two pools
+        (total capacity 30) -- exercises the separate merged-path gate
+        (Event.get_is_full under an event-level lock) rather than
+        add_to_pool's per-pool gate."""
+        event = Event.objects.get(title="POOLS_NO_REGISTRATIONS")
+        event.start_time = timezone.now() + timedelta(days=1)
+        event.merge_time = timezone.now() - timedelta(hours=1)
+        event.save()
+
+        pool_one = event.pools.get(name="Abakusmember")
+        pool_one.activation_date = timezone.now() - timedelta(days=1)
+        pool_one.capacity = 15
+        pool_one.save()
+
+        pool_two = event.pools.get(name="Webkom")
+        pool_two.activation_date = timezone.now() - timedelta(days=1)
+        pool_two.capacity = 15
+        pool_two.save()
+
+        users = get_dummy_users(200)
+        _run_burst(event.id, users)
+
+        total_admitted = pool_one.registrations.count() + pool_two.registrations.count()
+        self.assertLessEqual(total_admitted, 30)
+        self.assertEqual(total_admitted, 30)
+        self.assertEqual(event.waiting_registrations.count(), 170)
+
+
+class ConcurrentRegisterAndUnregisterTestCase(BaseAPITransactionTestCase):
+    """People unregistering at the exact moment others register -- asserts
+    the pool is never observed over capacity and every attempt lands somewhere."""
+
+    fixtures = [
+        "test_abakus_groups.yaml",
+        "test_users.yaml",
+        "test_events.yaml",
+        "test_companies.yaml",
+    ]
+
+    def _setup_event(self, capacity: int) -> tuple[Event, Pool]:
+        event = Event.objects.get(title="POOLS_NO_REGISTRATIONS")
+        event.start_time = timezone.now() + timedelta(days=1)
+        event.merge_time = None
+        event.save()
+
+        pool = event.pools.get(name="Abakusmember")
+        pool.activation_date = timezone.now() - timedelta(days=1)
+        pool.capacity = capacity
+        pool.save()
+        # The fixture's other pool ("Webkom") is left in place -- none of these users
+        # belong to that group, so get_possible_pools() never routes them there.
+        return event, pool
+
+    def test_small_concurrent_register_and_unregister_race(self):
+        """5 incumbents unregister at the same moment 15 new challengers
+        race for the pool -- more challengers than freed slots, on purpose."""
+        event, pool = self._setup_event(capacity=5)
+
+        all_users = get_dummy_users(20)
+        incumbents, challengers = all_users[:5], all_users[5:]
+        abakus = AbakusGroup.objects.get(name="Abakus")
+        for user in incumbents + challengers:
+            abakus.add_user(user)
+
+        for user in incumbents:
+            registration = Registration.objects.get_or_create(event=event, user=user)[0]
+            event.register(registration)
+        pool.refresh_from_db()
+        self.assertEqual(pool.registrations.count(), 5)
+        connections.close_all()
+
+        with ThreadPoolExecutor(max_workers=20) as ex:
+            futures = [ex.submit(_unregister, event.id, u.id) for u in incumbents]
+            futures += [ex.submit(_register, event.id, u.id) for u in challengers]
+            for f in as_completed(futures):
+                f.result()
+
+        pool.refresh_from_db()
+        self.assertLessEqual(pool.registrations.count(), pool.capacity)
+
+        challenger_regs = Registration.objects.filter(event=event, user__in=challengers)
+        admitted = challenger_regs.filter(pool__isnull=False).count()
+        waiting = challenger_regs.filter(
+            pool__isnull=True, status=constants.SUCCESS_REGISTER
+        ).count()
+        self.assertEqual(admitted + waiting, 15)
+
+        for user in incumbents:
+            reg = Registration.objects.get(event=event, user=user)
+            self.assertIsNone(reg.pool)
+            self.assertEqual(reg.status, constants.SUCCESS_UNREGISTER)
+
+    def test_large_concurrent_register_and_unregister_race(self):
+        """Bigger version: pool starts full at capacity 100; 40 incumbents
+        unregister while 150 challengers race concurrently for the same
+        pool row. Same invariant, higher contention."""
+        event, pool = self._setup_event(capacity=100)
+
+        all_users = get_dummy_users(250)
+        incumbents, challengers = all_users[:100], all_users[100:]
+        abakus = AbakusGroup.objects.get(name="Abakus")
+        for user in incumbents + challengers:
+            abakus.add_user(user)
+
+        for user in incumbents:
+            registration = Registration.objects.get_or_create(event=event, user=user)[0]
+            event.register(registration)
+        pool.refresh_from_db()
+        self.assertEqual(pool.registrations.count(), 100)
+        connections.close_all()
+
+        unregistering, staying = incumbents[:40], incumbents[40:]
+
+        with ThreadPoolExecutor(max_workers=60) as ex:
+            futures = [ex.submit(_unregister, event.id, u.id) for u in unregistering]
+            futures += [ex.submit(_register, event.id, u.id) for u in challengers]
+            for f in as_completed(futures):
+                f.result()
+
+        pool.refresh_from_db()
+        self.assertLessEqual(pool.registrations.count(), pool.capacity)
+
+        for user in staying:
+            reg = Registration.objects.get(event=event, user=user)
+            self.assertIsNotNone(reg.pool)
+
+        challenger_regs = Registration.objects.filter(event=event, user__in=challengers)
+        admitted = challenger_regs.filter(pool__isnull=False).count()
+        waiting = challenger_regs.filter(
+            pool__isnull=True, status=constants.SUCCESS_REGISTER
+        ).count()
+        self.assertEqual(admitted + waiting, 150)

--- a/lego/apps/events/tests/test_event_methods.py
+++ b/lego/apps/events/tests/test_event_methods.py
@@ -29,23 +29,6 @@ class EventMethodTest(BaseTestCase):
         event = Event.objects.get(pk=1)
         self.assertEqual(str(event), event.title)
 
-    def test_event_save(self):
-        event = Event.objects.get(title="POOLS_NO_REGISTRATIONS")
-        event.merge_time = timezone.now() - timedelta(days=1)
-        users = get_dummy_users(2)
-        webkom = AbakusGroup.objects.get(name="Webkom")
-        for user in users:
-            webkom.add_user(user)
-            reg = Registration.objects.create(event=event, user=user)
-            event.register(reg)
-
-        for pool in event.pools.all():
-            self.assertEqual(pool.counter, 0)
-        event.save()
-        event.refresh_from_db()
-        for pool in event.pools.all():
-            self.assertEqual(pool.counter, pool.registrations.count())
-
     def test_populate_event_registration_users_with_grade(self):
         """Test that grades get correctly populated in registration users"""
         event = Event.objects.get(title="POOLS_WITH_REGISTRATIONS")

--- a/lego/apps/events/tests/test_registrations.py
+++ b/lego/apps/events/tests/test_registrations.py
@@ -571,7 +571,6 @@ class RegistrationTestCase(BaseTestCase):
 
         pool.refresh_from_db()
 
-        self.assertEqual(pool.counter, pool.registrations.count())
         self.assertEqual(pool.registrations.count(), pool_size_before)
         self.assertEqual(event.number_of_registrations, event_size_before)
         self.assertEqual(event.waiting_registrations.count(), waiting_list_before - 1)

--- a/lego/settings/celery.py
+++ b/lego/settings/celery.py
@@ -33,10 +33,6 @@ schedule = {
         "task": "lego.apps.external_sync.tasks.sync_external_systems",
         "schedule": crontab(hour="*", minute=0),
     },
-    "check-that-pool-counters-match-registration-number": {
-        "task": "lego.apps.events.tasks.check_that_pool_counters_match_registration_number",
-        "schedule": crontab(hour="*", minute=0),
-    },
     "notify_user_about_new_survey": {
         "task": "lego.apps.surveys.tasks.send_survey_mail",
         "schedule": crontab(minute="*/10"),


### PR DESCRIPTION
# Description

Remove the pool.counter, replace with COUNT query.
This was tested locally on 3k regs being about 80ms slower. It should be performance wise fine and avoids all drift.
Also properly set registration failure when retry fails.
Centralize a lot of code regarding bumping/select_for_bump into one method.
Ensure always using transaction.atomic on updating the pools and regs.

# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

Some load tests and updated old tests.

Resolves #4313
