### PR TITLE
Chore: Fix context field and serializer for feed-notifications

### DIFF
--- a/lego/apps/feeds/context.py
+++ b/lego/apps/feeds/context.py
@@ -1,0 +1,17 @@
+def collect_refs(obj):
+    """
+    Given one aggregated feed object, return the set of actor/object/target
+    strings referenced by its activities.
+    """
+    refs = set()
+    for activity in obj.activities:
+        for attr in ("actor", "object", "target"):
+            ref = getattr(activity, attr, None)
+            if ref:
+                refs.add(ref)
+    return refs
+
+
+def resolve_context(obj, lookup):
+    refs = collect_refs(obj)
+    return {ref: lookup[ref] for ref in refs if ref in lookup}

--- a/lego/apps/feeds/serializers/feeds.py
+++ b/lego/apps/feeds/serializers/feeds.py
@@ -1,5 +1,9 @@
 from rest_framework import serializers
 
+from drf_spectacular.utils import extend_schema_field
+
+from lego.apps.feeds.context import resolve_context
+
 
 class FeedActivitySerializer(serializers.Serializer):
     activity_id = serializers.CharField(read_only=True)
@@ -21,6 +25,11 @@ class AggregatedFeedSerializer(serializers.Serializer):
     activities = FeedActivitySerializer(many=True)
     activity_count = serializers.IntegerField()
     actor_ids = serializers.ListField(child=serializers.CharField())
+    context = serializers.SerializerMethodField()
+
+    @extend_schema_field(serializers.DictField())
+    def get_context(self, obj):
+        return resolve_context(obj, self.context.get("attr_lookup", {}))
 
 
 class MarkSerializer(serializers.Serializer):

--- a/lego/apps/feeds/views.py
+++ b/lego/apps/feeds/views.py
@@ -1,9 +1,8 @@
-from typing import List
-
 from rest_framework import decorators, permissions, status, viewsets
 from rest_framework.response import Response
 
 from lego.apps.feeds.attr_cache import AttrCache
+from lego.apps.feeds.context import collect_refs
 
 from .feed_manager import feed_manager
 from .models import NotificationFeed, PersonalFeed, UserFeed
@@ -22,59 +21,28 @@ class FeedViewSet(viewsets.GenericViewSet):
     ordering = "-updated_at"
     serializer_class = AggregatedFeedSerializer
 
-    @staticmethod
-    def attach_metadata(data: List[dict]) -> List[dict]:
-        """
-        Map over the feed here to attach more information to each element.
-        """
-        content_strings = set()
-
-        for item in data:
-            activities = item.get("activities")
-            if activities:
-                # Aggregated Activity
-                for activity in activities:
-                    target = activity.get("target")
-                    object = activity.get("object")
-                    actor = activity.get("actor")
-                    content_strings.add(target) if target else None
-                    content_strings.add(object) if object else None
-                    content_strings.add(actor) if actor else None
-
-        if content_strings:
-            cache = AttrCache()
-            lookup = cache.bulk_lookup(content_strings)
-
-        for item in data:
-            context = {}
-
-            activities = item.get("activities")
-            if activities:
-                # Aggregated Activity
-                for activity in activities:
-                    target = activity.get("target")
-                    object = activity.get("object")
-                    actor = activity.get("actor")
-                    if target in lookup.keys():
-                        context[target] = lookup[target]
-                    if object in lookup.keys():
-                        context[object] = lookup[object]
-                    if actor in lookup.keys():
-                        context[actor] = lookup[actor]
-            item["context"] = context
-
-        return data
-
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
-
         page = self.paginate_queryset(queryset)
-        if page is not None:
-            serializer = self.get_serializer(page, many=True)
-            return self.get_paginated_response(self.attach_metadata(serializer.data))
+        data = list(page if page is not None else queryset)
 
-        serializer = self.get_serializer(queryset, many=True)
-        return Response(self.attach_metadata(serializer.data))
+        all_refs = set()
+        for item in data:
+            all_refs |= collect_refs(item)
+
+        lookup = AttrCache().bulk_lookup(all_refs) if all_refs else {}
+
+        serializer_context = self.get_serializer_context()
+        serializer_context["attr_lookup"] = lookup
+
+        if page is not None:
+            serializer = self.get_serializer(
+                data, many=True, context=serializer_context
+            )
+            return self.get_paginated_response(serializer.data)
+
+        serializer = self.get_serializer(data, many=True, context=serializer_context)
+        return Response(serializer.data)
 
 
 class FeedMarkerViewSet(viewsets.GenericViewSet):

--- a/lego/apps/feeds/websockets.py
+++ b/lego/apps/feeds/websockets.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from lego.apps.feeds.attr_cache import AttrCache
+from lego.apps.feeds.context import collect_refs
 from lego.apps.feeds.serializers.sockets import FeedActivitySocketSerializer
 from lego.apps.websockets.groups import group_for_user
 from lego.apps.websockets.notifiers import notify_group
@@ -11,15 +13,16 @@ if TYPE_CHECKING:
 
 
 def notify_new_notification(aggregated_activity: NotificationFeed):
-    from lego.apps.feeds.views import FeedViewSet
+    refs = collect_refs(aggregated_activity)
+    lookup = AttrCache().bulk_lookup(refs) if refs else {}
 
     group = group_for_user(aggregated_activity.feed_id)
     serializer = FeedActivitySocketSerializer(
         {
             "type": "SOCKET_NEW_NOTIFICATION",
             "payload": aggregated_activity,
-        }
+        },
+        context={"attr_lookup": lookup},
     )
     data = serializer.data
-    data["payload"] = FeedViewSet.attach_metadata([data["payload"]])[0]
     notify_group(group, data)


### PR DESCRIPTION
# Description

The context field was previously attached to feed responses after serialization via `FeedViewSet.attach_metadata()`, so it never appeared in the generated schema despite always being present in the response body. It has now been moved.

Notification_data had no serializer_class set so the viewset defaulted to the AggregatedMarkedFeedSerializer. We added a NotificationsDataSerializer and set it via serializer_class on the action.

# Testing
- [x] The code quality is at a minimum required level of quality, readability, and performance.
- [x] I have thoroughly tested my changes.

Wrote FeedContextTestCase to cover the context field.

Resolves #4311